### PR TITLE
Improve efficiency, persist landmarks, remove within-shot face crop-dependency

### DIFF
--- a/facekit/cli/resolve_face_ids_v2_cli.py
+++ b/facekit/cli/resolve_face_ids_v2_cli.py
@@ -23,10 +23,12 @@ from facekit.pipeline.checkpoint import CheckpointManager
 from facekit.tracking.tracking_resolution import GlobalIdentityResolver
 from facekit.tracking.face_structures import FaceTrack
 from facekit.validation import validate_manifest
+from facekit.tracking.track_consolidation_and_pruning import apply_track_consolidation_and_pruning
 from facekit.output.json_v2 import (
     V2WriterConfig,
     build_v2_manifest_from_tracks,
     build_v2_1_manifest_from_tracks,
+    fix_shots,
     derive_face_metadata_from_observations,
     write_v2_json,
     EmbeddingCollector,
@@ -151,6 +153,10 @@ def run_pipeline(args):
             shot_json_path = tmp_path
         _fix_shot_coverage(shot_json_path, total_frames)
 
+        # Read the full shot definitions *once*; this is the authoritative shot list.
+        shot_data = json.loads(shot_json_path.read_text())
+        shot_defs = shot_data.get("shots", [])
+
         # Detector / embedder
         yolo = load_yolo5face_model(args.detector_model, args.config, device=device)
         detector = FaceDetector(yolo)
@@ -237,7 +243,7 @@ def run_pipeline(args):
             logging.info("resume: stable segment labeling enabled (track_order entries=%d)",
                          int(anchor_summary.get("track_order_entries", 0)))
             # Emit an easily parsable line for tests:
-            print(f"ANCHOR:{int(resume_anchor_f or 0)}", flush=True)
+            logging.info(f"ANCHOR:{int(resume_anchor_f or 0)}")
         else:
             logging.info("resume: disabled or no prior state; starting cold.")
     
@@ -276,6 +282,14 @@ def run_pipeline(args):
             resolver = GlobalIdentityResolver()
             next_gid = resolver.resolve_global_ids(tracks, start_id=0)
             logging.info("global-id: assignment complete (next_gid=%d)", next_gid)
+
+            tracks = apply_track_consolidation_and_pruning(
+                tracks,
+                min_gap_len=args.post_min_gap_len,     # pick defaults you like
+                min_track_len=args.post_min_track_len,
+                iou_threshold=args.post_iou_threshold,
+            )
+            logging.info("post: tracks after consolidation/pruning=%d", len(tracks))
 
         ckpt.finalize()
 
@@ -366,7 +380,8 @@ def run_pipeline(args):
             obs_path = Path(args.obs_sidecar_path) if args.obs_sidecar_path else video_path.with_suffix(".observations.npz")
 
             manifest = build_v2_1_manifest_from_tracks(
-                tracks, cfg,
+                tracks, 
+                cfg,
                 face_metadata=face_meta,
                 generation=None,
                 detector=detector,
@@ -376,6 +391,8 @@ def run_pipeline(args):
                 emb_collector=(emb_collector if emb_store == "sidecar" else None),
                 obs_collector=obs_collector, 
             )
+
+            fix_shots(manifest, shot_defs)
 
             # finalize observations sidecar
             manifest["observations_sidecar"] = obs_collector.finalize_sidecar(
@@ -464,6 +481,21 @@ def main() -> None:
     parser.add_argument("--embedding-batch-size-max", type=int, default=32)
     parser.add_argument("--device",  choices=["auto", "cuda", "cpu"], default="auto",
                         help="Compute device for detector/embedder (default: auto)")
+    
+    # Post processing
+    parser.add_argument("--post-min-gap-len", type=int, default=210,
+                        help=("Minimum gap length (in frames) that will NOT be filled during post-processing. "
+                              "Gaps shorter than this, between tracks with the same global ID and sufficient "
+                              "spatial overlap, may be filled via interpolation and the two contiguous tracks merged."))
+    parser.add_argument("--post-min-track-len", type=int, default=70,
+                        help=("Minimum track length (in frames) required for a track to survive post-processing. "
+                              "Tracks shorter than this may be reassigned to nearby global IDs or pruned entirely "
+                              "if no valid reassignment exists."))
+    parser.add_argument("--post-iou-threshold", type=float, default=0.2,
+                        help=("Minimum Intersection-over-Union (IoU) required when considering spatial continuity "
+                              "during post-processing. Used both for reassigning short tracks to nearby global IDs "
+                              "and for filling short gaps between tracks."))
+
     # Storage controls
     parser.add_argument("--emb-store", choices=["inline", "sidecar", "none"], default="inline",
                         help="How to serialize embeddings in V2 manifest (default: inline).",)

--- a/facekit/common/obs_consts.py
+++ b/facekit/common/obs_consts.py
@@ -6,16 +6,20 @@ class Source(StrEnum):
     TRACKED  = "tracked"
     FLOW     = "flow"
     FALLBACK = "fallback"
+    INTERPOLATED = "interpolated"
+    EXTRAPOLATED = "extrapolated"
 
     def __str__(self) -> str:  # makes, for example, print(member) -> "detected" 
         return self.value
 
 
 SRC_TO_CODE = {
-    Source.DETECTED: 0,
-    Source.TRACKED:  1,
-    Source.FLOW:     2,
-    Source.FALLBACK: 3,
+    Source.DETECTED:     0,
+    Source.TRACKED:      1,
+    Source.FLOW:         2,
+    Source.FALLBACK:     3,
+    Source.INTERPOLATED: 4,
+    Source.EXTRAPOLATED: 5,
 }
 CODE_TO_SRC = {v: k for (k, v) in SRC_TO_CODE.items()}
 

--- a/facekit/embedding/alignment.py
+++ b/facekit/embedding/alignment.py
@@ -1,6 +1,8 @@
 import cv2
 import numpy as np
-from typing import List, Tuple, Optional, Dict, Any
+from typing import List, Tuple, Optional, Dict, Any, Union, Sequence
+
+Landmarks5 = Union[np.ndarray, Sequence[Sequence[float]]]
 
 # ArcFace 112×112 reference (left eye, right eye, nose, left mouth, right mouth)
 ARC_FACE_TEMPLATE = np.array(
@@ -16,7 +18,7 @@ ARC_FACE_TEMPLATE = np.array(
 
 def align_face_for_arcface(
     image: np.ndarray,
-    landmarks: List[Tuple[float, float]],
+    landmarks: Landmarks5,
     frame_idx: Optional[int] = None,
     source: Optional[str] = None,
     *,

--- a/facekit/output/json_v2.py
+++ b/facekit/output/json_v2.py
@@ -16,13 +16,12 @@ from facekit.common.obs_consts import (
 )
 from facekit.utils.io import atomic_write_npz, atomic_write_npy
 from facekit.tracking.face_structures import FaceObservation
+from facekit.pipeline.checkpoint import CheckpointManager
 
 XYXY = Tuple[float, float, float, float]
 
 SCHEMA_VERSION_V2_0 = "2.0"
 SCHEMA_VERSION_V2_1 = "2.1"
-
-PARANOID = bool(os.environ.get("FACEKIT_PARANOID"))
 
 @dataclass
 class V2WriterConfig:
@@ -199,17 +198,17 @@ def _to_int01(flag) -> int:
     # normalize truthy → 1, falsy → 0
     return 1 if bool(flag) else 0
 
-
 ObsRow = np.dtype([
-    ("f", np.int32),                 # absolute frame index
-    ("shot", np.int32),              # shot number (for grouping)
-    ("track_id", np.int32),          # per-shot track identity
-    ("bbox_xyxy", np.float32, (4,)), # x1,y1,x2,y2
-    ("src", np.uint8),               # 0=detected,1=tracked,2=flow
-    ("conf", np.float32),            # NaN if absent
-    ("emb_idx", np.int32),            # -1 if absent
-    ("has_crop", np.uint8),          # 1 if a 112x112 crop exists on disk, else 0
-    ("crop_ref", "U256"),            # path to aligned crop ("" if none)
+    ("f", np.int32),
+    ("shot", np.int32),
+    ("track_id", np.int32),
+    ("bbox_xyxy", np.float32, (4,)),
+    ("src", np.uint8),
+    ("conf", np.float32),
+    ("emb_idx", np.int32),
+
+    ("has_landmarks", np.uint8),            # 1 iff landmarks_flat10 is valid
+    ("landmarks_flat10", np.float32, (10,)) # [x1,y1,...,x5,y5] in ArcFace order
 ])
 
 class ObservationsCollector:
@@ -217,7 +216,7 @@ class ObservationsCollector:
     @property
     def columns(self) -> tuple[str, ...]:
         # Must match ObsRow exactly
-        return ("f","shot","track_id","bbox_xyxy","src","conf","emb_idx","has_crop")
+        return ("f","shot","track_id","bbox_xyxy","src","conf","emb_idx","has_landmarks","landmarks_flat10")
     
     @property
     def schema(self) -> dict:
@@ -238,9 +237,9 @@ class ObservationsCollector:
         track_id: int,
         frame_last: int | None = None,
         count: int | None = None,
-        # optional filters (all backward-compatible)
+        # optional filters
         only_unassigned: bool | None = None,
-        only_with_crop: bool | None = None,
+        only_with_landmarks: bool | None = None,
         source: int | None = None,
         **kwargs,
     ) -> list[tuple[int, int]]:
@@ -250,14 +249,15 @@ class ObservationsCollector:
         AND (emb_idx == -1 if only_unassigned)
         AND (f <= frame_last if provided)
         AND (src == source if provided)
-        AND (valid bbox if only_with_crop)
-        Ordered from newest to oldest (descending frame index).
-        Accepts legacy alias `frame_max` via **kwargs.
-        """
+        AND (has_landmarks == 1 if only_with_landmarks)
 
-        logging.info(f"In find_rows: shot {shot}, track_id{track_id}, frame_last {frame_last}, count {count}, \
-                     only_unassigned {only_unassigned}, only_with_crop {only_with_crop}, source {source} \
-                     rows {self._rows}")
+        Ordering:
+        Rows are returned newest→oldest (descending frame index), based on current storage order.
+
+        Notes:
+        - Accepts legacy alias `frame_max` via **kwargs.
+        - Callers should not rely on ordering for correctness; use frame_at_pos(pos) if needed.
+        """
 
         # Back-compat alias: some callers used frame_max
         if frame_last is None and "frame_max" in kwargs and kwargs["frame_max"] is not None:
@@ -283,14 +283,13 @@ class ObservationsCollector:
                     continue
                 if source is not None and int(row["src"]) != int(source):
                     continue
-                if only_with_crop:
-                    if "has_crop" in row.dtype.names:
-                        if int(row["has_crop"]) != 1:
+                if only_with_landmarks:
+                    if "has_landmarks" in row.dtype.names:
+                        if int(row["has_landmarks"]) != 1:
                             continue
                     else:
-                        # legacy fallback: bbox sanity as proxy
-                        if not _bbox_valid(row["bbox_xyxy"]):
-                            continue
+                        # legacy checkpoints without landmarks field cannot satisfy this filter
+                        continue
 
                 out.append((b_idx, r_idx))
                 if want is not None and len(out) >= want:
@@ -377,71 +376,67 @@ class ObservationsCollector:
         k = len(obs_items)
         block = np.empty(k, dtype=ObsRow)
 
-        def _validate_faceObs_dict(o: dict):
-            if not isinstance(o, dict):
+        def _validate_faceObs_dict(row: dict):
+            if not isinstance(row, dict):
                 raise TypeError("ObservationsCollector.append_track_obs expects normalized dicts.")
 
             missing = []
             # use .get to avoid KeyError so we can report everything at once
-            if o.get("shot") is None:       missing.append("shot_id")
-            if o.get("track_id") is None:   missing.append("track_id")
-            if o.get("f") is None:          missing.append("frame_idx")
-            if ("bbox_xyxy" not in o) and ("bbox_xywh" not in o):
+            if row.get("shot") is None:       missing.append("shot_id")
+            if row.get("track_id") is None:   missing.append("track_id")
+            if row.get("f") is None:          missing.append("frame_idx")
+            if ("bbox_xyxy" not in row) and ("bbox_xywh" not in row):
                 missing.append("bbox")
-            if o.get("src") is None:
+            if row.get("src") is None:
                 missing.append("source")
 
             if missing:
-                raise ValueError(f"Observation missing required fields: {missing} | row={o!r}")
+                raise ValueError(f"Observation missing required fields: {missing} | row={row!r}")
 
             # --- normalize src to int code  ---
-            return _src_to_int(o.get("src"))
+            return _src_to_int(row.get("src"))
         
-        for i, o in enumerate(obs_items):
-            oN = o if isinstance(o, dict) else dict(o)  # ensure dict-like
-            src_any = _validate_faceObs_dict(oN)
+        for i, obs in enumerate(obs_items):
+            row = obs if isinstance(obs, dict) else dict(obs)  # ensure dict-like
+            src_any = _validate_faceObs_dict(row)
 
-            f = int(oN["f"])
-            shot = int(oN["shot"])
-            if "bbox_xyxy" in oN and oN["bbox_xyxy"] is not None:
-                bb = [float(x) for x in oN["bbox_xyxy"]]
+            f = int(row["f"])
+            shot = int(row["shot"])
+            if "bbox_xyxy" in row and row["bbox_xyxy"] is not None:
+                bb = [float(x) for x in row["bbox_xyxy"]]
             else:
-                x, y, w, h = oN["bbox_xywh"]
+                x, y, w, h = row["bbox_xywh"]
                 bb = [float(x), float(y), float(x + w), float(y + h)]
 
             src_code =_src_to_int(src_any)
-            conf = float(oN["conf"]) if ("conf" in oN and oN["conf"] is not None) else np.nan
+            conf = float(row["conf"]) if ("conf" in row and row["conf"] is not None) else np.nan
 
-            # Normalize crop_ref to a string
-            crop_ref = oN.get("crop_ref") or ""
-            crop_ref = str(crop_ref)
+            # --- Landmarks (strict) ---
+            has_landmarks, lm_flat10 = CheckpointManager._landmarks_to_flat10(row)
 
-            # has_crop: normalize to 0/1; infer from crop_ref when missing
-            has_crop = oN.get("has_crop", None)
-            if has_crop is None:
-                has_crop = 1 if crop_ref else 0
-            has_crop = _to_int01(has_crop)
-
-            if has_crop:
-                crop_ref = oN.get("crop_ref") or ""
-            crop_ref = str(crop_ref)
-
+            # DETECTED rows must have landmarks
+            det_code = int(src_to_code(Source.DETECTED.value))
+            if int(src_code) == det_code and has_landmarks != 1:
+                raise ValueError(
+                    f"append_track_obs: DETECTED row missing landmarks "
+                    f"(shot={shot}, track_id={int(row['track_id'])}, f={f})"
+                )
             emb_idx = -1
             if emb_idx_fn is not None:
                 try:
-                    emb_idx = int(emb_idx_fn(oN))
+                    emb_idx = int(emb_idx_fn(row))
                 except Exception:
                     emb_idx = -1
 
             block[i]["f"] = f
             block[i]["shot"] = shot 
-            block[i]["track_id"] = int(oN["track_id"])
+            block[i]["track_id"] = int(row["track_id"])
             block[i]["bbox_xyxy"] = bb
             block[i]["src"] = src_code
             block[i]["conf"] = conf
             block[i]["emb_idx"] = emb_idx
-            block[i]["has_crop"] = has_crop
-            block[i]["crop_ref"] = crop_ref
+            block[i]["has_landmarks"] = int(has_landmarks)
+            block[i]["landmarks_flat10"] = lm_flat10
 
         offset = self._count
         self._rows.append(block)
@@ -482,8 +477,8 @@ class ObservationsCollector:
                 {"name":"src","type":"u1","desc":"0=detected,1=tracked,2=flow"},
                 {"name":"conf","type":"f4","desc":"NaN if absent"},
                 {"name":"emb_idx","type":"i4","desc":"-1 if absent"},
-                {"name":"has_crop","type":"u1","desc":"1 if crop saved"},
-                {"name":"crop_ref","type":"U256","desc":"path to aligned crop or empty"},
+                {"name":"has_landmarks","type":"u1","desc":"1 if landmarks_flat10 is valid"},
+                {"name":"landmarks_flat10","type":"f4[10]","desc":"[x1,y1,...,x5,y5] ArcFace order"},
             ],
             "count": int(arr.shape[0]),
         }
@@ -587,14 +582,11 @@ class ObservationsCollector:
                 if not np.isnan(conf):
                     d["conf"] = conf
 
-                if "crop_ref" in row.dtype.names:
-                    val = row["crop_ref"]
-                    # handle possible bytes/unicode
-                    if isinstance(val, bytes):
-                        val = val.decode("utf-8", "ignore")
-                    crop_ref = str(val).strip()
-                    if crop_ref:
-                        d["crop_ref"] = crop_ref
+                # Landmarks: expose both has_landmarks + landmarks_flat10 (as Python list)
+                if "has_landmarks" in row.dtype.names:
+                    d["has_landmarks"] = int(row["has_landmarks"])
+                    if int(row["has_landmarks"]) == 1 and "landmarks_flat10" in row.dtype.names:
+                        d["landmarks_flat10"] = [float(x) for x in row["landmarks_flat10"]]
 
                 groups.setdefault((s, t), []).append(d)
 
@@ -1002,6 +994,64 @@ def build_v2_manifest_from_tracks(
     manifest["generation"] = base_gen
 
     return manifest
+
+def fix_shots(manifest: Dict[str, Any], shot_defs: List[Dict[str, Any]]) -> None:
+    """
+    Ensure manifest['shots']:
+      - contains one entry per shot in `shot_defs`
+      - each shot's (first_frame, last_frame) matches the shot segmentation,
+        regardless of whether the shot has tracks.
+
+    Mutates `manifest` in-place, including `totals.num_shots` and `totals.num_tracks` if present.
+    """
+    if not shot_defs:
+        return
+
+    shots = manifest.get("shots") or []
+
+    # Index existing shots by shot_number
+    existing_by_num: Dict[int, Dict[str, Any]] = {}
+    for s in shots:
+        if "shot_number" not in s:
+            continue
+        sn = int(s["shot_number"])
+        existing_by_num[sn] = s
+
+    # For every known shot definition:
+    #   - create a new shot entry if missing
+    #   - normalize first_frame/last_frame to the segmentation
+    for sd in shot_defs:
+        sn = int(sd["shot_number"])
+        first = int(sd.get("first_frame", 0))
+        last = int(sd.get("last_frame", max(first, first)))
+
+        entry = existing_by_num.get(sn)
+        if entry is None:
+            # No tracks for this shot -> trackless/graphics-only shot
+            entry = {
+                "shot_number": sn,
+                "first_frame": first,
+                "last_frame": last,
+                "num_tracks": 0,
+                "face_tracks": [],
+            }
+            shots.append(entry)
+            existing_by_num[sn] = entry
+        else:
+            # Shot already exists (has tracks); normalize coverage to full shot span
+            entry["first_frame"] = first
+            entry["last_frame"] = last
+
+    # Keep shots sorted by shot_number for stable output
+    shots.sort(key=lambda s: int(s["shot_number"]))
+    manifest["shots"] = shots
+
+    # Fix totals, if present
+    totals = manifest.get("totals")
+    if isinstance(totals, dict):
+        totals["num_shots"] = len(shots)
+        totals["num_tracks"] = sum(int(s.get("num_tracks", 0)) for s in shots)
+        manifest["totals"] = totals
 
 def normalize_obs_items_for_output(
     items: list[FaceObservation],

--- a/facekit/pipeline/checkpoint.py
+++ b/facekit/pipeline/checkpoint.py
@@ -4,11 +4,9 @@ from pathlib import Path
 from datetime import datetime, timezone
 import json
 import os
-import time
 import tempfile
-import typing as _t
 import hashlib
-from typing import Protocol, List, Optional, Any, Dict, Tuple
+from typing import Protocol, List, Optional, Union, Any
 import numpy as np
 from numpy.lib import recfunctions as rfn
 import shutil
@@ -24,20 +22,15 @@ from facekit.pipeline.track_order import (
     TrackOrderError,
 )
 from facekit.utils.io import fsync_parent_dir
-from facekit.utils.io import atomic_write_npz
 from facekit.tracking.aggregator import ShotFaceTrackAggregatorProtocol
 from facekit.utils.debug_snapshots import (
-    snapshot_from_aggregator, 
     load_latest_snapshot, 
     diff_snapshot_vs_rehydrate,
     write_snapshot_atomic,
 )
 from facekit.common.obs_consts import Source, SRC_TO_CODE, CODE_TO_SRC, src_to_code, code_to_src
-from facekit.tracking.face_structures import FaceObservation
 
 REQUIRED_SCHEMA_VERSION = "2.3"
-# PARANOID = bool(os.environ.get("FACEKIT_PARANOID"))
-PARANOID = 1
 
 class TrackingCheckpoint(Protocol):
     # lifecycle/progress
@@ -172,7 +165,7 @@ def _sha256_file(path: Path) -> Optional[str]:
     except Exception:
         return None
 
-def _assert_npz_keys(npz_path: Path, required_keys: tuple[str, ...], *, strict: bool) -> None:
+def _assert_npz_keys(npz_path: Path, required_keys: tuple[str, ...], *, strict: bool = True) -> None:
     """
     Ensure an NPZ exists and contains specific top-level keys.
     In strict mode, raise ResumeSafetyError if violated; else log and continue.
@@ -261,9 +254,9 @@ class CheckpointManager(TrackingCheckpoint):
         return self.root.name
 
     def __init__(self,
-                 root_dir: _t.Union[str, Path],
+                 root_dir: Union[str, Path],
                  *,
-                 video_path: _t.Union[str, Path],
+                 video_path: Union[str, Path],
                  resume: bool = True) -> None:
         
         # Paths
@@ -313,7 +306,7 @@ class CheckpointManager(TrackingCheckpoint):
         self._open_tracks_inline: list[dict] | None = None
 
         # Snapshot of CLI/options for safe resume (populated in start())
-        self._cfg: dict[str, _t.Any] = {}
+        self._cfg: dict[str, Any] = {}
 
         self.logger = getattr(self, "logger", None) or logging.getLogger("facekit.checkpoint")
 
@@ -331,7 +324,7 @@ class CheckpointManager(TrackingCheckpoint):
             tracks_seen: int = 0,
             shots_done: int = 0,
             frames_done: int = 0,
-            options_snapshot: dict[str, _t.Any] | None = None) -> None:
+            options_snapshot: dict[str, Any] | None = None) -> None:
         """
         Bind collectors & counters and prepare track-order state.
 
@@ -445,7 +438,7 @@ class CheckpointManager(TrackingCheckpoint):
 
     def on_shot_done(self) -> None:
         self._shots_done += 1
-        # Ensure the anchor’s row counters include end-of-shot backfill (embeddings/crop links).
+        # Ensure the anchor’s row counters include end-of-shot backfill.
         try:
             self.refresh_anchor_row_counts_post_backfill()
         except Exception:
@@ -498,6 +491,103 @@ class CheckpointManager(TrackingCheckpoint):
             return Source(src_obj.lower()).value
         raise TypeError(f"invalid observation source for in-RAM row: {src_obj!r}")
     
+    @staticmethod
+    def _landmarks_to_flat10(ob_or_row) -> tuple[int, np.ndarray]:
+        """
+        Normalize landmarks into (has_landmarks, landmarks_flat10).
+
+        Accepts:
+        - FaceObservation (expects .landmarks and .source)
+        - dict row (supports keys: 'landmarks', 'landmarks_flat10', 'has_landmarks', 'src')
+
+        Contract:
+        - returns (0, nan[10]) if no valid landmarks are present
+        - returns (1, float32[10]) if valid landmarks are present
+        - if source == DETECTED: invalid/missing landmarks raise ValueError
+        """
+        import numpy as np
+        from facekit.common.obs_consts import Source, src_to_code
+
+        nan_landmarks_flat10 = np.full((10,), np.nan, dtype=np.float32)
+
+        # --- helpers ---------------------------------------------------------
+        def _is_detected(source_any) -> bool:
+            if source_any is None:
+                return False
+            detected_code = int(src_to_code(Source.DETECTED.value))
+            if isinstance(source_any, Source):
+                return source_any == Source.DETECTED
+            if isinstance(source_any, int):
+                return int(source_any) == detected_code
+            if isinstance(source_any, str):
+                s = source_any.strip().lower()
+                return ("detected" in s)  # intentionally loose
+            return False
+
+        def _fail_detected(msg: str) -> None:
+            raise ValueError(f"landmarks invalid for DETECTED row: {msg}")
+
+        # --- determine source ------------------------------------------------
+        if isinstance(ob_or_row, dict):
+            source_any = ob_or_row.get("src", None)
+        else:
+            source_any = getattr(ob_or_row, "source", None)
+
+        is_detected = _is_detected(source_any)
+
+        # --- fast path: already-normalized dict fields -----------------------
+        if isinstance(ob_or_row, dict):
+            if "has_landmarks" in ob_or_row and "landmarks_flat10" in ob_or_row:
+                has_landmarks = int(ob_or_row.get("has_landmarks", 0))
+                landmarks_flat10 = np.asarray(
+                    ob_or_row.get("landmarks_flat10", nan_landmarks_flat10),
+                    dtype=np.float32,
+                ).reshape(-1)
+
+                if has_landmarks == 1:
+                    if landmarks_flat10.shape != (10,):
+                        if is_detected:
+                            _fail_detected(f"landmarks_flat10 wrong shape {landmarks_flat10.shape}")
+                        return (0, nan_landmarks_flat10)
+                    if not np.all(np.isfinite(landmarks_flat10)):
+                        if is_detected:
+                            _fail_detected("landmarks_flat10 contains NaN/Inf")
+                        return (0, nan_landmarks_flat10)
+                    return (1, landmarks_flat10.astype(np.float32, copy=False))
+
+                # has_landmarks == 0
+                if is_detected:
+                    _fail_detected("has_landmarks=0")
+                return (0, nan_landmarks_flat10)
+
+        # --- general path: look for 'landmarks' ------------------------------
+        if isinstance(ob_or_row, dict):
+            landmarks = ob_or_row.get("landmarks", None)
+        else:
+            landmarks = getattr(ob_or_row, "landmarks", None)
+
+        if landmarks is None:
+            if is_detected:
+                _fail_detected("missing landmarks")
+            return (0, nan_landmarks_flat10)
+
+        landmarks_arr = np.asarray(landmarks, dtype=np.float32)
+        if landmarks_arr.shape == (5, 2):
+            landmarks_flat10 = landmarks_arr.reshape(10)
+        elif landmarks_arr.shape == (10,):
+            landmarks_flat10 = landmarks_arr
+        else:
+            if is_detected:
+                _fail_detected(f"wrong shape {landmarks_arr.shape} (expected (5,2) or (10,))")
+            return (0, nan_landmarks_flat10)
+
+        if not np.all(np.isfinite(landmarks_flat10)):
+            if is_detected:
+                _fail_detected("contains NaN/Inf")
+            return (0, nan_landmarks_flat10)
+
+        return (1, landmarks_flat10.astype(np.float32, copy=False))
+
 
     @staticmethod
     def _obs_to_row_dict(shot: int, ob) -> dict:
@@ -507,35 +597,33 @@ class CheckpointManager(TrackingCheckpoint):
             raise TypeError(f"_obs_to_row_dict requires FaceObservation, got {type(ob).__name__}")
         if not isinstance(ob.source, Source):
             raise TypeError(f"FaceObservation.source must be Source enum, got {ob.source!r}")
-                            
+
         # bbox normalized to xyxy list
         if getattr(ob, "bbox", None) is None:
             raise ValueError("ob.bbox required")
-        x1,y1,x2,y2 = [float(v) for v in ob.bbox[:4]]
+        x1, y1, x2, y2 = [float(v) for v in ob.bbox[:4]]
 
-       # Canonicalize and take the numeric code we persist to the sidecar.
+        # Canonicalize and take the numeric code to persist to the sidecar.
         src_name = CheckpointManager._src_to_name(ob.source)  # 'detected' / 'tracked' / 'flow'
-        src_code = int(src_to_code(src_name))  # <- persist numeric code, not string
+        src_code = int(src_to_code(src_name))  # persist numeric code
 
-        # "has_crop" is implied by either an in-RAM aligned_face or a persisted crop_ref
-        has_crop = 1 if ((getattr(ob, "aligned_face", None) is not None) or bool(getattr(ob, "crop_ref", None))) else 0
+        # Landmarks: centralized + invariant-enforcing (DETECTED must have valid landmarks)
+        has_landmarks, landmarks_flat10 = CheckpointManager._landmarks_to_flat10(ob)
 
-
-        # Confidence can legitimately be None; in that case use NaN (collector already handles NaN).
         conf_val = getattr(ob, "confidence", None)
-        d = {
-            "shot":       int(shot),
-            "track_id":   int(getattr(ob, "track_id")),
-            "f":          int(getattr(ob, "frame_idx")),
-            "bbox_xyxy":  [x1,y1,x2,y2],
-            "src":        src_code,          # *** numeric code persisted to sidecar ***
-            "conf":       (float(conf_val) if conf_val is not None else float("nan")),
-            # optional fields your collector might accept:
-            "has_crop":   has_crop,
-            "crop_ref":   getattr(ob, "crop_ref", None) or "",
+
+        return {
+            "shot": int(shot),
+            "track_id": int(getattr(ob, "track_id")),
+            "f": int(getattr(ob, "frame_idx")),
+            "bbox_xyxy": [x1, y1, x2, y2],
+            "src": src_code,
+            "conf": (float(conf_val) if conf_val is not None else float("nan")),
+            "has_landmarks": int(has_landmarks),
+            "landmarks_flat10": landmarks_flat10,   # <-- this name must match ObsRow
         }
-        return d
-    
+
+
     def add_observations(self, shot_number: int, frame_idx: int, observations: list[FaceObservation]) -> int:
         """
         Append observations for THIS FRAME into the observations collector.
@@ -556,12 +644,7 @@ class CheckpointManager(TrackingCheckpoint):
             )
         # Convert FaceObservation -> dict rows exactly once (src already numeric)
         observations = [self._obs_to_row_dict(shot_number, ob) for ob in observations]
-        if PARANOID:
-            self.logger.debug("ckpt.add_observations: after _obs_to_row_dict "
-                         "shot=%s frame=%s n=%s sample=%r",
-                         shot_number, frame_idx, len(observations),
-                         observations[0] if observations else None)
-            
+
         # Skip anything strictly before the resume anchor.
         if self._is_pre_anchor(frame_idx):
             logging.debug("ckpt:add_obs SKIP (pre-anchor) frame=%s anchor=%s",
@@ -604,10 +687,11 @@ class CheckpointManager(TrackingCheckpoint):
                                  "(shot=%s frame=%s tid=%s) row=%r",
                                  shot_number, frame_idx, tid, r)
                     raise TypeError(f"BUG: row without valid 'src' int code: {r!r}")
-
-                # robust has_crop: true if aligned_face already persisted via crop_ref,
-                # or explicit has_crop flag present (fallback).
-                has_crop_flag = 1 if r.get("crop_ref") else int(r.get("has_crop", 0))
+                
+                # 'landmarks_flat10' is canonical coming out of _obs_to_row_dict
+                landmarks_f10 = r.get("landmarks_flat10", None)
+                if landmarks_f10 is None:
+                    landmarks_f10 = [float("nan")] * 10
 
                 out = {
                     "shot": int(shot_number),
@@ -615,12 +699,11 @@ class CheckpointManager(TrackingCheckpoint):
                     "f": int(r.get("f", frame_idx)),
                     "bbox_xyxy": [float(v) for v in bbox],
                     "src": int(src_val),
-                    "has_crop": has_crop_flag,
+                    "has_landmarks": int(r.get("has_landmarks", 0)),
+                    "landmarks": [float(x) for x in np.asarray(landmarks_f10, dtype=np.float32).reshape(10)],
                 }
                 if r.get("conf") is not None:
                     out["conf"] = float(r["conf"])
-                if r.get("crop_ref"):
-                    out["crop_ref"] = str(r["crop_ref"])
                 out_rows.append(out)
 
             # sanity: every row must have an int 'src'
@@ -631,13 +714,6 @@ class CheckpointManager(TrackingCheckpoint):
                              len(bad), shot_number, frame_idx, bad[0])
                 raise TypeError(f"BUG: row passed to collector without int 'src': {bad[0]!r}")
             # emb_idx unknown here: set -1 via emb_idx_fn
-
-            if PARANOID:
-               self.logger.debug("ckpt.add_observations: to collector "
-                            "shot=%s frame=%s rows=%s first_src=%r",
-                            shot_number, frame_idx, len(out_rows),
-                             out_rows[0].get("src") if out_rows else None)
-
 
             _, added = self._obs.append_track_obs(out_rows, emb_idx_fn=lambda _o: -1)
             total_rows_added += int(added)
@@ -657,190 +733,110 @@ class CheckpointManager(TrackingCheckpoint):
         return total_rows_added
 
     def add_embeddings(self, shot_number: int, track_id: int, frame_idx_last: int, embs: np.ndarray) -> int:
+        """
+        Persist embeddings and link them to observations WITHOUT referencing the video.
+
+        - This call represents embeddings for exactly ONE frame (frame_idx_last).
+        - `embs` must be shape (1, D).
+        - We link by exact frame equality to exactly one DETECTED, has_landmarks=1, emb_idx=-1 observation row.
+        """
         anchor = self._anchor_frame
-        self.logger.info(
-            "add_embeddings: shot=%d tid=%d frame_last=%d anchor=%s embs_shape=%s",
+        self.logger.debug(
+            "add_embeddings: shot=%d tid=%d frame=%d anchor=%s embs_shape=%s",
             int(shot_number), int(track_id), int(frame_idx_last),
             (str(anchor) if anchor is not None else "None"),
-            tuple(embs.shape) if hasattr(embs, "shape") else "?"
+            getattr(embs, "shape", None),
         )
 
-        # ---------- basic guards / shape checks ----------
+        # ---- basic guards / shape checks ----
         if embs is None:
             return 0
         embs = np.asarray(embs, dtype=np.float32)
         if embs.ndim != 2:
-            raise ResumeSafetyError(
-                f"[ckpt] add_embeddings expected 2D array (N, D), got shape={embs.shape!r}"
-            )
+            raise ResumeSafetyError(f"[ckpt] add_embeddings expected 2D array (N, D), got shape={embs.shape!r}")
         if embs.shape[0] == 0:
             return 0
 
-        # If you have pre-anchor rules, keep them here (not shown in your snippet):
-        # e.g.:
-        # if anchor is not None and frame_idx_last < anchor and shot_number < self.anchor_shot():
-        #     self.logger.info("add_embeddings: SKIP pre-anchor shot=%d frame_last=%d", shot_number, frame_idx_last)
-        #     return 0
+        # Bulletproof: require one frame per call
+        if embs.shape[0] != 1:
+            raise ResumeSafetyError(
+                f"[ckpt] add_embeddings expects one embedding per call (shape[0]==1). "
+                f"Got shape={embs.shape!r} for shot={shot_number} track={track_id} frame={frame_idx_last}"
+            )
 
         if self._emb is None or self._obs is None:
             return 0
 
-        # ---------- assign vectors into the embedding sidecar ----------
-        assigned: list[int] = []
-        for row_vec in embs:
-            emb_idx = self._emb.assign(row_vec)
-            if not isinstance(emb_idx, int):
-                raise ResumeSafetyError(
-                    "[ckpt] EmbeddingCollector.assign(vec) must return int index, "
-                    f"got {type(emb_idx).__name__}: {emb_idx!r}"
-                )
-            assigned.append(int(emb_idx))
+        # ---- assign vector into embedding sidecar ----
+        emb_idx = self._emb.assign(embs[0])
+        if not isinstance(emb_idx, int):
+            raise ResumeSafetyError(
+                "[ckpt] EmbeddingCollector.assign(vec) must return int index, "
+                f"got {type(emb_idx).__name__}: {emb_idx!r}"
+            )
+        emb_idx = int(emb_idx)
 
-        cnt = len(assigned)
-        self.logger.debug(
-            "add_embeddings: assigned %d vectors; emb_rows_total=%d",
-            cnt, (self._emb.count() if hasattr(self._emb, "count") else -1)
-        )
-
-        if cnt == 0:
-            return 0
-
+        # ---- find candidate obs rows for linking ----
         find_rows = getattr(self._obs, "find_rows", None)
         update_emb_idx = getattr(self._obs, "update_emb_idx", None)
-        if not callable(find_rows) or not callable(update_emb_idx):
-            raise ResumeSafetyError("[ckpt] ObservationsCollector needs find_rows/update_emb_idx.")
+        frame_at_pos = getattr(self._obs, "frame_at_pos", None)
+        if not callable(find_rows) or not callable(update_emb_idx) or not callable(frame_at_pos):
+            raise ResumeSafetyError("[ckpt] ObservationsCollector needs find_rows/update_emb_idx/frame_at_pos.")
 
-        # ---------- diagnostics (unchanged semantics, just tuples-aware) ----------
-        if self.logger.isEnabledFor(logging.DEBUG):
-            diag = self._diagnose_candidates(
-                self._obs,
-                shot=shot_number,
-                track_id=track_id,
-                frame_last=frame_idx_last,
-            )
-            if diag:
-                self.logger.debug(
-                    "link:diag shot=%d tid=%d upto=%d "
-                    "seen=%d det=%d det_unassigned=%d det_crop=%d final=%d "
-                    "filtered(no_crop=%d, assigned=%d, future=%d)",
-                    int(shot_number), int(track_id), int(frame_idx_last),
-                    diag.get("rows_seen", -1), diag.get("rows_det", -1),
-                    diag.get("rows_det_unassigned", -1),
-                    diag.get("rows_det_crop", -1),
-                    diag.get("rows_final_candidates", -1),
-                    diag.get("filtered_no_crop", -1),
-                    diag.get("filtered_assigned", -1),
-                    diag.get("filtered_future", -1),
-                )
+        det_code = int(SRC_TO_CODE[Source.DETECTED])
 
-        # ---------- find candidate obs rows for linking ----------
-        candidate_rows = find_rows(
+        candidates = find_rows(
             shot=int(shot_number),
             track_id=int(track_id),
             frame_last=int(frame_idx_last),
             only_unassigned=True,
-            only_with_crop=True,
-            source=SRC_TO_CODE[Source.DETECTED],
-        )
-        self.logger.info(
-            "link: candidates=%d (DET+crop, unassigned, ≤%d) for shot=%d tid=%d",
-            len(candidate_rows), int(frame_idx_last), int(shot_number), int(track_id)
+            only_with_landmarks=True,
+            source=det_code,
+            count=None,
         )
 
-        # --- Normalize candidate positions to (block_idx, row_idx) tuples ---
-        norm_candidates: list[tuple[int, int]] = []
-        for pos in candidate_rows:
-            # Canonical: already a tuple
+        # normalize candidate positions to (block,row) tuples
+        norm: list[tuple[int, int]] = []
+        for pos in candidates:
             if isinstance(pos, tuple) and len(pos) == 2:
                 b, r = pos
-                norm_candidates.append((int(b), int(r)))
-                continue
+                norm.append((int(b), int(r)))
+            elif isinstance(pos, (int, np.integer)):
+                # legacy single-block
+                norm.append((0, int(pos)))
+            else:
+                raise ResumeSafetyError(
+                    "[ckpt] ObservationsCollector.find_rows must return (block,row) tuples (or int legacy); "
+                    f"got {type(pos).__name__} value={pos!r}"
+                )
 
-            # Legacy: flat integer row index
-            if isinstance(pos, (int, np.integer)):
-                # Treat legacy flat index as (0, pos)
-                norm_candidates.append((0, int(pos)))
-                continue
+        # filter to exact frame match
+        exact = [p for p in norm if int(frame_at_pos(p)) == int(frame_idx_last)]
 
+        if len(exact) == 0:
             raise ResumeSafetyError(
-                "[ckpt] ObservationsCollector.find_rows must return (block,row) tuples; "
-                f"got {type(pos)!r} value={pos!r}"
+                f"[ckpt] cannot link embedding: no DETECTED+landmarks+unassigned obs row at exact frame "
+                f"(shot={shot_number} track={track_id} frame={frame_idx_last}). "
+                f"Candidates_upto_frame={len(norm)}"
             )
 
-        candidate_rows = norm_candidates
-
-        if not candidate_rows:
+        if len(exact) > 1:
+            # For bulletproof linking, ambiguity should be fatal.
             raise ResumeSafetyError(
-                f"[ckpt] no candidate obs rows for shot={shot_number} track={track_id} "
-                f"≤ frame={frame_idx_last}"
+                f"[ckpt] ambiguous link: multiple candidate obs rows at the same frame "
+                f"(shot={shot_number} track={track_id} frame={frame_idx_last}) count={len(exact)}"
             )
 
-        if len(candidate_rows) < cnt:
-            self.logger.error(
-                "link:mismatch fewer candidates than embeddings: candidates=%d < embs=%d "
-                "(shot=%d tid=%d ≤%d). Likely causes: has_crop not flipped, wrong src, or wrong frame_last.",
-                len(candidate_rows), cnt, int(shot_number), int(track_id), int(frame_idx_last)
-            )
-            raise ResumeSafetyError(
-                f"[ckpt] fewer DET+crop rows ({len(candidate_rows)}) than embeddings ({cnt}) "
-                f"for shot={shot_number} track={track_id}."
-            )
+        target_pos = exact[0]
 
-        # Choose newest K rows (collector defines meaning; we treat as flat row indices)
-        target_positions = candidate_rows[-cnt:]
+        # ---- do the actual linking ----
+        update_emb_idx(positions=[target_pos], emb_indices=[emb_idx])
 
-        # ---------- log mapping (pos -> frame, emb_idx) for debugging ----------
-        frames_for_targets: list[int] = []
-        if self.logger.isEnabledFor(logging.INFO):
-            try:
-                if hasattr(self._obs, "frame_at_pos"):
-                    # frame_at_pos(pos: int) -> frame index
-                    frames_for_targets = [
-                        int(self._obs.frame_at_pos(pos)) for pos in target_positions
-                    ]
-                else:
-                    # Fallback via to_array(): interpret positions as flat indices
-                    arr = self._obs.to_array()
-                    frames_for_targets = []
-                    for pos in target_positions:
-                        flat_idx = int(pos)
-                        if 0 <= flat_idx < arr.shape[0]:
-                            frames_for_targets.append(int(arr["f"][flat_idx]))
-                        else:
-                            frames_for_targets.append(-1)
-            except Exception:
-                frames_for_targets = [-1] * len(target_positions)
-
-        linked_emb_indices = assigned[-len(target_positions):]
-
-        for (pos, f, emb_idx) in zip(target_positions, frames_for_targets, linked_emb_indices):
-            self.logger.info(
-                "EMB-EVENT stage=checkpoint shot=%d tid=%d frame=%d pos=%s emb_idx=%d",
-                int(shot_number), int(track_id),
-                int(f if f is not None else -1),
-                f"{pos}",
-                int(emb_idx),
-            )
-
-        # ---------- do the actual linking ----------
-        if len(target_positions) != len(linked_emb_indices):
-            raise ResumeSafetyError(
-                f"[ckpt] internal error: positions={len(target_positions)} "
-                f"emb_indices={len(linked_emb_indices)}"
-            )
-
-        update_emb_idx(
-            positions=target_positions,
-            emb_indices=linked_emb_indices,
+        self.logger.debug(
+            "link:done shot=%d tid=%d frame=%d pos=%s emb_idx=%d",
+            int(shot_number), int(track_id), int(frame_idx_last), target_pos, emb_idx
         )
-
-        self.logger.info(
-            "link:done shot=%d tid=%d linked=%d_of_%d (candidates=%d)",
-            int(shot_number), int(track_id),
-            len(target_positions), cnt, len(candidate_rows)
-        )
-        return cnt
-
+        return 1
 
     def checkpoint_now(
             self, 
@@ -881,7 +877,7 @@ class CheckpointManager(TrackingCheckpoint):
         self._open_tracks_inline = self._build_open_tracks_list(aggregator, shot_number)
         self._write_status(note or "checkpoint")
 
-    def matches_video(self, video_path: _t.Union[str, Path]) -> bool:
+    def matches_video(self, video_path: Union[str, Path]) -> bool:
         """Return True if the stored checkpoint was created for this video path."""
         status = self.read_status()
         return bool(status and str(status.get("video_path")) == str(video_path))
@@ -1059,9 +1055,90 @@ class CheckpointManager(TrackingCheckpoint):
 
     #     return np.stack(out, axis=0)
 
-    def get_det_frames_for_track(self, shot: int, track_id: int, frame_max: int | None = None) -> list[int]:
-        arr = self._obs_np()
+    def get_det_frames_with_landmarks_for_track(
+        self,
+        shot: int,
+        track_id: int,
+        frame_max: int | None = None,
+    ) -> list[int]:
         det_code = int(SRC_TO_CODE[Source.DETECTED])
+
+        # Prefer live collector if available
+        arr = None
+        if getattr(self, "_obs", None) is not None and hasattr(self._obs, "to_array"):
+            try:
+                arr = self._obs.to_array()
+            except Exception:
+                arr = None
+
+        if arr is None:
+            arr = self._obs_np()
+
+        mask = (
+            (arr["shot"] == int(shot)) &
+            (arr["track_id"] == int(track_id)) &
+            (arr["src"] == det_code)
+        )
+
+        # Require has_landmarks column. If absent (legacy), be conservative and treat as 0.
+        if "has_landmarks" in (arr.dtype.names or ()):
+            mask &= (arr["has_landmarks"] == 1)
+        else:
+            mask &= False  # no has_landmarks => cannot assert eligible
+
+        if frame_max is not None:
+            mask &= (arr["f"] <= int(frame_max))
+
+        frames = [int(f) for f in np.asarray(arr["f"][mask]).tolist()]
+        frames.sort()
+        return frames
+    
+    def get_emb_frames_for_track(
+        self,
+        shot: int,
+        track_id: int,
+        frame_max: int | None = None,
+    ) -> list[int]:
+        # Prefer live collector
+        arr = None
+        if getattr(self, "_obs", None) is not None and hasattr(self._obs, "to_array"):
+            try:
+                arr = self._obs.to_array()
+            except Exception:
+                arr = None
+        if arr is None:
+            arr = self._obs_np()
+
+        if "emb_idx" not in (arr.dtype.names or ()):
+            return []
+
+        mask = (
+            (arr["shot"] == int(shot)) &
+            (arr["track_id"] == int(track_id)) &
+            (arr["emb_idx"] >= 0)
+        )
+        if frame_max is not None:
+            mask &= (arr["f"] <= int(frame_max))
+
+        frames = [int(f) for f in np.asarray(arr["f"][mask]).tolist()]
+        frames.sort()
+        return frames
+
+
+    def get_det_frames_for_track(self, shot: int, track_id: int, frame_max: int | None = None) -> list[int]:
+        det_code = int(SRC_TO_CODE[Source.DETECTED])
+
+        # Prefer live in-memory collector if present (avoids stale NPZ during end-of-shot work)
+        arr = None
+        if getattr(self, "_obs", None) is not None and hasattr(self._obs, "to_array"):
+            try:
+                arr = self._obs.to_array()
+            except Exception:
+                arr = None
+
+        # Fallback: disk NPZ (used when resuming or when no live collector exists)
+        if arr is None:
+            arr = self._obs_np()
 
         mask = (
             (arr["shot"] == int(shot)) &
@@ -1188,8 +1265,6 @@ class CheckpointManager(TrackingCheckpoint):
         try:
             return json.loads(self.status_path.read_text())
         except Exception as e:
-            if PARANOID:
-                raise ResumeSafetyError(f"[ckpt] corrupt status.json: {e}")
             return None
         
     def _validate_collectors_schema(self, obs_collector, emb_collector) -> None:
@@ -1210,7 +1285,7 @@ class CheckpointManager(TrackingCheckpoint):
         # ---- observations sidecar structure (ckpt/obs_ckpt.npz) ----
         # We always require the checkpoint obs NPZ to have an 'observations' array.
         if self.obs_path.exists():
-            _assert_npz_keys(self.obs_path, ("observations",), strict=PARANOID)
+            _assert_npz_keys(self.obs_path, ("observations",))
         else:
             # If resume was requested but the obs sidecar is missing, this is a hard error.
             raise ResumeSafetyError(
@@ -1220,7 +1295,7 @@ class CheckpointManager(TrackingCheckpoint):
         # ---- embeddings sidecar structure (ckpt/emb_ckpt.npz) ----
         # Embeddings are optional, but when the file exists it must expose 'embeddings'.
         if self.emb_path.exists():
-            _assert_npz_keys(self.emb_path, ("embeddings",), strict=PARANOID)
+            _assert_npz_keys(self.emb_path, ("embeddings",))
 
         # ---- in-memory embedding collector sanity checks ----
         # If the embedding collector can expose its in-RAM array, make sure it looks sane.
@@ -1284,8 +1359,6 @@ class CheckpointManager(TrackingCheckpoint):
             try:
                 emb_rows = emb_collector.load_npz(self.emb_path)
             except Exception:
-                if PARANOID:
-                    raise ResumeSafetyError("ckpt:load: obs_collector.load_npz failed; strict mode active")
                 logging.info("ckpt:load obs_collector.load_npz() raised exception (non-strict)")
 
 
@@ -1303,48 +1376,42 @@ class CheckpointManager(TrackingCheckpoint):
         return self._last_det_shot_first_frame
     
     def _diagnose_candidates(self, obs, *, shot, track_id, frame_last) -> dict:
-        """
-        Return a breakdown of how many rows are excluded by each filter.
-        Uses obs.to_array() if available; otherwise returns {}.
-        """
         try:
             arr = obs.to_array()
         except Exception:
             return {}
 
-        out = {}
+        if getattr(arr, "size", 0) == 0:
+            return {}
+
+        out: dict[str, int] = {}
         try:
-            det_code = SRC_TO_CODE[Source.DETECTED]
-            m_shot   = (arr["shot"] == int(shot))
-            m_tid    = (arr["track_id"] == int(track_id))
-            m_upto   = (arr["f"] <= int(frame_last))
-            m_det    = (arr["src"] == int(det_code))
-            m_unass  = (arr["emb_idx"] == -1) if "emb_idx" in arr.dtype.names else True
-            if "has_crop" in arr.dtype.names:
-                m_crop = (arr["has_crop"] == 1)
-            else:
-                # Legacy fallback: assume all DET are crop-eligible
-                m_crop = m_det
+            det_code = int(SRC_TO_CODE[Source.DETECTED])
 
-            base_all = m_shot & m_tid & m_upto
-            out["rows_seen"]          = int(base_all.sum())
-            out["rows_det"]           = int((base_all & m_det).sum())
-            out["rows_det_unassigned"]= int((base_all & m_det & m_unass).sum())
-            out["rows_det_crop"]      = int((base_all & m_det & m_crop).sum())
-            out["rows_final_candidates"] = int((base_all & m_det & m_crop & m_unass).sum())
+            m_shot = (arr["shot"] == int(shot))
+            m_tid  = (arr["track_id"] == int(track_id))
+            m_upto = (arr["f"] <= int(frame_last))
+            m_det  = (arr["src"] == det_code)
 
-            # Which filter bites the most? (counts of rows eliminated by each)
-            out["filtered_no_crop"]   = int((base_all & m_det & ~m_crop).sum())
-            out["filtered_assigned"]  = int((base_all & m_det & m_crop & ~m_unass).sum())
-            out["filtered_future"]    = int(((arr["shot"] == int(shot)) &
-                                            (arr["track_id"] == int(track_id)) &
-                                            (arr["f"] > int(frame_last))).sum())
+            m_unass = (arr["emb_idx"] == -1) if "emb_idx" in (arr.dtype.names or ()) else np.ones(arr.shape[0], dtype=bool)
+            m_lm = (arr["has_landmarks"] == 1) if "has_landmarks" in (arr.dtype.names or ()) else m_det
+
+            base = m_shot & m_tid & m_upto
+
+            out["rows_seen"] = int(base.sum())
+            out["rows_det"]  = int((base & m_det).sum())
+            out["rows_det_unassigned"] = int((base & m_det & m_unass).sum())
+            out["rows_det_lm"] = int((base & m_det & m_lm).sum())
+            out["rows_final_candidates"] = int((base & m_det & m_lm & m_unass).sum())
+
+            out["filtered_no_landmarks"] = int((base & m_det & ~m_lm).sum())
+            out["filtered_assigned"]     = int((base & m_det & m_lm & ~m_unass).sum())
+            out["filtered_future"]       = int((m_shot & m_tid & (arr["f"] > int(frame_last))).sum())
         except Exception:
-            # Best effort; never break the pipeline for diagnostics
-            pass
+            return {}
+
         return out
 
-    
     # ---------- run-dir factory ----------
     @classmethod
     def open(
@@ -1505,14 +1572,14 @@ class CheckpointManager(TrackingCheckpoint):
                         f"ckpt.open: inconsistent checkpoint: emb_anchor={emb_anchor} "
                         f"but {emb_sidecar_path} is missing."
                     )
-                # NEW: structural sanity — in paranoid mode demand expected arrays:
+                # structural sanity 
                 try:
-                    _assert_npz_keys(obs_sidecar_path, ("observations",), strict=PARANOID)
+                    _assert_npz_keys(obs_sidecar_path, ("observations",))
                 except ResumeSafetyError:
                     # If we’re strict, bubble up. If not strict, continue after logging.
                     raise
                 try:
-                    _assert_npz_keys(emb_sidecar_path, ("embeddings",), strict=PARANOID)
+                    _assert_npz_keys(emb_sidecar_path, ("embeddings",))
                 except ResumeSafetyError:
                     raise
             else:
@@ -1926,7 +1993,7 @@ class CheckpointManager(TrackingCheckpoint):
 
     # ---------- embeddings validation helpers ----------
     def _det_stats_for_shot(self, shot_num: int) -> tuple[int, int]:
-        """Returns (det_with_crop, det_with_crop_and_emb) for a given shot."""
+        """Returns (det_with_landmarks, det_with_landmarks_and_emb) for a given shot."""
         if not hasattr(self, "obs_collector") or self.obs_collector is None:
             return (0, 0)
         try:
@@ -1940,19 +2007,18 @@ class CheckpointManager(TrackingCheckpoint):
             det_code = SRC_TO_CODE[Source.DETECTED]
             mask_shot = (arr["shot"] == int(shot_num))
             mask_det  = (arr["src"]  == int(det_code))
-            mask_crop = None
-            if "has_crop" in arr.dtype.names:
-                mask_crop = (arr["has_crop"] == 1)
+            if "has_landmarks" in arr.dtype.names:
+                mask_lm = (arr["has_landmarks"] == 1)
             else:
-                # Legacy fallback: assume croppable == all DET (conservative)
-                mask_crop = (arr["src"] == int(det_code))
+                # Legacy fallback: assume all DET have landmarks (conservative)
+                mask_lm = (arr["src"] == int(det_code))
 
-            base = mask_shot & mask_det & mask_crop
-            det_with_crop = int(base.sum())
-            if det_with_crop == 0:
+            base = mask_shot & mask_det & mask_lm
+            det_with_lm = int(base.sum())
+            if det_with_lm == 0:
                 return (0, 0)
             with_emb = int(((arr["emb_idx"] >= 0) & base).sum())
-            return (det_with_crop, with_emb)        
+            return (det_with_lm, with_emb)  
         except Exception:
             # Be cautious; prefer to not fail here. The caller enforces policy.
             return (0, 0)
@@ -1997,7 +2063,7 @@ class CheckpointManager(TrackingCheckpoint):
                 # Fatal: we have DET rows but not enough embeddings stored for a *completed* shot.
                 raise ResumeSafetyError(
                     f"resume: embeddings incomplete for completed shot {s}: "
-                    f"det_with_crop=%d={det_rows}, with_embeddings={with_emb}. "
+                    f"det_with_landmarks={det_rows}, with_embeddings={with_emb}. "
                     "This would break deterministic global-ID resolution. "
                     "Re-run prior segment or regenerate checkpoints."
                 )
@@ -2006,12 +2072,12 @@ class CheckpointManager(TrackingCheckpoint):
     
     def _build_open_tracks_list(self, aggregator: ShotFaceTrackAggregatorProtocol, shot_number: int) -> list[dict]:
         """
-        Each open track MUST expose attributes (not methods):
-            - track_id: int
-            - last_frame_idx: int
-            - last_det_frame_idx: int
-            - last_bbox: tuple/list len>=4 (xyxy), ints preferred
-            - closed: bool
+        Method-based contract (matches TrackLike / aggregator usage):
+            - track_id: int attribute
+            - last_frame(): int
+            - last_det_frame(): Optional[int]
+            - get_last_bbox(): Optional[xyxy]
+            - is_closed(): bool
         The shot number is provided by the caller; we do not read it from the track.
         """
         tracks = getattr(aggregator, "tracks", None)
@@ -2020,23 +2086,18 @@ class CheckpointManager(TrackingCheckpoint):
 
         out: list[dict] = []
         for t in tracks:
-            if not hasattr(t, "closed"):
-                raise TypeError("track missing required boolean attribute 'closed'")
-            if t.closed:
+            if t.is_closed():
                 continue
 
-            # Hard requirements — attributes only.
-            try:
-                track_id = int(t.track_id)
-                last_frame_idx = int(t.last_frame_idx)
-                last_det_frame_idx = int(t.last_det_frame_idx)
-                bb = t.last_bbox
-            except AttributeError as e:
-                raise TypeError(f"track missing required attribute: {e}") from e
+            track_id = int(getattr(t, "track_id", -1))
+            last_frame_idx = int(t.last_frame())
+            last_det = t.last_det_frame()
+            last_det_frame_idx = int(last_det) if last_det is not None else -1
 
-            if not isinstance(bb, (list, tuple)) or len(bb) < 4:
-                raise TypeError("track.last_bbox must be a length-4 sequence")
-            x1, y1, x2, y2 = (int(bb[0]), int(bb[1]), int(bb[2]), int(bb[3]))
+            bb = t.get_last_bbox()
+            if bb is None:
+                bb = (0, 0, 0, 0)
+            x1, y1, x2, y2 = map(int, bb[:4])
 
             out.append({
                 "shot": int(shot_number),

--- a/facekit/pipeline/checkpoint_io.py
+++ b/facekit/pipeline/checkpoint_io.py
@@ -1,0 +1,370 @@
+import numpy as np
+from pathlib import Path
+import logging
+
+from facekit.tracking.aggregator import ShotFaceTrackAggregator
+from facekit.pipeline.checkpoint import TrackingCheckpoint
+from facekit.common.obs_consts import Source
+from facekit.pipeline.resume_rehydrate import ResumePlan
+from facekit.tracking.face_structures import FaceTrack, FaceObservation
+
+logger = logging.getLogger(__name__)
+
+def _checkpoint_root_dir(checkpoint) -> Path | None:
+    """
+    Return the run root directory for the active checkpoint.
+    Prefers .root (run_dir), falls back to .run_dir, else parent of .ckpt_dir.
+    """
+    candidate = getattr(checkpoint, "root", None)
+    if candidate:
+        return Path(candidate)
+    candidate = getattr(checkpoint, "run_dir", None)
+    if candidate:
+        return Path(candidate)
+    ckpt_dir = getattr(checkpoint, "ckpt_dir", None)
+    if ckpt_dir:
+        return Path(ckpt_dir).parent
+    # For in-memory / test stubs that don't persist to disk, we can proceed
+    # without a run root. This only affects logging / debug snapshots.
+    logger.warning(
+        "Cannot determine checkpoint run root (need one of .root, .run_dir, or .ckpt_dir); "
+        "proceeding with None (disk-backed debug snapshots will be disabled)."
+    )
+    return None
+
+# def _save_crops_for_frame(
+#     checkpoint: TrackingCheckpoint | None,
+#     *,
+#     shot_number: int,
+#     frame_idx: int,
+#     aggregator: ShotFaceTrackAggregator,
+# ) -> None:
+#     """
+#     Persist aligned 112×112 crops associated with detection observations on a frame.
+
+#     For each DET observation with an in-memory aligned_face and no crop_ref yet,
+#     this function:
+#       * Writes a PNG into the checkpoint's run-root under ckpt/crops/shot-####.
+#       * Sets obs.crop_ref to the path relative to the run-root so that
+#         checkpoint.add_observations can persist the reference.
+
+#     Parameters
+#     ----------
+#     checkpoint :
+#         Optional TrackingCheckpoint providing the run-root. If None, this is a no-op.
+#     shot_number :
+#         Logical shot identifier.
+#     frame_idx :
+#         Absolute frame index just processed.
+#     aggregator :
+#         ShotFaceTrackAggregator from which DET observations are read.
+#     """
+#     if not checkpoint:
+#         return
+#     det_obs = aggregator.observations_at(
+#         frame_idx, source=Source.DETECTED, require_track_id=True
+#     )
+#     if not det_obs:
+#         return
+
+#     crops_root = _checkpoint_root_dir(checkpoint)
+#     _saved = 0
+#     for ob in det_obs:
+#         if getattr(ob, "aligned_face", None) is None:
+#             continue
+#         if getattr(ob, "crop_ref", None):
+#             continue
+#         try:
+#             rel = _save_crop_for_obs(
+#                 crops_root, shot_number, ob.frame_idx, ob.track_id, ob.aligned_face
+#             )
+#             setattr(ob, "crop_ref", rel)
+#             _saved += 1
+#         except Exception:
+#             logger.exception(
+#                 "crop-archive: failed at frame=%d tid=%s", ob.frame_idx, ob.track_id
+#             )
+#     logger.info(
+#         "CROP-SAVED frame=%d shot=%d saved=%d",
+#         frame_idx,
+#         int(shot_number),
+#         int(_saved),
+#     )
+
+def do_checkpoint(
+    checkpoint: TrackingCheckpoint | None,
+    *,
+    frame_idx: int,
+    shot_number: int,
+    aggregator: ShotFaceTrackAggregator,
+    shot_first_frame: int,
+) -> None:
+    """
+    Issue a checkpoint event, if a checkpoint is configured.
+
+    This is called just before running the detector on a given frame so that
+    status.json and sidecars reflect the current state even if detection or
+    embedding work crashes.
+
+    Parameters
+    ----------
+    checkpoint :
+        Optional TrackingCheckpoint; if None, this is a no-op.
+    frame_idx :
+        Absolute frame index about to be processed by the detector.
+    shot_number :
+        Logical shot identifier.
+    aggregator :
+        Current ShotFaceTrackAggregator for this shot.
+    shot_first_frame :
+        Absolute first frame of this shot (for status/debug).
+    """
+    if not checkpoint:
+        return
+    try:
+        checkpoint.checkpoint_now(
+            frame_idx=frame_idx,
+            shot_number=shot_number,
+            aggregator=aggregator,
+            shot_first_frame=shot_first_frame,
+            note=f"detect@{frame_idx}",
+        )
+    except Exception:
+        logger.exception("checkpoint: failed to persist at detect frame %s", frame_idx)
+
+
+def _checkpoint_observations_and_snapshot(
+    checkpoint: TrackingCheckpoint | None,
+    *,
+    shot_number: int,
+    frame_idx: int,
+    aggregator: ShotFaceTrackAggregator,
+    resume_plan: ResumePlan,
+) -> None:
+    """
+    Persist observations for a frame and (optionally) write a lightweight snapshot.
+
+    This function:
+      * Collects FaceObservation objects for the frame.
+      * At the anchor frame, optionally retries without require_track_id to avoid
+        losing DET rows at the resume boundary.
+      * Validates that all observations have FaceObservation type and Source enums.
+      * Calls checkpoint.add_observations().
+      * If snapshots are enabled, writes a small payload describing the detect frame.
+
+    Parameters
+    ----------
+    checkpoint :
+        Optional TrackingCheckpoint; if None, this is a no-op.
+    shot_number :
+        Logical shot identifier.
+    frame_idx :
+        Absolute frame index just processed.
+    aggregator :
+        ShotFaceTrackAggregator from which we read the observations.
+    resume_plan :
+        ResumePlan with anchor_frame for the anchor special case.
+    """
+    if not checkpoint:
+        return
+
+    frame_obs_objs = aggregator.observations_at(frame_idx, require_track_id=True)
+    if (not frame_obs_objs) and (frame_idx == resume_plan.anchor_frame):
+        logger.info(
+            "resume: no require_track_id observations at anchor; retrying without strictness."
+        )
+        frame_obs_objs = aggregator.observations_at(frame_idx, require_track_id=False)
+
+    if frame_obs_objs:
+        if not all(isinstance(o, FaceObservation) for o in frame_obs_objs):
+            bad = [
+                type(o).__name__
+                for o in frame_obs_objs
+                if not isinstance(o, FaceObservation)
+            ]
+            logger.error(
+                "seg: Non-FaceObservation in frame_obs_objs at frame=%s shot=%s types=%s sample=%r",
+                frame_idx,
+                shot_number,
+                bad,
+                frame_obs_objs[:1],
+            )
+            raise TypeError(
+                f"frame_obs_objs must be FaceObservation objects, got {bad}"
+            )
+        if not all(isinstance(o.source, Source) for o in frame_obs_objs):
+            bad = [
+                getattr(o, "source", None)
+                for o in frame_obs_objs
+                if not isinstance(getattr(o, "source", None), Source)
+            ]
+            logger.error(
+                "seg: Observation with non-enum source at frame=%s shot=%s bad=%r",
+                frame_idx,
+                shot_number,
+                bad[:3],
+            )
+            raise TypeError(
+                f"Observation.source must be Source enum; bad={bad[:3]}"
+            )
+
+        # Enforce: DETECTED observations must have 5-point landmarks.
+        for obs in frame_obs_objs:
+            if obs.source == Source.DETECTED:
+                lm = getattr(obs, "landmarks", None)
+                if lm is None:
+                    raise ValueError(
+                        f"checkpoint: DETECTED obs missing landmarks "
+                        f"(shot={shot_number}, frame={frame_idx}, tid={getattr(obs,'track_id',None)})"
+                    )
+                arr = np.asarray(lm, dtype=np.float32)
+                if arr.shape != (5, 2):
+                    raise ValueError(
+                        f"checkpoint: landmarks must be (5,2) for DETECTED obs "
+                        f"(shot={shot_number}, frame={frame_idx}, tid={getattr(obs,'track_id',None)}), got {arr.shape}"
+                    )
+                if not np.all(np.isfinite(arr)):
+                    raise ValueError(
+                        f"checkpoint: landmarks contain NaN/Inf for DETECTED obs "
+                        f"(shot={shot_number}, frame={frame_idx}, tid={getattr(obs,'track_id',None)})"
+                    )
+
+        checkpoint.add_observations(shot_number, frame_idx, frame_obs_objs)
+
+    try:
+        if getattr(checkpoint, "snapshots_ready", False):
+            checkpoint.write_checkpoint_snapshot(
+                name=f"detect-{shot_number}-{frame_idx}",
+                payload={
+                    "shot": int(shot_number),
+                    "frame": int(frame_idx),
+                    "note": f"detect@{frame_idx}",
+                },
+            )
+    except Exception:
+        logger.exception("checkpoint: snapshot write failed at detect frame %s", frame_idx)
+
+def _persist_embeddings_for_track(
+    checkpoint: TrackingCheckpoint | None,
+    *,
+    shot_number: int,
+    track: FaceTrack,
+    frames_for_embed: list[int],
+    embs: np.ndarray,
+) -> None:
+    """
+    Persist per-frame embeddings for a single track into the checkpoint sidecar.
+
+    B2 contract enforced here:
+      - embeddings may ONLY be written for DETECTED frames
+      - DETECTED frames must have valid landmarks
+      - (optional) refuse to overwrite an existing embedding for the same frame
+    """
+    if checkpoint is None or embs is None or int(getattr(embs, "shape", (0,))[0]) == 0:
+        logging.info(f"end of shot {shot_number} and NO embeddings added to checkpoint")
+        return
+
+    if len(frames_for_embed) != int(embs.shape[0]):
+        raise ValueError(
+            f"frames/embs mismatch: frames={len(frames_for_embed)} embs={embs.shape}"
+        )
+
+    shot_i = int(shot_number)
+    tid_i = int(track.track_id)
+
+    # ------------------------------------------------------------------
+    # Embeddings may ONLY be written for DETECTED
+    # frames AND those DETECTED frames must have landmarks.
+    # ------------------------------------------------------------------
+    max_f = max(int(f) for f in frames_for_embed)
+
+    # 1) DETECTED frames up to max_f
+    det_frames = set(
+        checkpoint.get_det_frames_with_landmarks_for_track(
+            shot_i,
+            tid_i,
+            frame_max=max_f,
+        )
+    )
+
+    # 2) DETECTED+LANDMARKS frames up to max_f
+    #    (This assumes your checkpoint can answer this. If it can't yet,
+    #     see "Minimal supporting API" below.)
+    det_landmark_frames = set(
+        int(f)
+        for f in checkpoint.get_det_frames_with_landmarks_for_track(
+            shot_i,
+            tid_i,
+            frame_max=max_f,
+        )
+    )
+
+    # 3) Every requested frame must be in det_frames
+    bad_not_detected = [int(f) for f in frames_for_embed if int(f) not in det_frames]
+    if bad_not_detected:
+        raise ValueError(
+            "[ckpt] refusing to persist embeddings for non-DETECTED frames: "
+            f"shot={shot_i} track={tid_i} bad_frames={bad_not_detected} "
+            f"det_frames_up_to_{max_f}={sorted(det_frames)}"
+        )
+
+    # 4) Every requested frame must be in det_landmark_frames
+    bad_missing_landmarks = [
+        int(f) for f in frames_for_embed if int(f) not in det_landmark_frames
+    ]
+    if bad_missing_landmarks:
+        raise ValueError(
+            "[ckpt] refusing to persist embeddings for DETECTED frames without landmarks: "
+            f"shot={shot_i} track={tid_i} bad_frames={bad_missing_landmarks} "
+            f"detected_with_landmarks_up_to_{max_f}={sorted(det_landmark_frames)}"
+        )
+
+    # ------------------------------------------------------------------
+    # Refuse to overwrite if we already have an embedding stored
+    # for that frame. This prevents silent double-writes on resume logic.
+    # ------------------------------------------------------------------
+    already = set(
+        int(f)
+        for f in checkpoint.get_emb_frames_for_track(
+            shot_i,
+            tid_i,
+            frame_max=max_f,
+        )
+    )
+    overwrite_frames = [int(f) for f in frames_for_embed if int(f) in already]
+    if overwrite_frames:
+        raise ValueError(
+            "[ckpt] refusing to overwrite existing per-frame embeddings: "
+            f"shot={shot_i} track={tid_i} frames={overwrite_frames}"
+        )
+
+    for f_idx, vec in zip(frames_for_embed, embs):
+        checkpoint.add_embeddings(
+            shot_i,
+            tid_i,
+            int(f_idx),
+            np.asarray(vec, dtype=np.float32).reshape(1, -1),
+        )
+
+    logging.info(
+        f"end of shot {shot_number} and {len(embs)} per-frame embeddings added to checkpoint"
+    )
+
+def _finalize_checkpoint_run(checkpoint: TrackingCheckpoint | None) -> None:
+    """
+    Finalize checkpoint sidecars at end-of-video and mark the run as completed.
+
+    This flushes in-memory collectors to disk (obs_ckpt.npz, emb_ckpt.npz) and
+    clears the "resume anchor" semantics so downstream tools can safely read
+    the full obs/emb datasets without trimming to the last detection frame.
+
+    Parameters
+    ----------
+    checkpoint :
+        Optional TrackingCheckpoint; if None, this is a no-op.
+    """
+    if not checkpoint:
+        return
+    checkpoint.finalize(note="final video flush")
+    checkpoint.mark_completed()
+

--- a/facekit/pipeline/resume_rehydrate.py
+++ b/facekit/pipeline/resume_rehydrate.py
@@ -2,11 +2,13 @@ from typing import Optional, List, Tuple, Callable, Iterable, Dict
 import numpy as np
 from math import isfinite
 from pathlib import Path
+from dataclasses import dataclass
 import logging
+
 from facekit.tracking.face_structures import FaceTrack, FaceObservation
 from facekit.common.obs_consts import Source, code_to_src, SRC_TO_CODE
 from facekit.errors import ResumeSafetyError
-
+from facekit.pipeline.checkpoint import TrackingCheckpoint
 
 # ---------- bbox helpers (unchanged) ----------
 def _as_int_bbox(bb) -> tuple[int, int, int, int] | None:
@@ -68,7 +70,46 @@ def _normalize_src(raw_src) -> Source:
         f"rehydrate: unsupported src type {type(raw_src)!r} value={raw_src!r}"
     )
 
-def _row_to_faceobs(row: dict, track_id: int) -> FaceObservation | None:
+def _landmarks_from_flat10(has_landmarks, flat10) -> np.ndarray | None:
+    """
+    Convert persisted (has_landmarks, flat10) into a (5,2) float32 array.
+
+    Contract:
+      - If has_landmarks == 0 → return None
+      - If has_landmarks == 1 → flat10 MUST be length 10, all finite
+      - Anything else → ResumeSafetyError
+    """
+    if not has_landmarks:
+        return None
+
+    if flat10 is None:
+        raise ResumeSafetyError("rehydrate: has_landmarks=1 but landmarks_flat10 is None")
+
+    try:
+        arr = np.asarray(flat10, dtype=np.float32)
+    except Exception as e:
+        raise ResumeSafetyError(f"rehydrate: invalid landmarks_flat10: {e}")
+
+    if arr.shape != (10,):
+        raise ResumeSafetyError(
+            f"rehydrate: landmarks_flat10 must have shape (10,), got {arr.shape}"
+        )
+
+    if not np.all(np.isfinite(arr)):
+        raise ResumeSafetyError(
+            "rehydrate: landmarks_flat10 contains NaN/Inf but has_landmarks=1"
+        )
+
+    return arr.reshape((5, 2))
+
+def _row_to_faceobs(row: dict, *, shot_id: int, track_id: int) -> FaceObservation | None:
+    """
+    Convert a persisted observation row into a FaceObservation.
+
+    IMPORTANT:
+      - Some collectors omit 'shot' inside each row because shot is implied by grouping.
+        We therefore accept shot_id explicitly and only *read* row['shot'] if present.
+    """
     bb = _as_int_bbox(row["bbox_xyxy"])
     if bb is None:
         return None
@@ -76,40 +117,48 @@ def _row_to_faceobs(row: dict, track_id: int) -> FaceObservation | None:
 
     raw_src = row.get("src")
     try:
-        # Sidecars may hold enum, int code, numeric str, or legacy name ("detected")
         src = _normalize_src(raw_src)
     except Exception as e:
         raise ResumeSafetyError(
             f"rehydrate: invalid src={raw_src!r} in obs row "
-            f"(shot={row.get('shot')}, f={row.get('f')}, tid={track_id})"
+            f"(shot={shot_id}, f={row.get('f')}, tid={track_id})"
         ) from e
+
+    # landmarks payload (strict/soft policy is handled in B; for A keep strict call)
+    has_landmarks = int(row.get("has_landmarks", 0))
+    landmarks_flat10 = row.get("landmarks_flat10")
+    landmarks = _landmarks_from_flat10(has_landmarks, landmarks_flat10)
+
+    # confidence (optional)
+    conf = None
+    if "conf" in row and row["conf"] is not None:
+        try:
+            v = float(row["conf"])
+            conf = None if np.isnan(v) else v
+        except Exception:
+            conf = None
 
     obs = FaceObservation(
         frame_idx=int(row["f"]),
         track_id=int(track_id) if track_id is not None and int(track_id) >= 0 else None,
         bbox=(x1, y1, x2, y2),
         embedding=None,
-        confidence=(
-            float(row["conf"])
-            if "conf" in row and row["conf"] is not None and not np.isnan(row["conf"])
-            else None
-        ),
+        confidence=conf,
         aligned_face=None,
+        landmarks=landmarks,
         source=src,
     )
 
-    crop_ref = row.get("crop_ref") or row.get("crop_path") or ""
-    if crop_ref:
-        setattr(obs, "crop_ref", str(crop_ref))
-
+    # Debug logging (optional, safe)
     try:
         logging.info(
-            "rehydrate DEBUG FaceObservation: shot=%r track_id=%r frame=%r src=%r crop_ref=%r",
-            row.get("shot"),
+            "rehydrate DEBUG obs row: shot=%r tid=%r f=%r src=%r has_landmarks=%r flat10_len=%r",
+            int(shot_id),
             track_id,
-            obs.frame_idx,
-            obs.source,
-            getattr(obs, "crop_ref", None),
+            row.get("f"),
+            raw_src,
+            has_landmarks,
+            (len(landmarks_flat10) if landmarks_flat10 is not None else None),
         )
     except Exception:
         pass
@@ -174,7 +223,7 @@ def make_emb_lookup_from_sidecars(
                 f"rehydrate: invalid src={row['src']!r} in obs sidecar row idx={idx}"
             ) from e
 
-        if row_src is not det_src:
+        if row_src != det_src:
             continue
 
         emb_idx = int(row["emb_idx"])
@@ -274,34 +323,13 @@ def rehydrate_observation_tracks(
     for shot, track_id, rows in groups:
         obs_list: List[FaceObservation] = []
 
-        # DEBUG: dump raw rows for the specific test case (shot=2, tid=1)
-        try:
-            if int(shot) == 2 and int(track_id) == 1:
-                for r in rows:
-                    # r is expected to be a dict-like object
-                    try:
-                        logging.info(
-                            "rehydrate DEBUG raw row: "
-                            "shot=%r tid=%r f=%r src=%r crop_ref=%r has_crop=%r",
-                            r.get("shot"),
-                            r.get("track_id", r.get("tid")),
-                            r.get("f"),
-                            r.get("src"),
-                            r.get("crop_ref", None),
-                            r.get("has_crop", None),
-                        )
-                    except AttributeError:
-                        # If r is a numpy record instead of dict
-                        logging.info(
-                            "rehydrate DEBUG raw row (non-dict): type=%s fields=%s",
-                            type(r),
-                            getattr(r, "dtype", None),
-                        )
-        except Exception:
-            logging.exception("rehydrate DEBUG: logging raw rows failed")
-
         for r in rows:
-            o = _row_to_faceobs(r, track_id)
+            # Some collectors omit 'shot' in row dicts. Ensure shot is always known.
+            # Also avoid mutating collector-owned objects by copying to a plain dict.
+            row = dict(r)
+            row.setdefault("shot", int(shot))  # ensures debug/log consistency and downstream safety
+
+            o = _row_to_faceobs(row, shot_id=int(shot), track_id=int(track_id))
             if o is not None:
                 obs_list.append(o)
 
@@ -450,7 +478,6 @@ def attach_embeddings_to_tracks(
         "%s: DET obs=%d, with_embeddings=%d (%.1f%%)", log_prefix, tot_det, tot_attached, pct
     )
 
-
 # ---------- Phase 3: one-call rehydration (observations + embeddings) ----------
 def rehydrate_tracks(
     collector,
@@ -515,3 +542,688 @@ def rehydrate_tracks(
 
     # 3) Stitch back together in the original order
     return completed_tracks + anchor_tracks
+
+@dataclass
+class ResumePlan:
+    """
+    Immutable snapshot of all resume-related state needed by track_across_segments.
+
+    Fields
+    ------
+    anchor_frame :
+        Absolute frame index at which new work must begin. All frames strictly
+        before this are considered "pre-anchor" and must already be persisted.
+    is_resume :
+        True if this run is resuming from a previous checkpoint (anchor_frame > 0),
+        False for a cold start.
+    first_processed_shot_number :
+        The shot_number of the first shot that will be processed in this run
+        (i.e. the shot containing anchor_frame, after trimming the shot list).
+    segment_id_seed_by_shot :
+        Per-shot seed for segment_id assignment. For shots that were already
+        completed pre-anchor, this is the count of their pre-existing segments;
+        for the anchor shot it is the number of pre-anchor segments.
+    trackid_seed_by_shot :
+        Per-shot seed for track_id allocation. For each shot, this is
+        max(pre-anchor track_id) + 1, so new tracks continue numbering cleanly.
+    prior_tracks_anchor :
+        Tracks rehydrated for the anchor-containing shot, limited to frames
+        strictly before anchor_frame. These are used to seed the first shot's
+        aggregator so labels and embeddings remain consistent across runs.
+    reuse_tid_for_first_shot :
+        If not None, the specific track_id that should be reused for the first
+        *new* detection track in the anchor shot, to preserve exact parity of
+        labels at the resume boundary.
+    """
+    anchor_frame: int
+    is_resume: bool
+    first_processed_shot_number: int
+    segment_id_seed_by_shot: Dict[int, int]
+    trackid_seed_by_shot: Dict[int, int]
+    prior_tracks_anchor: List[FaceTrack]
+    reuse_tid_for_first_shot: Optional[int]
+
+def _resolve_anchor(
+    checkpoint: TrackingCheckpoint | None,
+    resume_enabled: bool,
+) -> int:
+    """
+    Decide the global resume anchor frame for this run.
+
+    Precedence (highest to lowest):
+      1. checkpoint.get_resume_anchor()[0]               # explicit tuple
+      2. checkpoint.read_status()['last_detection_frame']
+      3. status.json on disk via checkpoint.status_path
+      4. checkpoint.last_detection_frame                 # legacy attr/callable
+      5. max frame index from checkpoint.obs_collector
+      6. Fallback to 0 if resume is disabled or no info exists.
+
+    Parameters
+    ----------
+    checkpoint :
+        Optional TrackingCheckpoint providing status and observation sidecars.
+    resume_enabled :
+        If False, all resume sources are ignored and 0 is returned.
+
+    Returns
+    -------
+    int
+        The absolute frame index where new work must begin. 0 means cold start.
+    """
+    if not (resume_enabled and checkpoint):
+        logging.info("resume: disabled or no checkpoint -> anchor=0")
+        return 0
+
+    # (1) explicit tuple from get_resume_anchor()
+    try:
+        anchors = checkpoint.get_resume_anchor()
+        if anchors is not None and len(anchors) >= 1:
+            logging.info("resume: using get_resume_anchor() -> %r", anchors)
+            return int(anchors[0])
+    except Exception:
+        pass
+
+    # (2) prefer read_status() → status.json
+    try:
+        rs = getattr(checkpoint, "read_status", None)
+        if callable(rs):
+            status = rs() or {}
+            val = status.get("last_detection_frame")
+            if val is not None:
+                logging.info("resume: using read_status()['last_detection_frame'] -> %r", val)
+                return int(val)
+    except Exception:
+        pass
+
+    # (3) direct status.json path if exposed
+    try:
+        status_path = getattr(checkpoint, "status_path", None)
+        if status_path:
+            import os as _os, json as _json
+            if _os.path.exists(status_path):
+                with open(status_path, "r") as f:
+                    status = _json.load(f) or {}
+                val = status.get("last_detection_frame")
+                if val is not None:
+                    logging.info("resume: using status.json file -> %r", val)
+                    return int(val)
+    except Exception:
+        pass
+
+    # (4) legacy callable/attr last_detection_frame
+    try:
+        candidate = getattr(checkpoint, "last_detection_frame", None)
+        val = candidate() if callable(candidate) else candidate
+        if val is not None:
+            logging.info("resume: using legacy last_detection_frame -> %r", val)
+            return int(val)
+    except Exception:
+        pass
+
+    # (5) max observed frame from the obs collector
+    try:
+        collector = getattr(checkpoint, "obs_collector", None)
+        if collector is not None and hasattr(collector, "get_all_frame_indices"):
+            frames_seen = collector.get_all_frame_indices()
+            if frames_seen is not None and len(frames_seen) > 0:
+                max_frame = int(np.max(frames_seen))
+                logging.info("resume: using obs_collector max frame -> %d", max_frame)
+                return max_frame
+    except Exception:
+        pass
+
+    logging.info("resume: no anchor inputs -> anchor=0")
+    return 0
+
+def _shot_idx_by_abs_frame(shots, abs_frame_idx: int) -> int:
+    """
+    Return the **shot index** i such that shots[i]["last_frame"] >= abs_frame_idx,
+    choosing the leftmost such i. If no such shot exists (abs_frame_idx is after
+    all shots), return len(shots).
+
+    Notes:
+    - Shots must be sorted, non-overlapping, ascending by frame range.
+    - If abs_frame_idx < shots[0]["first_frame"], this returns 0. The caller
+      could clamp the starting frame i.e:
+          start_at = max(shots[i]["first_frame"], abs_frame_idx)
+    """
+    # First shot whose last_frame >= resume_abs_frame
+    from bisect import bisect_left
+    last_frames = [s["last_frame"] for s in shots]
+    return bisect_left(last_frames, abs_frame_idx)
+
+def _assign_segment_ids_for_rehydrated(
+    prior_tracks: List[FaceTrack],
+    track_order: dict[tuple[int, int], int],
+) -> Dict[int, int]:
+    """
+    Assign deterministic per-shot segment_id values to rehydrated tracks.
+
+    Primary rule:
+      - If (shot_id, track_id) exists in `track_order`, use that order index as segment_id.
+        This makes segment labeling stable across resumes, independent of tracking dynamics.
+
+    Fallback rule (only if track_order is missing for a particular track):
+      - Use track_id as a deterministic stand-in segment_id.
+
+    Returns:
+      segment_id_seed_by_shot: {shot_id: next_segment_id_seed}
+        where next_seed is max_assigned_segment_id + 1 for that shot (or 0 if none).
+    """
+    seed_by_shot: Dict[int, int] = {}
+    max_seg_by_shot: Dict[int, int] = {}
+
+    for tr in prior_tracks or []:
+        shot = int(getattr(tr, "shot_id", -1))
+        tid  = int(getattr(tr, "track_id", -1))
+        if shot < 0 or tid < 0:
+            continue
+
+        key = (shot, tid)
+        if key in track_order:
+            seg = int(track_order[key])
+        else:
+            # Deterministic fallback (keeps resume working even if track_order is partial)
+            seg = tid
+            logging.warning(
+                "resume: track_order missing for (shot=%d, tid=%d); "
+                "using fallback segment_id=%d",
+                shot, tid, seg
+            )
+
+        # Mutate the track in place (expected by downstream segment labeling)
+        setattr(tr, "segment_id", seg)
+
+        prev = max_seg_by_shot.get(shot, -1)
+        if seg > prev:
+            max_seg_by_shot[shot] = seg
+
+    for shot, max_seg in max_seg_by_shot.items():
+        seed_by_shot[int(shot)] = int(max_seg) + 1 if int(max_seg) >= 0 else 0
+
+    return seed_by_shot
+
+def _build_resume_plan(
+    shots: list,
+    *,
+    checkpoint: TrackingCheckpoint | None,
+    resume_enabled: bool,
+    all_tracks: List[FaceTrack],
+) -> tuple[ResumePlan, list]:
+    """
+    Construct a ResumePlan and trim the shot list to the anchor-containing shot.
+
+    This function encapsulates all the heavy lifting that used to live inline
+    in track_across_segments:
+      * Resolve the anchor frame.
+      * Audit pre-anchor DET rows for embedding/landmarks parity.
+      * Rehydrate pre-anchor tracks from sidecars.
+      * Split pre-anchor tracks into completed vs anchor-containing shots.
+      * Push completed-shot tracks into all_tracks immediately.
+      * Assign segment_id seeds and track_id seeds per shot.
+      * Decide which tid to reuse at the resume boundary.
+      * Trim `shots` so the first processed shot always contains the anchor.
+
+    Parameters
+    ----------
+    shots :
+        Original list of shot dicts from shot JSON (untrimmed).
+    checkpoint :
+        Optional TrackingCheckpoint for accessing sidecars and status.
+    resume_enabled :
+        Whether resume is allowed. If False, this behaves like a cold start.
+    all_tracks :
+        The list that will ultimately hold all tracks; pre-anchor completed
+        tracks are appended here immediately.
+
+    Returns
+    -------
+    plan, trimmed_shots :
+        plan : ResumePlan
+            Immutable resume state struct used by the main tracking loop.
+        trimmed_shots : list
+            The subset of shots starting from the anchor-containing shot.
+    """
+    segment_id_seed_by_shot: Dict[int, int] = {}
+    trackid_seed_by_shot: Dict[int, int] = {}
+    prior_tracks: List[FaceTrack] = []
+
+    resume_abs_frame: int = _resolve_anchor(checkpoint, resume_enabled)
+
+    # === AUDIT FENCE #0: record collector rows BEFORE any new work ===
+    try:
+        if checkpoint and hasattr(checkpoint, "obs_collector"):
+            rows_before = int(checkpoint.obs_collector.count())
+            logging.info("resume: obs_collector rows BEFORE processing=%d", rows_before)
+    except Exception:
+        logging.exception("resume: failed to read obs_collector.count() before")
+
+    # Identify anchor-containing shot BEFORE any trimming (used for logging)
+    anchor_shot_idx = _shot_idx_by_abs_frame(shots, resume_abs_frame) if resume_abs_frame > 0 else None
+    anchor_shot_num = (
+        shots[anchor_shot_idx]["shot_number"]
+        if (anchor_shot_idx is not None and anchor_shot_idx < len(shots))
+        else None
+    )
+
+    # --- AUDIT: verify pre-anchor DET rows have embeddings in sidecar ---
+    _audit_preanchor_embedding_parity(
+        checkpoint,
+        shots=shots,
+        anchor_frame=resume_abs_frame,
+        anchor_shot=anchor_shot_num,
+    )
+
+    # Compute completed shots (fully before anchor) BEFORE trimming
+    completed_shot_nums = (
+        {s["shot_number"] for s in shots}
+        if resume_abs_frame == 0
+        else {s["shot_number"] for s in shots if s["last_frame"] < resume_abs_frame}
+    )
+
+    # Rehydrate BEFORE the anchor (if any)
+    obs_for_rehydrate = getattr(checkpoint, "obs_collector", None)
+    if obs_for_rehydrate is not None and resume_abs_frame > 0:
+        emb_lookup, emb_array_lookup = _build_emb_lookups_for_checkpoint(
+            checkpoint,
+            anchor_frame=resume_abs_frame,
+        )
+        prior_tracks = rehydrate_tracks(
+            obs_for_rehydrate,
+            frame_max=resume_abs_frame - 1,
+            track_order=(checkpoint.get_track_order() or {}) if checkpoint else {},
+            emb_lookup=emb_lookup,
+            emb_array_lookup=emb_array_lookup,
+            anchor_shot_id=anchor_shot_num,
+            strict=True,
+        )
+    elif obs_for_rehydrate is not None:
+        logging.info("resume: anchor=0 -> cold start; skipping pre-anchor rehydration")
+        prior_tracks = []
+    else:
+        logging.info("resume: no obs_collector on checkpoint; skipping pre-anchor rehydration")
+        prior_tracks = []
+
+    # Hard guard: enforce DET↔EMB parity and landmarks presence on pre-anchor DETs
+    for t in prior_tracks or []:
+        shot_id = int(getattr(t, "shot_id", -1))
+        is_completed_shot = shot_id in completed_shot_nums
+        is_anchor_shot = (anchor_shot_num is not None and shot_id == int(anchor_shot_num))
+
+        if not (is_completed_shot or is_anchor_shot):
+            continue
+
+        det_cnt = sum(
+            1
+            for o in (getattr(t, "observations", []) or [])
+            if getattr(o, "source", None) == Source.DETECTED
+            and int(o.frame_idx) <= int(resume_abs_frame - 1)
+        )
+        emb_cnt = len(getattr(t, "embeddings", []) or [])
+
+        if is_completed_shot and det_cnt > 0 and emb_cnt != det_cnt:
+            raise ResumeSafetyError(
+                f"rehydrate: pre-anchor embedding parity failed for (shot={shot_id}, "
+                f"tid={int(getattr(t,'track_id',-1))}): DET={det_cnt} vs EMB={emb_cnt}"
+            )
+
+        for o in getattr(t, "observations", []) or []:
+            if (
+                getattr(o, "source", None) == Source.DETECTED
+                and int(o.frame_idx) <= int(resume_abs_frame - 1)
+            ):
+                lm = getattr(o, "landmarks", None)
+                if lm is None:
+                    raise ResumeSafetyError(
+                        "rehydrate: missing landmarks for pre-anchor DET "
+                        f"(shot={shot_id}, tid={int(getattr(t,'track_id',-1))}, frame={int(o.frame_idx)})"
+                    )
+                arr = np.asarray(lm, dtype=np.float32)
+                if arr.shape != (5, 2):
+                    raise ResumeSafetyError(
+                        f"rehydrate: landmarks must be (5,2) on pre-anchor DET "
+                        f"(shot={shot_id}, tid={int(getattr(t,'track_id',-1))}, frame={int(o.frame_idx)}), got {arr.shape}"
+                    )
+                if not np.all(np.isfinite(arr)):
+                    raise ResumeSafetyError(
+                        f"rehydrate: landmarks contain NaN/Inf on pre-anchor DET "
+                        f"(shot={shot_id}, tid={int(getattr(t,'track_id',-1))}, frame={int(o.frame_idx)})"
+                    )
+
+    # Split rehydrated tracks into fully completed vs anchor shot
+    prior_tracks_completed: List[FaceTrack] = []
+    prior_tracks_anchor: List[FaceTrack] = []
+    for t in prior_tracks or []:
+        s = int(getattr(t, "shot_id", -1))
+        if s in completed_shot_nums:
+            prior_tracks_completed.append(t)
+        elif s == (anchor_shot_num if anchor_shot_num is not None else -1):
+            prior_tracks_anchor.append(t)
+        else:
+            logging.debug("rehydrate: ignoring pre-anchor track from unexpected shot=%s", s)
+
+    # Completed shots become outputs immediately
+    if prior_tracks_completed:
+        logging.info(
+            "resume: adding %d completed pre-anchor tracks to outputs",
+            len(prior_tracks_completed),
+        )
+        all_tracks.extend(prior_tracks_completed)
+
+    # Logging for rehydrated counts
+    try:
+        by_shot_counts = {}
+        for track in prior_tracks:
+            shot = int(getattr(track, "shot_id", -1))
+            by_shot_counts[shot] = by_shot_counts.get(shot, 0) + 1
+        logging.info("resume: rehydrated counts by shot: %r", by_shot_counts)
+        logging.info(
+            "resume: segment_id_seed_by_shot: %r",
+            {int(k): int(v) for k, v in (segment_id_seed_by_shot or {}).items()},
+        )
+        logging.info(
+            "resume: trackid_seed_by_shot: %r",
+            {int(k): int(v) for k, v in (trackid_seed_by_shot or {}).items()},
+        )
+    except Exception:
+        logging.exception("resume: failed summarizing seeds")
+
+    # Assign stable segment_ids to rehydrated tracks and compute per-shot seeds
+    last_tid_by_shot: Dict[int, int] = {}
+    try:
+        track_order_map = (
+            checkpoint.get_track_order()
+            if (checkpoint and hasattr(checkpoint, "get_track_order"))
+            else {}
+        )
+        segment_id_seed_by_shot = _assign_segment_ids_for_rehydrated(
+            prior_tracks, track_order_map or {}
+        )
+
+        tmp: Dict[int, int] = {}
+        last_frame_by_shot_tid: Dict[Tuple[int, int], int] = {}
+
+        for track in prior_tracks:
+            shot = int(getattr(track, "shot_id", 0))
+            tid = int(getattr(track, "track_id", -1))
+            if tid >= 0:
+                tmp[shot] = max(tmp.get(shot, -1), tid)
+                if getattr(track, "observations", None):
+                    last_frame = max(o.frame_idx for o in track.observations)
+                    key = (shot, tid)
+                    if key not in last_frame_by_shot_tid or last_frame > last_frame_by_shot_tid[key]:
+                        last_frame_by_shot_tid[key] = last_frame
+
+        trackid_seed_by_shot = {shot: (max_tid + 1) for shot, max_tid in tmp.items()}
+        for (shot, tid), last_frame in last_frame_by_shot_tid.items():
+            if (shot not in last_tid_by_shot) or last_frame > last_frame_by_shot_tid.get(
+                (shot, last_tid_by_shot[shot]), -1
+            ):
+                last_tid_by_shot[shot] = tid
+
+        logging.info(
+            "resume: assigned segment_ids to %d rehydrated tracks; seeds=%s",
+            len(prior_tracks),
+            {k: int(v) for k, v in segment_id_seed_by_shot.items()},
+        )
+    except Exception:
+        logging.exception(
+            "resume: failed to assign segment_ids to rehydrated tracks; continuing with empty seeds"
+        )
+        segment_id_seed_by_shot = {}
+        trackid_seed_by_shot = {}
+        last_tid_by_shot = {}
+
+    if checkpoint and hasattr(checkpoint, "_validate_resume_embeddings"):
+        checkpoint._validate_resume_embeddings(anchor_shot=anchor_shot_num)
+
+    logging.info(
+        "resume: prior_tracks strictness OK (anchor_shot=%s); rehydrated=%d (completed=%d, anchor-shot=%d)",
+        anchor_shot_num,
+        len(prior_tracks or []),
+        len(prior_tracks_completed),
+        len(prior_tracks_anchor),
+    )
+
+    # Trim shots so the first processed shot is the one containing the anchor
+    start_shot_idx = _shot_idx_by_abs_frame(shots, resume_abs_frame)
+    if start_shot_idx >= len(shots):
+        raise ResumeSafetyError("resume anchor beyond last shot; aborting for safety.")
+    shots_trimmed = shots[start_shot_idx:]
+
+    if not shots_trimmed:
+        first_processed_shot_number = 0
+    else:
+        first_processed_shot_number = shots_trimmed[0]["shot_number"]
+
+    is_resume = bool(resume_abs_frame > 0)
+
+    reuse_tid_for_first_shot: Optional[int] = None
+    if checkpoint and resume_abs_frame > 0:
+        try:
+            reuse_tid_for_first_shot = last_tid_by_shot.get(int(first_processed_shot_number))
+            if reuse_tid_for_first_shot is not None:
+                logging.info(
+                    "resume: will reuse tid=%d for first detection in shot=%d",
+                    int(reuse_tid_for_first_shot),
+                    int(first_processed_shot_number),
+                )
+        except Exception:
+            reuse_tid_for_first_shot = None
+
+        logging.info(
+            "resume: anchor=%d anchor_shot_num=%s first_processed_shot_number=%s reuse_tid_for_first_shot=%s",
+            resume_abs_frame,
+            anchor_shot_num,
+            first_processed_shot_number,
+            reuse_tid_for_first_shot,
+        )
+
+    plan = ResumePlan(
+        anchor_frame=int(resume_abs_frame),
+        is_resume=is_resume,
+        first_processed_shot_number=int(first_processed_shot_number),
+        segment_id_seed_by_shot=segment_id_seed_by_shot,
+        trackid_seed_by_shot=trackid_seed_by_shot,
+        prior_tracks_anchor=prior_tracks_anchor,
+        reuse_tid_for_first_shot=reuse_tid_for_first_shot,
+    )
+    return plan, shots_trimmed
+
+def _audit_preanchor_embedding_parity(checkpoint, *, shots: list, anchor_frame: int, anchor_shot: Optional[int]):
+    """
+    Resume-only audit: verify that every DET row with frame <= anchor-1 has an embedding.
+    Uses rows_for_frame(shot, frame) if available. Falls back to iter_track_frames(...) to
+    at least count DETs and flag likely gaps. Logs which frames are missing and whether a
+    landmarks are present (when available).
+    """
+    if not checkpoint or not hasattr(checkpoint, "obs_collector"):
+        logging.info("RESUME-AUDIT: no checkpoint/collector; skipping.")
+        return
+
+    oc = checkpoint.obs_collector
+    has_rows_for_frame = hasattr(oc, "rows_for_frame") and callable(getattr(oc, "rows_for_frame"))
+    has_iter_track_frames = hasattr(oc, "iter_track_frames") and callable(getattr(oc, "iter_track_frames"))
+
+    if not has_rows_for_frame and not has_iter_track_frames:
+        logging.info("RESUME-AUDIT: collector lacks rows_for_frame/iter_track_frames; skipping.")
+        return
+
+    # Helper: record a missing embedding at (shot, tid, frame) with landmarks presence if we can see it.
+    def _record_missing(
+        shot: int,
+        tid: int,
+        frame: int,
+        *,
+        has_landmarks: Optional[int],
+        det_by_key: Dict[tuple[int, int], list],
+    ):
+        det_by_key.setdefault((shot, tid), []).append(
+            {"f": int(frame), "has_landmarks": int(bool(has_landmarks))}
+        )
+
+    det_by_key: Dict[tuple[int,int], list] = {}
+    total_missing = 0
+
+    # Iterate only up to anchor-1 and (optionally) only up to anchor_shot.
+    for s in shots:
+        shot_num = int(s["shot_number"])
+        if anchor_shot is not None and shot_num > int(anchor_shot):
+            break  # nothing pre-anchor beyond the anchor shot
+        first_f = int(s["first_frame"])
+        last_f  = int(s["last_frame"])
+        limit_last = min(last_f, (anchor_frame - 1)) if anchor_frame > 0 else last_f
+        if limit_last < first_f:
+            continue
+
+        if has_rows_for_frame:
+            # Strong path: examine persisted rows per frame.
+            for f in range(first_f, limit_last + 1):
+                try:
+                    rows = list(oc.rows_for_frame(shot_num, f))  # iterable of dict-ish
+                except Exception:
+                    logging.exception("RESUME-AUDIT: rows_for_frame failed at shot=%d frame=%d", shot_num, f)
+                    continue
+                for r in rows:
+                    try:
+                        det_code = int(SRC_TO_CODE[Source.DETECTED])
+                        if int(r.get("src", -1)) != det_code:
+                            continue
+                        tid = int(r.get("track_id", -1))
+                        emb_idx = int(r.get("emb_idx", -1))
+                        if emb_idx < 0:
+                            _record_missing(
+                                shot_num,
+                                tid,
+                                f,
+                                has_landmarks=r.get("has_landmarks", 0),
+                                det_by_key=det_by_key,
+                            )
+                            total_missing += 1
+                    except Exception:
+                        # tolerate malformed rows
+                        continue
+        elif has_iter_track_frames:
+            # We can at least detect DET frames per (shot, tid) and infer that missing embs likely exist.
+            # We won’t know landmarks on this path unless rows_for_frame exists, so mark has_landmarks=0.
+            # This is a coarse safety net.
+            # Iterate known tids by scanning iter_track_frames for small tid range until it yields nothing.
+            # If your collector exposes a way to list tids per shot, prefer that.
+            seen_any = False
+            for tid_guess in range(0, 2048):  # generous upper bound; adjust if you know a tighter cap
+                try:
+                    frames_src = list(oc.iter_track_frames(shot_num, tid_guess))
+                except Exception:
+                    frames_src = []
+                if not frames_src:
+                    # Heuristic break: after a few consecutive empty tids, stop probing.
+                    # (Assumes dense, small tid space per shot.)
+                    if tid_guess > 32:
+                        break
+                    continue
+                seen_any = True
+                for f, src_code in frames_src:
+                    try:
+                        f = int(f)
+                        if f > limit_last:
+                            continue
+                        if int(src_code) != int(Source.DETECTED.value):
+                            continue
+                        # We don't know emb_idx here, but strict parity expects one vector per DET.
+                        # Flag as "missing/unknown"; later rows_for_frame (if implemented) will be authoritative.
+                        _record_missing(
+                            shot_num,
+                            int(tid_guess),
+                            f,
+                            has_landmarks=None,   # unknown on this path
+                            det_by_key=det_by_key,
+                        )
+                        total_missing += 1
+                    except Exception:
+                        continue
+            if not seen_any:
+                logging.debug("RESUME-AUDIT: no tracks observed via iter_track_frames for shot=%d", shot_num)
+
+    # Summarize
+    if not det_by_key:
+        logging.info("RESUME-AUDIT: no pre-anchor DET rows to audit (or none missing).")
+        return
+
+    for (shot, tid), misses in sorted(det_by_key.items()):
+        misses.sort(key=lambda r: int(r["f"]))
+        frames_str = ",".join(f'{m["f"]}({m["has_landmarks"]})' for m in misses)
+        logging.error(
+            "RESUME-AUDIT shot=%d tid=%d missing_preanchor=%d frames=[%s]  (paren=has_landmarks)",
+            shot, tid, len(misses), frames_str
+        )
+
+    if total_missing == 0:
+        logging.info("RESUME-AUDIT OK: all pre-anchor DET rows have embeddings.")
+    else:
+        logging.error("RESUME-AUDIT FAIL: total missing pre-anchor DET embeddings=%d", total_missing)
+
+def _build_emb_lookups_for_checkpoint(
+    checkpoint: TrackingCheckpoint | None,
+    *,
+    anchor_frame: int,
+):
+    """
+    Build emb_lookup/emb_array_lookup callables for resume_rehydrate.rehydrate_tracks.
+
+    emb_lookup(shot, tid) returns (frames, embs) for DET observations strictly
+    before the anchor frame, using the checkpoint's sidecar accessors:
+      - get_det_frames_for_track(shot, tid, frame_max=anchor-1)
+      - get_embeddings_by_frames(shot, frames)
+    """
+    if checkpoint is None or anchor_frame <= 0:
+        return None, None
+
+    def emb_lookup(shot: int, tid: int):
+        try:
+            frames = checkpoint.get_det_frames_for_track(
+                int(shot), int(tid), frame_max=int(anchor_frame - 1)
+            )
+        except Exception:
+            return None
+
+        if not frames:
+            return None
+
+        try:
+            embs = checkpoint.get_embeddings_by_frames(int(shot), frames)
+        except Exception:
+            return None
+
+        if embs is None or len(embs) != len(frames):
+            # Let resume_rehydrate.attach_embeddings enforce strict parity.
+            return None
+
+        return frames, embs
+
+    # We intentionally disable emb_array_lookup to avoid any "count only" matching.
+    return emb_lookup, None
+
+def _validate_shots_are_absolute_and_increasing(shots):
+    if not shots:
+        return
+    # Absolute: shot 0 must start at 0 (or ≥ 0) and later shots must NOT restart at 0
+    later_all_zero = len(shots) > 1 and all(s.get("first_frame", None) == 0 for s in shots[1:])
+    # Strictly increasing windows
+    strictly_increasing = all(
+        int(shots[i]["first_frame"]) > int(shots[i-1]["last_frame"])
+        for i in range(1, len(shots))
+    )
+
+    if later_all_zero or not strictly_increasing:
+        # Build a short diagnostic of the first few shots
+        diag = ", ".join(
+            f'#{i}[{int(s["first_frame"])},{int(s["last_frame"])}]'
+            for i, s in enumerate(shots[:5])
+        )
+        raise ResumeSafetyError(
+            "Shots must be in ABSOLUTE frame space and strictly increasing. "
+            "Detected per-shot relative indexing and/or non-monotone ranges. "
+            f"Example windows: {diag}. "
+            "Ensure the shot detector writes global first_frame/last_frame (no reset to 0 between shots)."
+        )
+    

--- a/facekit/pipeline/track_across_segments.py
+++ b/facekit/pipeline/track_across_segments.py
@@ -1,13 +1,9 @@
-import os
 import numpy as np
 import json
 from pathlib import Path
-from typing import List, Tuple, Dict, Union, Optional, Iterable
+from typing import List, Tuple, Dict, Union, Callable
 import copy
-import tempfile
 from contextlib import ExitStack
-from bisect import bisect_left
-from PIL import Image
 import logging
 
 from facekit.tracking.aggregator import ShotFaceTrackAggregator
@@ -20,430 +16,432 @@ from facekit.detection.face_detector import FaceDetector
 from facekit.io.frame_provider import FrameProvider, ReaderCoordinator
 from facekit.pipeline.checkpoint import TrackingCheckpoint
 from facekit.common.obs_consts import Source
-from facekit.pipeline.resume_rehydrate import rehydrate_tracks
-from facekit.utils.geometry import compute_iou
+from facekit.pipeline.resume_rehydrate import (
+    ResumePlan,
+    _build_resume_plan,
+    _validate_shots_are_absolute_and_increasing,
+)
+from facekit.pipeline.checkpoint_io import (
+    _checkpoint_root_dir,
+    do_checkpoint, 
+    _checkpoint_observations_and_snapshot,
+    _persist_embeddings_for_track,
+    _finalize_checkpoint_run
+)
 from facekit.errors import ResumeSafetyError
-from facekit.utils.io import fsync_parent_dir
-from facekit.utils.debug_logging import _dump_agg_state
 
 logger = logging.getLogger(__name__)
-PARANOID = bool(os.environ.get("FACEKIT_PARANOID"))
 
-# --- Logging helpers (diagnostics only) ---------------------------------------
-
-def _last_det_bbox_and_frame(tr: FaceTrack) -> tuple[Optional[tuple[int,int,int,int]], int]:
-    last_det_frame = -1
-    last_det_bbox = None
-    for o in getattr(tr, "observations", []) or []:
-        src = getattr(o, "source", None)
-        assert isinstance(src, Source), f"Non-enum source in FaceObservation: {src!r}"
- 
-        if src is Source.DETECTED and o.bbox is not None:
-            if o.frame_idx > last_det_frame:
-                last_det_frame = int(o.frame_idx)
-                last_det_bbox = tuple(int(v) for v in o.bbox[:4])
-    return last_det_bbox, last_det_frame
-
-def _shot_idx_by_abs_frame(shots, abs_frame_idx: int) -> int:
+def _init_shot_aggregator(
+    *,
+    shot_idx: int,
+    shot_number: int,
+    first: int,
+    last: int,
+    detect_interval: int,
+    resume_plan: ResumePlan,
+    iou_thresh: float,
+    embedding_thresh: float,
+    checkpoint: TrackingCheckpoint | None,
+) -> tuple[int, ShotFaceTrackAggregator, int]:
     """
-    Return the **shot index** i such that shots[i]["last_frame"] >= abs_frame_idx,
-    choosing the leftmost such i. If no such shot exists (abs_frame_idx is after
-    all shots), return len(shots).
+    Initialize a ShotFaceTrackAggregator for a single shot, applying resume rules.
 
-    Notes:
-    - Shots must be sorted, non-overlapping, ascending by frame range.
-    - If abs_frame_idx < shots[0]["first_frame"], this returns 0. The caller
-      could clamp the starting frame i.e:
-          start_at = max(shots[i]["first_frame"], abs_frame_idx)
-    """
-    # First shot whose last_frame >= resume_abs_frame
-    last_frames = [s["last_frame"] for s in shots]
-    return bisect_left(last_frames, abs_frame_idx)
+    Responsibilities
+    ----------------
+    * Decide the starting frame for this shot:
+        - First processed shot starts at max(first_frame, anchor_frame).
+        - Subsequent shots start at their first_frame.
+    * For the anchor-containing shot, seed the aggregator with pre-anchor tracks
+      so that labels and embeddings continue seamlessly.
+    * Apply track_id seeding and (optional) forced tid reuse at the resume boundary.
+    * Compute the per-shot segment-id seed returned as seg_seed.
 
-def _ckpt_run_root(checkpoint) -> Path | None:
+    Parameters
+    ----------
+    shot_idx :
+        0-based index of this shot within the trimmed shot list.
+    shot_number :
+        Logical shot identifier from the shot JSON.
+    first, last :
+        Absolute first and last frame indices for this shot.
+    detect_interval :
+        Detection interval used for logging the resume fence.
+    resume_plan :
+        ResumePlan containing anchor frame and per-shot seeds.
+    iou_thresh, embedding_thresh :
+        Aggregator matching and within-shot identity thresholds.
+    checkpoint :
+        Optional checkpoint used to hydrate open tracks for seeded shots.
+
+    Returns
+    -------
+    start_at, aggregator, seg_seed :
+        start_at : int
+            Absolute frame index at which this shot-loop should start.
+        aggregator : ShotFaceTrackAggregator
+            Fully initialized aggregator for this shot.
+        seg_seed : int
+            Initial segment_id_counter seed for this shot (used at resolve_segment_ids()).
     """
-    Return the run root directory for the active checkpoint.
-    Prefers .root (run_dir), falls back to .run_dir, else parent of .ckpt_dir.
+    # Decide starting frame
+    if shot_idx == 0:
+        start_at = max(first, resume_plan.anchor_frame)
+    else:
+        start_at = first
+
+    if shot_idx == 0:
+        logging.info(
+            "resume: first_new_frame=%d (shot=[%d..%d]) detect_interval=%d mod=%d",
+            start_at,
+            first,
+            last,
+            detect_interval,
+            ((start_at - first) % max(1, detect_interval)),
+        )
+        if start_at > last:
+            raise ResumeSafetyError(
+                f"empty work-range at resume: start_at={start_at} > shot_last={last} for shot={shot_number}"
+            )
+
+    # Seeded tracks only for anchor-containing shot
+    seeded_tracks = None
+    if (
+        shot_idx == 0
+        and resume_plan.is_resume
+        and resume_plan.prior_tracks_anchor
+    ):
+        seeded_tracks = [
+            copy.deepcopy(t)
+            for t in resume_plan.prior_tracks_anchor
+            if int(getattr(t, "shot_id", -1)) == int(shot_number)
+        ]
+
+    # Build aggregator
+    if seeded_tracks:
+        aggregator = ShotFaceTrackAggregator(
+            shot_number=shot_number,
+            iou_threshold=iou_thresh,
+            embedding_threshold=embedding_thresh,
+            prior_tracks=seeded_tracks,
+            resume_abs_frame=start_at,
+            next_tid_seed=int(resume_plan.trackid_seed_by_shot.get(int(shot_number), 0)),
+        )
+        if checkpoint:
+            checkpoint.hydrate_open_tracks_into(aggregator)
+    else:
+        aggregator = ShotFaceTrackAggregator(
+            shot_number=shot_number,
+            iou_threshold=iou_thresh,
+            embedding_threshold=embedding_thresh,
+        )
+
+    # Apply forced tid reuse on very first detection frame of anchor shot
+    if (
+        shot_idx == 0
+        and resume_plan.is_resume
+        and resume_plan.reuse_tid_for_first_shot is not None
+        and int(shot_number) == int(resume_plan.first_processed_shot_number)
+    ):
+        try:
+            aggregator.set_resume_force_tid(int(resume_plan.reuse_tid_for_first_shot))
+            logging.info(
+                "resume: aggregator will force tid=%d on the next created track in shot=%d",
+                int(resume_plan.reuse_tid_for_first_shot),
+                int(shot_number),
+            )
+        except Exception:
+            logging.exception("resume: failed to set forced tid on aggregator")
+
+    if seeded_tracks:
+        logging.info("RESUME: aggregator seeded with %d tracks", len(aggregator.tracks))
+        for track in aggregator.tracks:
+            last_bbox = getattr(track, "get_last_bbox", lambda: None)()
+            logging.info(
+                "RESUME TRACK: tid=%s closed=%s last_frame=%s last_bbox=%s",
+                track.track_id,
+                track.is_closed() if hasattr(track, "is_closed") else None,
+                track.last_frame() if hasattr(track, "last_frame") else None,
+                last_bbox,
+            )
+
+    seed_tid = int(resume_plan.trackid_seed_by_shot.get(int(shot_number), 0))
+    seg_seed = int(
+        resume_plan.segment_id_seed_by_shot.get(int(shot_number), 0)
+    ) if resume_plan.segment_id_seed_by_shot else 0
+
+    logging.info(
+        "shot=%d init: aggregator.next_track_id=%d, seed_tid=%d, seg_seed=%d",
+        int(shot_number),
+        int(getattr(aggregator, "next_track_id", -1)),
+        seed_tid,
+        seg_seed,
+    )
+
+    # Seed track_id if we didn't create the aggregator with a next_tid_seed
+    if not seeded_tracks and seed_tid > 0:
+        if hasattr(aggregator, "set_track_id_seed") and callable(
+            getattr(aggregator, "set_track_id_seed")
+        ):
+            aggregator.set_track_id_seed(seed_tid)
+        elif hasattr(aggregator, "next_track_id"):
+            setattr(aggregator, "next_track_id", seed_tid)
+        elif hasattr(aggregator, "_next_track_id"):
+            setattr(aggregator, "_next_track_id", seed_tid)
+
+    return start_at, aggregator, seg_seed
+
+
+def _guard_seek_failure(
+    *,
+    frame: np.ndarray | None,
+    frame_idx: int,
+    start_at: int,
+    shot_number: int,
+    first: int,
+    last: int,
+    resume_plan: ResumePlan,
+) -> np.ndarray | None:
     """
-    candidate = getattr(checkpoint, "root", None)
-    if candidate:
-        return Path(candidate)
-    candidate = getattr(checkpoint, "run_dir", None)
-    if candidate:
-        return Path(candidate)
-    ckpt_dir = getattr(checkpoint, "ckpt_dir", None)
-    if ckpt_dir:
-        return Path(ckpt_dir).parent
-    # For in-memory / test stubs that don't persist to disk, we can proceed
-    # without a run root. This only affects logging / debug snapshots.
-    logging.getLogger(__name__).warning(
-        "Cannot determine checkpoint run root (need one of .root, .run_dir, or .ckpt_dir); "
-        "proceeding with None (disk-backed debug snapshots will be disabled)."
+    Handle frame_provider.next() returning None at the start of shot processing.
+
+    If the failure occurs exactly on the anchor frame for a resume run, this is
+    considered unsafe and a ResumeSafetyError is raised. Otherwise a warning is
+    logged and the caller is allowed to skip the frame.
+
+    Parameters
+    ----------
+    frame :
+        Frame returned by frame_provider.next(), or None.
+    frame_idx :
+        Absolute index of the frame we attempted to read.
+    start_at :
+        First frame this shot-loop is supposed to process.
+    shot_number :
+        Logical shot identifier, for logging.
+    first, last :
+        Absolute first and last frame indices for the shot.
+    resume_plan :
+        ResumePlan indicating whether this run is a resume and the anchor frame.
+
+    Returns
+    -------
+    frame or None :
+        The same frame if non-None; otherwise None (caller should skip work).
+    """
+    if frame is not None:
+        return frame
+
+    if resume_plan.is_resume and frame_idx == start_at:
+        raise ResumeSafetyError(
+            f"frame provider failed to seek to start_at={start_at} for shot={shot_number} "
+            f"(first={first}, last={last})."
+        )
+
+    logging.warning(
+        "frame_provider returned None at frame %d (shot=%d); skipping frame.",
+        frame_idx,
+        shot_number,
     )
     return None
 
-def _audit_preanchor_embedding_parity(checkpoint, *, shots: list, anchor_frame: int, anchor_shot: Optional[int]):
+def _guard_no_rewind(frame_idx: int, resume_plan: ResumePlan) -> None:
     """
-    Resume-only audit: verify that every DET row with frame <= anchor-1 has an embedding.
-    Uses rows_for_frame(shot, frame) if available. Falls back to iter_track_frames(...) to
-    at least count DETs and flag likely gaps. Logs which frames are missing and whether a
-    crop exists (when we can check it).
+    Guardrail to prevent emitting pre-anchor frames after a resume.
+
+    Any attempt to produce observations for a frame strictly before
+    resume_plan.anchor_frame is treated as a bug and raises ResumeSafetyError.
     """
-    if not checkpoint or not hasattr(checkpoint, "obs_collector"):
-        logging.info("RESUME-AUDIT: no checkpoint/collector; skipping.")
-        return
-
-    oc = checkpoint.obs_collector
-    has_rows_for_frame = hasattr(oc, "rows_for_frame") and callable(getattr(oc, "rows_for_frame"))
-    has_iter_track_frames = hasattr(oc, "iter_track_frames") and callable(getattr(oc, "iter_track_frames"))
-    run_root = None
-    try:
-        run_root = _ckpt_run_root(checkpoint)
-    except Exception:
-        run_root = None
-
-    if not has_rows_for_frame and not has_iter_track_frames:
-        logging.info("RESUME-AUDIT: collector lacks rows_for_frame/iter_track_frames; skipping.")
-        return
-
-    # Helper: record a missing embedding at (shot, tid, frame) with crop presence if we can see it.
-    def _record_missing(shot: int, tid: int, frame: int, crop_ref: Optional[str], det_by_key: Dict[tuple[int,int], list]):
-        has_crop = False
-        if crop_ref and run_root is not None:
-            try:
-                has_crop = (run_root / crop_ref).exists()
-            except Exception:
-                has_crop = False
-        det_by_key.setdefault((shot, tid), []).append({"f": int(frame), "has_crop": int(bool(has_crop))})
-
-    det_by_key: Dict[tuple[int,int], list] = {}
-    total_missing = 0
-
-    # Iterate only up to anchor-1 and (optionally) only up to anchor_shot.
-    for s in shots:
-        shot_num = int(s["shot_number"])
-        if anchor_shot is not None and shot_num > int(anchor_shot):
-            break  # nothing pre-anchor beyond the anchor shot
-        first_f = int(s["first_frame"])
-        last_f  = int(s["last_frame"])
-        limit_last = min(last_f, (anchor_frame - 1)) if anchor_frame > 0 else last_f
-        if limit_last < first_f:
-            continue
-
-        if has_rows_for_frame:
-            # Strong path: examine persisted rows per frame.
-            for f in range(first_f, limit_last + 1):
-                try:
-                    rows = list(oc.rows_for_frame(shot_num, f))  # iterable of dict-ish
-                except Exception:
-                    logging.exception("RESUME-AUDIT: rows_for_frame failed at shot=%d frame=%d", shot_num, f)
-                    continue
-                for r in rows:
-                    try:
-                        if int(r.get("src", -1)) != int(Source.DETECTED.value):
-                            continue
-                        tid = int(r.get("tid", -1))
-                        emb_idx = int(r.get("emb_idx", -1))
-                        if emb_idx < 0:
-                            _record_missing(shot_num, tid, f, r.get("crop_ref"), det_by_key)
-                            total_missing += 1
-                    except Exception:
-                        # tolerate malformed rows
-                        continue
-        elif has_iter_track_frames:
-            # We can at least detect DET frames per (shot, tid) and infer that missing embs likely exist.
-            # We won’t know crop_ref on this path unless rows_for_frame exists, so mark has_crop=0.
-            # This is a coarse safety net.
-            # Iterate known tids by scanning iter_track_frames for small tid range until it yields nothing.
-            # If your collector exposes a way to list tids per shot, prefer that.
-            seen_any = False
-            for tid_guess in range(0, 2048):  # generous upper bound; adjust if you know a tighter cap
-                try:
-                    frames_src = list(oc.iter_track_frames(shot_num, tid_guess))
-                except Exception:
-                    frames_src = []
-                if not frames_src:
-                    # Heuristic break: after a few consecutive empty tids, stop probing.
-                    # (Assumes dense, small tid space per shot.)
-                    if tid_guess > 32:
-                        break
-                    continue
-                seen_any = True
-                for f, src_code in frames_src:
-                    try:
-                        f = int(f)
-                        if f > limit_last:
-                            continue
-                        if int(src_code) != int(Source.DETECTED.value):
-                            continue
-                        # We don't know emb_idx here, but strict parity expects one vector per DET.
-                        # Flag as "missing/unknown"; later rows_for_frame (if implemented) will be authoritative.
-                        _record_missing(shot_num, int(tid_guess), f, None, det_by_key)
-                        total_missing += 1
-                    except Exception:
-                        continue
-            if not seen_any:
-                logging.debug("RESUME-AUDIT: no tracks observed via iter_track_frames for shot=%d", shot_num)
-
-    # Summarize
-    if not det_by_key:
-        logging.info("RESUME-AUDIT: no pre-anchor DET rows to audit (or none missing).")
-        return
-
-    for (shot, tid), misses in sorted(det_by_key.items()):
-        misses.sort(key=lambda r: int(r["f"]))
-        frames_str = ",".join(f'{m["f"]}({m["has_crop"]})' for m in misses)
-        logging.error(
-            "RESUME-AUDIT shot=%d tid=%d missing_preanchor=%d frames=[%s]",
-            shot, tid, len(misses), frames_str
-        )
-
-    if total_missing == 0:
-        logging.info("RESUME-AUDIT OK: all pre-anchor DET rows have embeddings.")
-    else:
-        logging.error("RESUME-AUDIT FAIL: total missing pre-anchor DET embeddings=%d", total_missing)
-
-def _shot_crops_dir(ckpt_root: Path, shot_number: int) -> Path:
-    p = ckpt_root / "ckpt" / "crops" / f"shot-{int(shot_number):04d}"
-    p.mkdir(parents=True, exist_ok=True)
-    return p
-
-def _atomic_write_png(dst: Path, img_np) -> None:
-    # img_np expected 112x112x3, RGB or BGR depending on aligner
-    # ArcFace aligner you’re using returns RGB — if yours is BGR, swap here.
-    im = Image.fromarray(img_np)  # assumes RGB
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(dir=dst.parent, suffix=".png", delete=False) as tmp:
-        tmp_path = Path(tmp.name)
-        im.save(tmp_path, format="PNG", optimize=True)
-        tmp.flush(); os.fsync(tmp.fileno())
-    os.replace(tmp_path, dst)
-    # Ensure directory entry is durable on crash
-    try:
-        fsync_parent_dir(dst)
-    except Exception as e:
-        logging.info(f"_atomic_write_png: fsync of parent dir failed: {e}")
-        pass
-
-def _save_crop_for_obs(ckpt_root: Path, shot_number: int, frame_idx: int, tid: int, aligned_face) -> str:
-    crops_dir = _shot_crops_dir(ckpt_root, shot_number)
-    rel_name  = f"f{int(frame_idx):06d}_tid{int(tid):03d}.png"
-    abs_path  = crops_dir / rel_name
-    if not abs_path.exists():
-        _atomic_write_png(abs_path, aligned_face)
-    # return path relative to run root to keep status portable
-    # run root == checkpoint.root
-    rel_path = abs_path.relative_to(ckpt_root)
-    return str(rel_path)
-
-def _assign_segment_ids_for_rehydrated(prior_tracks, track_order: dict[tuple[int,int], int]) -> dict[int, int]:
-    """
-    Deterministically assign segment_id to already rehydrated tracks per shot using persisted track_order.
-    Returns: {shot_number: next_segment_seed} where the seed equals the count of assigned segments in that shot.
-    """
-    by_shot: dict[int, list] = {}
-    for t in prior_tracks or []:
-        s = int(getattr(t, "shot_id", 0))
-        by_shot.setdefault(s, []).append(t)
-
-    seeds: dict[int, int] = {}
-    for s, tracks in by_shot.items():
-        # Sort tracks by the persisted first-seen order
-        tracks.sort(key=lambda tr: track_order.get((s, int(getattr(tr, "track_id", -1))), 1 << 30))
-        # Assign deterministic segment ids
-        for idx, tr in enumerate(tracks):
-            setattr(tr, "segment_id", idx)
-        seeds[s] = len(tracks)
-    return seeds
-
-def _validate_shots_are_absolute_and_increasing(shots):
-    if not shots:
-        return
-    # Absolute: shot 0 must start at 0 (or ≥ 0) and later shots must NOT restart at 0
-    later_all_zero = len(shots) > 1 and all(s.get("first_frame", None) == 0 for s in shots[1:])
-    # Strictly increasing windows
-    strictly_increasing = all(
-        int(shots[i]["first_frame"]) > int(shots[i-1]["last_frame"])
-        for i in range(1, len(shots))
-    )
-
-    if later_all_zero or not strictly_increasing:
-        # Build a short diagnostic of the first few shots
-        diag = ", ".join(
-            f'#{i}[{int(s["first_frame"])},{int(s["last_frame"])}]'
-            for i, s in enumerate(shots[:5])
-        )
+    if resume_plan.anchor_frame and frame_idx < resume_plan.anchor_frame:
         raise ResumeSafetyError(
-            "Shots must be in ABSOLUTE frame space and strictly increasing. "
-            "Detected per-shot relative indexing and/or non-monotone ranges. "
-            f"Example windows: {diag}. "
-            "Ensure the shot detector writes global first_frame/last_frame (no reset to 0 between shots)."
+            f"Illegal rewind: got frame_idx={frame_idx} < anchor={resume_plan.anchor_frame}"
         )
     
-def _backfill_preanchor_crops_for_seeded_tracks(
-    seeded_tracks: List[FaceTrack],
+def _default_embedding_frame_policy(track, obs, frame_idx: int) -> bool:
+    """
+    Decide whether this observation/frame should be used for embedding.
+
+    For now this always returns True, meaning:
+      - if we can materialize an aligned_face or crop for this obs,
+        we will include it in the embed batch.
+
+    Later, we can replace or override this with:
+      - stride-based sampling (every Nth frame),
+      - max-embeddings-per-track caps,
+      - quality heuristics, etc.
+    """
+    return True
+
+
+def _collect_aligned_faces_for_embedding(
+    track,
     *,
     frame_provider: FrameProvider,
-    detector: FaceDetector,
-    align_fn,  # e.g., align_face_for_arcface
-    crops_root: Path,
-    shot_number: int,
-    shot_first: int,
-    anchor_abs: int,
-    iou_thresh: float = 0.5,
-) -> int:
+    embedding_frame_policy: Callable[[object, object, int], bool] | None = None,
+):
     """
-    For each DET observation with frame_idx <= anchor_abs and missing aligned_face,
-    (1) try to re-detect on that frame and match by IOU; use landmarks to align;
-    (2) else fall back to simple bbox crop+resize to 112x112 (last resort).
-    Archive PNG and set obs.aligned_face and obs.crop_ref.
-    Returns number of crops created.
+    Builds and collects (aligned_faces, frame_indices) for a single track.
+    The optional embedding_frame_policy(track, obs, frame_idx) can be used
+    to subsample frames (e.g., stride rules) without changing the call site.
     """
-    made = 0
-    # collect unique frames to process
-    frames_needed = set()
-    obs_by_frame: Dict[int, List[tuple[FaceObservation, int]]] = {}
-    for tr in seeded_tracks or []:
-        for o in getattr(tr, "observations", []) or []:
-            if getattr(o, "source", None) != Source.DETECTED:
-                continue
-            if int(o.frame_idx) > int(anchor_abs):
-                continue
-            if (getattr(o, "aligned_face", None) is not None) or (getattr(o, "crop_ref", None) is not None):
-                continue
-            frames_needed.add(int(o.frame_idx))
-            obs_by_frame.setdefault(int(o.frame_idx), []).append((o, int(getattr(tr, "track_id", -1))))
+    if embedding_frame_policy is None:
+        embedding_frame_policy = _default_embedding_frame_policy
 
-    for f in sorted(frames_needed):
-        # fetch exact frame f (absolute index)
-        frame_provider.reset_to_frame(f)
-        frame = frame_provider.next()
-        if frame is None:
+    aligned_faces: list[np.ndarray] = []
+    frames_for_embed: list[int] = []
+
+    for obs in getattr(track, "observations", []) or []:
+        frame_idx = int(getattr(obs, "frame_idx", -1))
+
+        # Let the policy decide if this frame is even eligible
+        try:
+            if not embedding_frame_policy(track, obs, frame_idx):
+                continue
+        except Exception:
+            # If policy explodes, skip this obs but keep going.
+            logging.exception(
+                "embed-policy: error applying embedding_frame_policy for "
+                "track_id=%s frame=%s",
+                getattr(track, "track_id", None),
+                frame_idx,
+            )
             continue
 
-        # run detection to get landmarks; match to each obs by IOU
-        dets = detector.detect_faces_in_frame(frame) or None
-        boxes, lmks, confs = (dets if dets else ([], [], []))
+        # # Case 1: aligned_face already in memory
+        # if getattr(obs, "aligned_face", None) is not None:
+        #     try:
+        #         crops.append(obs.aligned_face)
+        #         frames_for_embed.append(frame_idx)
+        #     except Exception:
+        #         logging.exception(
+        #             "embed-collect: failed to use aligned_face for track_id=%s frame=%s",
+        #             getattr(track, "track_id", None),
+        #             frame_idx,
+        #         )
+        #     continue
 
-        for o, tid in obs_by_frame.get(f, []):
-            # best IOU match box->o.bbox
-            best_iou, best_j = 0.0, None
-            for j, b in enumerate(boxes):
-                bb = (int(b[0]), int(b[1]), int(b[2]), int(b[3]))
-                iou = compute_iou(bb, tuple(int(v) for v in o.bbox[:4]))
-                if iou > best_iou:
-                    best_iou, best_j = iou, j
+        # # Case 2: try to load crop from disk via crop_ref
+        # cr = getattr(obs, "crop_ref", None)
+        # if checkpoint and cr and run_root is not None:
+        #     try:
+        #         abs_path = Path(run_root, cr)
+        #         if abs_path.exists():
+        #             img = Image.open(abs_path).convert("RGB")
+        #             crops.append(np.asarray(img))
+        #             frames_for_embed.append(frame_idx)
+        #     except Exception:
+        #         logging.exception("embed-load: failed to load crop %s", cr)
 
-            aligned = None
-            if best_j is not None and best_iou >= iou_thresh:
-                try:
-                    aligned = align_fn(frame, lmks[best_j], f, source="resume-backfill")
-                except Exception:
-                    aligned = None
+        # only embed from DETECTED observations (landmarks required)
+        if getattr(obs, "source", None) != Source.DETECTED:
+            continue
 
-            # last-resort: bbox crop+resize (still beats having no embedding)
-            if aligned is None:
-                try:
-                    x1,y1,x2,y2 = [int(v) for v in o.bbox[:4]]
-                    x1,y1 = max(x1,0), max(y1,0)
-                    crop = frame[y1:y2, x1:x2]
-                    if crop is not None and crop.size:
-                        # resize to 112x112
-                        import cv2
-                        aligned = cv2.resize(crop, (112,112), interpolation=cv2.INTER_LINEAR)
-                        # convert BGR->RGB if needed for the embedder
-                        aligned = aligned[:, :, ::-1]
-                except Exception:
-                    aligned = None
+        landmarks = getattr(obs, "landmarks", None)
+        if landmarks is None:
+            continue
 
-            if aligned is None:
+        # Re-read the frame
+        try:
+            frame = frame_provider.get_frame(frame_idx)
+            if frame is None:
                 continue
+        except Exception:
+            logging.exception("embed-collect: failed to re-read frame=%s", frame_idx)
+            continue
 
-            try:
-                rel = _save_crop_for_obs(crops_root, int(shot_number), f, tid, aligned)
-                setattr(o, "aligned_face", aligned)
-                setattr(o, "crop_ref", rel)
-                made += 1
-            except Exception:
-                logging.exception("backfill: failed to archive crop for frame=%d tid=%d", f, tid)
-
-    return made
-
-def _debug_det_embed_event(
-    log,
-    *,
-    stage: str,            # 'detect' | 'attach' | 'checkpoint'
-    shot: int,
-    frame: int | None,
-    tid: int | None,
-    det_idx: int | None,   # index within the detections on that frame (for 'detect' stage), else None
-    has_crop: bool | None, # True if aligned_face/crop_ref present
-    aligned_ok: bool | None,
-    emb_ok: bool | None,   # True if we actually have a vector (post-attach), else False/None
-    emb_idx: int | None,   # final sidecar index; only known inside checkpoint.add_embeddings
-    reason: str | None = None
-):
-    """
-    Single-line, grep-friendly log for any DET row’s lifecycle.
-    Examples:
-      stage=detect:    EMB-EVENT stage=detect shot=1 frame=180 tid=- det=0 has_crop=1 aligned_ok=1 emb_ok=0 emb_idx=-1 reason=ok
-      stage=attach:    EMB-EVENT stage=attach shot=1 frame=180 tid=3  det=- has_crop=1 aligned_ok=1 emb_ok=1 emb_idx=-1 reason=ok
-      stage=checkpoint:EMB-EVENT stage=checkpoint shot=1 frame=180 tid=3  det=- has_crop=1 aligned_ok=1 emb_ok=1 emb_idx=42 reason=ok
-    """
-    log.info(
-        "EMB-EVENT stage=%s shot=%s frame=%s tid=%s det=%s has_crop=%s aligned_ok=%s emb_ok=%s emb_idx=%s reason=%s",
-        stage,
-        (str(shot) if shot is not None else "-"),
-        (str(frame) if frame is not None else "-"),
-        (str(tid) if tid is not None else "-"),
-        (str(det_idx) if det_idx is not None else "-"),
-        int(bool(has_crop)) if has_crop is not None else -1,
-        int(bool(aligned_ok)) if aligned_ok is not None else -1,
-        int(bool(emb_ok)) if emb_ok is not None else -1,
-        (-1 if emb_idx is None else int(emb_idx)),
-        (reason or "ok"),
-    )
-
-def _build_emb_lookups_for_checkpoint(
-    checkpoint: TrackingCheckpoint | None,
-    *,
-    anchor_frame: int,
-):
-    """
-    Build emb_lookup/emb_array_lookup callables for resume_rehydrate.rehydrate_tracks.
-
-    emb_lookup(shot, tid) returns (frames, embs) for DET observations strictly
-    before the anchor frame, using the checkpoint's sidecar accessors:
-      - get_det_frames_for_track(shot, tid, frame_max=anchor-1)
-      - get_embeddings_by_frames(shot, frames)
-    """
-    if checkpoint is None or anchor_frame <= 0:
-        return None, None
-
-    def emb_lookup(shot: int, tid: int):
+        # Align
         try:
-            frames = checkpoint.get_det_frames_for_track(
-                int(shot), int(tid), frame_max=int(anchor_frame - 1)
+            aligned = align_face_for_arcface(frame, landmarks, frame_idx, source="embed")
+        except Exception:
+            logging.exception(
+                "embed-collect: align failed track_id=%s frame=%s",
+                getattr(track, "track_id", None),
+                frame_idx,
             )
-        except Exception:
-            return None
+            continue
 
-        if not frames:
-            return None
+        if aligned is None:
+            continue
 
-        try:
-            embs = checkpoint.get_embeddings_by_frames(int(shot), frames)
-        except Exception:
-            return None
+        aligned_faces.append(aligned)
+        frames_for_embed.append(frame_idx)
 
-        if embs is None or len(embs) != len(frames):
-            # Let resume_rehydrate.attach_embeddings enforce strict parity.
-            return None
+    return aligned_faces, frames_for_embed
 
-        return frames, embs
+from facekit.utils.geometry import compute_iou  # add if not already imported
 
-    # We intentionally disable emb_array_lookup to avoid any "count only" matching.
-    return emb_lookup, None
+
+def extend_prev_track_for_overlapping_detection(
+    *,
+    aggregator: ShotFaceTrackAggregator,
+    detections: List[FaceObservation],
+    iou_threshold: float,
+) -> int:
+    """
+    Pair-driven greedy IoU matching:
+      - Build all (open_track, detection_obs) pairs with IoU >= threshold
+      - Sort by IoU desc, tie-break deterministically
+      - Assign 1-to-1 matches by descending IoU
+      - Mutates detection FaceObservations by setting obs.track_id for matched obs
+
+    Returns
+    -------
+    int : number of matches made
+    """
+    if not detections:
+        return 0
+
+    # Only consider detections that are not already assigned (should all be None here)
+    det_indices = [i for i, ob in enumerate(detections) if getattr(ob, "track_id", None) is None]
+    if not det_indices:
+        return 0
+
+    # Collect open tracks with a last bbox
+    open_tracks = []
+    for t in getattr(aggregator, "tracks", []) or []:
+        if t.is_closed():
+            continue
+        last_bbox = t.get_last_bbox()
+        if last_bbox is None:
+            continue
+        open_tracks.append((int(t.track_id), t, last_bbox))
+
+    if not open_tracks:
+        return 0
+
+    # Build candidate pairs
+    # pair = (iou, track_id, det_idx)
+    pairs: list[tuple[float, int, int]] = []
+    for det_idx in det_indices:
+        ob = detections[det_idx]
+        for track_id, _t, last_bbox in open_tracks:
+            iou = float(compute_iou(last_bbox, ob.bbox))
+            if iou >= float(iou_threshold):
+                pairs.append((iou, track_id, det_idx))
+
+    if not pairs:
+        return 0
+
+    # Sort: IoU desc, then track_id asc, then det_idx asc (det order already deterministic)
+    pairs.sort(key=lambda x: (-x[0], x[1], x[2]))
+
+    used_tracks: set[int] = set()
+    used_dets: set[int] = set()
+    matched = 0
+
+    for _iou, track_id, det_idx in pairs:
+        if track_id in used_tracks:
+            continue
+        if det_idx in used_dets:
+            continue
+
+        detections[det_idx].track_id = int(track_id)
+        used_tracks.add(track_id)
+        used_dets.add(det_idx)
+        matched += 1
+
+    return matched
+
 
 
 def track_across_segments(
@@ -473,7 +471,7 @@ def track_across_segments(
          and emits **tracking** observations for currently active tracks.
       4) If any tracker update fails, all open tracks are marked closed, and the pipeline **falls back to detection**
          on that frame to reboot tracking cleanly.
-      5) At shot end, batches all aligned detection crops through the `embedder` and attaches 512-D embeddings
+      5) At shot end, batches all aligned faces through the `embedder` and attaches 512-D embeddings
          to each `FaceTrack`. The aggregator is then finalized, and per-shot **segment IDs** are resolved.
 
     Parameters
@@ -491,7 +489,7 @@ def track_across_segments(
         Face detector used on scheduled detection frames. Its `detect_faces_in_frame(frame)` is expected
         to return `(boxes_xyxy, landmarks, confidences)` or `None` when no faces are present.
     embedder : FaceEmbedder
-        Embeds aligned detection crops at the end of each shot; must return an `np.ndarray` of shape (K, 512), float32.
+        Embeds aligned faces at the end of each shot; must return an `np.ndarray` of shape (K, 512), float32.
     iou_thresh : float, default 0.5
         IOU threshold inside the per-shot `ShotFaceTrackAggregator` for associating detections to tracks.
     embedding_thresh : float, default 0.7
@@ -518,11 +516,11 @@ def track_across_segments(
         All finalized `FaceTrack` objects across all shots, each with:
           - `shot_id`, `track_id` (per-shot), `segment_id` (shot-local face ID),
           - `observations` (detection + tracking),
-          - attached 512-D embeddings for detection observations (if any crops existed).
+          - attached 512-D embeddings for detection observations (if landmarks existed).
 
     Notes
     -----
-    - **Detector scheduling:** Frames with detections produce aligned crops; tracking-only frames intentionally **do not**
+    - **Detector scheduling:** Frames with detections produce aligned faces; tracking-only frames intentionally **do not**
       create embeddings to keep the hot path fast. (A later second-pass can compute extra embeddings if needed.)
     - **Lifecycle:** When a `FrameProvider` is supplied, this function does not close it. When a path is supplied,
       the internally constructed provider is closed automatically via `ExitStack()`.
@@ -538,11 +536,10 @@ def track_across_segments(
     segment-id counter with the number of already-assigned tracks for that shot so new tracks
     continue numbering where the previous run left off (no gaps or renumbering).
     """
-
     logging.info(
         "ckpt.paths: status_path=%s; _ckpt_run_root(checkpoint)=%s",
         getattr(checkpoint, "status_path", None),
-        (_ckpt_run_root(checkpoint) if checkpoint else None),
+        (_checkpoint_root_dir(checkpoint) if checkpoint else None),
     )
 
     shot_json_path = Path(shot_json_path)
@@ -556,8 +553,6 @@ def track_across_segments(
         if isinstance(frame_source, (str, Path)):
             frame_provider = stack.enter_context(ReaderCoordinator(str(frame_source)))
         else:
-            # Require the canonical FrameProvider interface:
-            # props: fps, size, total_frames; methods: reset_to_frame(i), next()
             has_core = all(hasattr(frame_source, m) for m in ("fps", "size", "total_frames"))
             has_iter = hasattr(frame_source, "reset_to_frame") and hasattr(frame_source, "next")
             _ok = isinstance(frame_source, FrameProvider) or (has_core and has_iter)
@@ -570,728 +565,200 @@ def track_across_segments(
             frame_provider = frame_source
 
         all_tracks: List[FaceTrack] = []
-        segment_id_seed_by_shot: Dict[int, int] = {}
-        trackid_seed_by_shot: Dict[int, int] = {}
-        prior_tracks: List[FaceTrack] = []
-        # For exact resume parity: reuse the last pre-anchor track id on the
-        # first detection inside the anchor-containing shot.
-        reuse_tid_for_first_shot: Optional[int] = None
-        reuse_binding_used: bool = False
 
-        # ---------- Single, explicit resume arbiter ----------
-        def _resolve_anchor() -> int:
-            if not (resume_enabled and checkpoint):
-                logging.info("resume: disabled or no checkpoint -> anchor=0")
-                return 0
-            # (1) explicit tuple from get_resume_anchor()
-            try:
-                anchors = checkpoint.get_resume_anchor()
-                if anchors is not None and len(anchors) >= 1:
-                    logging.info("resume: using get_resume_anchor() -> %r", anchors)
-                    return int(anchors[0])
-            except Exception:
-                pass
-            # (2) prefer read_status() → status.json
-            try:
-                rs = getattr(checkpoint, "read_status", None)
-                if callable(rs):
-                    status = rs() or {}
-                    val = status.get("last_detection_frame")
-                    if val is not None:
-                        logging.info("resume: using read_status()['last_detection_frame'] -> %r", val)
-                        return int(val)
-            except Exception:
-                pass
-            # (3) direct status.json path if exposed
-            try:
-                status_path = getattr(checkpoint, "status_path", None)
-                if status_path:
-                    import os, json
-                    if os.path.exists(status_path):
-                        with open(status_path, "r") as f:
-                            status = json.load(f) or {}
-                        val = status.get("last_detection_frame")
-                        if val is not None:
-                            logging.info("resume: using status.json file -> %r", val)
-                            return int(val)
-            except Exception:
-                pass
-            # (4) legacy callable/attr last_detection_frame
-            try:
-                candidate = getattr(checkpoint, "last_detection_frame", None)
-                val = candidate() if callable(candidate) else candidate
-                if val is not None:
-                    logging.info("resume: using legacy last_detection_frame -> %r", val)
-                    return int(val)
-            except Exception:
-                pass
-            # (5) max observed frame from the obs collector
-            try:
-                collector = getattr(checkpoint, "obs_collector", None)
-                if collector is not None and hasattr(collector, "get_all_frame_indices"):
-                    frames_seen = collector.get_all_frame_indices()
-                    if frames_seen is not None and len(frames_seen) > 0:
-                        max_frame = int(np.max(frames_seen))
-                        logging.info("resume: using obs_collector max frame -> %d", max_frame)
-                        return max_frame
-            except Exception:
-                pass
-            logging.info("resume: no anchor inputs -> anchor=0")
-            return 0
-
-        resume_abs_frame: int = _resolve_anchor()
-
-        # === AUDIT FENCE #0: record collector rows BEFORE any new work ===
-        rows_before = None
-        try:
-            if checkpoint and hasattr(checkpoint, "obs_collector"):
-                rows_before = int(checkpoint.obs_collector.count())
-                logging.info("resume: obs_collector rows BEFORE processing=%d", rows_before)
-        except Exception:
-            logging.exception("resume: failed to read obs_collector.count() before")
-        #############----------------##################
-
-        # Identify anchor-containing shot BEFORE any trimming (used for logging)
-        anchor_shot_idx = _shot_idx_by_abs_frame(shots, resume_abs_frame) if resume_abs_frame > 0 else None
-        anchor_shot_num = (
-            shots[anchor_shot_idx]["shot_number"]
-            if (anchor_shot_idx is not None and anchor_shot_idx < len(shots))
-            else None
+        # Centralized resume/rehydrate logic
+        resume_plan, shots = _build_resume_plan(
+            shots,
+            checkpoint=checkpoint,
+            resume_enabled=resume_enabled,
+            all_tracks=all_tracks,
         )
-
-        # --- AUDIT: verify pre-anchor DET rows have embeddings in sidecar ---
-        _audit_preanchor_embedding_parity(
-            checkpoint,
-            shots=shots,
-            anchor_frame=resume_abs_frame,
-            anchor_shot=anchor_shot_num
-        )
-
-        # Compute completed shots (fully before anchor) BEFORE trimming
-        completed_shot_nums = {
-            s["shot_number"] for s in shots
-        } if resume_abs_frame == 0 else {
-            s["shot_number"] for s in shots if s["last_frame"] < resume_abs_frame
-        }
-
-        # Rehydrate BEFORE the anchor (if any)
-        obs_for_rehydrate = getattr(checkpoint, "obs_collector", None)
-        if obs_for_rehydrate is not None and resume_abs_frame > 0:
-            # Build embedding lookups from the checkpoint sidecars:
-            #   - (shot, tid) -> list of DET frames <= anchor-1
-            #   - (shot, frames) -> (K,512) embedding array
-            emb_lookup, emb_array_lookup = _build_emb_lookups_for_checkpoint(
-                checkpoint,
-                anchor_frame=resume_abs_frame,
-            )
-            prior_tracks = rehydrate_tracks(
-                obs_for_rehydrate,
-                frame_max=resume_abs_frame - 1,
-                track_order=(checkpoint.get_track_order() or {}),
-                emb_lookup=emb_lookup,
-                emb_array_lookup=emb_array_lookup,  # keep None if you only want frame-aware lookup
-                anchor_shot_id=anchor_shot_num,
-                strict=True,                         # fail fast if any pre-anchor track lacks embs
-            )
-        elif obs_for_rehydrate is not None:
-            # Anchor==0 → this is effectively a cold start; we skip pre-anchor rehydrate.
-            logging.info("resume: anchor=0 -> cold start; skipping pre-anchor rehydration")
-            prior_tracks = []
-        else:
-            logging.info("resume: no obs_collector on checkpoint; skipping pre-anchor rehydration")
-            prior_tracks = []
-
-        # Hard guard:
-        #   - For **completed shots** (< anchor shot): every pre-anchor DET must have an embedding.
-        #   - For both completed shots and the **anchor shot**: every pre-anchor DET must have a crop_ref.
-        #     (We rely on crops in the anchor shot to recompute embeddings during the resume run.)
-        for t in prior_tracks or []:
-            shot_id = int(getattr(t, "shot_id", -1))
-            is_completed_shot = shot_id in completed_shot_nums
-            is_anchor_shot = (anchor_shot_num is not None and shot_id == int(anchor_shot_num))
-
-            # Ignore any unexpected "future" shots defensively.
-            if not (is_completed_shot or is_anchor_shot):
-                continue
-
-            det_cnt = sum(
-                1
-                for o in (getattr(t, "observations", []) or [])
-                if getattr(o, "source", None) is Source.DETECTED
-                and int(o.frame_idx) <= int(resume_abs_frame - 1)
-            )
-            emb_cnt = len(getattr(t, "embeddings", []) or [])
-
-            # Only completed shots are required to have strict DET↔EMB parity.
-            if is_completed_shot and det_cnt > 0 and emb_cnt != det_cnt:
-                raise ResumeSafetyError(
-                    f"rehydrate: pre-anchor embedding parity failed for (shot={shot_id}, "
-                    f"tid={int(getattr(t,'track_id',-1))}): DET={det_cnt} vs EMB={emb_cnt}"
-                )
-
-            # For both completed-shots and anchor-shot, every pre-anchor DET must have a crop_ref.
-            for o in getattr(t, "observations", []) or []:
-                if (
-                    getattr(o, "source", None) is Source.DETECTED
-                    and int(o.frame_idx) <= int(resume_abs_frame - 1)
-                ):
-                    if getattr(o, "crop_ref", None) in (None, "", 0):
-                        raise ResumeSafetyError(
-                            "rehydrate: missing crop_ref for pre-anchor DET "
-                            f"(shot={shot_id}, tid={int(getattr(t,'track_id',-1))}, frame={int(o.frame_idx)})"
-                        )
-
-        if checkpoint and hasattr(checkpoint, "compare_rehydrate_to_snapshot"):
-            checkpoint.compare_rehydrate_to_snapshot(
-                prior_tracks=prior_tracks,
-                anchor_frame=resume_abs_frame
-            )
-
-        # -------------------------------
-        # Split rehydrated tracks:
-        #   - pre-anchor shots -> KEEP in outputs now
-        #   - anchor-containing shot -> ONLY seed aggregator (do NOT append to outputs here)
-        # -------------------------------
-        prior_tracks_completed: List[FaceTrack] = []
-        prior_tracks_anchor: List[FaceTrack] = []
-        for t in prior_tracks or []:
-            s = int(getattr(t, "shot_id", -1))
-            if s in completed_shot_nums:
-                prior_tracks_completed.append(t)
-            elif s == (anchor_shot_num if anchor_shot_num is not None else -1):
-                prior_tracks_anchor.append(t)
-            else:
-                # Future shots should not exist pre-anchor; be defensive and ignore.
-                logging.debug("rehydrate: ignoring pre-anchor track from unexpected shot=%s", s)
-
-        # Append only completed-shot tracks now; anchor-shot tracks will be continued by the aggregator.
-        if prior_tracks_completed:
-            logging.info("resume: adding %d completed pre-anchor tracks to outputs", len(prior_tracks_completed))
-            all_tracks.extend(prior_tracks_completed)
-
-
-
-        # Log by-shot counts & seeds we computed
-        try:
-            by_shot_counts = {}
-            for track in prior_tracks:
-                shot = int(getattr(track, "shot_id", -1))
-                by_shot_counts[shot] = by_shot_counts.get(shot, 0) + 1
-            logging.info("resume: rehydrated counts by shot: %r", by_shot_counts)
-            logging.info("resume: segment_id_seed_by_shot: %r", {int(k): int(v) for k,v in (segment_id_seed_by_shot or {}).items()})
-            logging.info("resume: trackid_seed_by_shot: %r", {int(k): int(v) for k,v in (trackid_seed_by_shot or {}).items()})
-        except Exception:
-            logging.exception("resume: failed summarizing seeds")
-
-        # Assign stable segment_ids to the rehydrated tracks and compute per-shot seeds
-        try:
-            track_order_map = checkpoint.get_track_order() if hasattr(checkpoint, "get_track_order") else {}
-            segment_id_seed_by_shot = _assign_segment_ids_for_rehydrated(prior_tracks, track_order_map or {})
-            # Compute next track_id seed per shot = max(track_id)+1 seen in that shot
-            tmp: Dict[int, int] = {}
-            # Also compute, per shot, the *last* observed track (by last frame) so we
-            # can reuse that exact track_id on the first post-resume detection.
-            last_tid_by_shot: Dict[int, int] = {}
-            last_frame_by_shot_tid: Dict[Tuple[int, int], int] = {}
-
-            for track in prior_tracks:
-                shot = int(getattr(track, "shot_id", 0))
-                tid = int(getattr(track, "track_id", -1))
-                if tid >= 0:
-                    tmp[shot] = max(tmp.get(shot, -1), tid)
-                    # Track the last frame seen for (shot, tid) and pick the tid with the max last frame.
-                    if getattr(track, "observations", None):
-                        last_frame = max(o.frame_idx for o in track.observations)
-                        key = (shot, tid)
-                        if key not in last_frame_by_shot_tid or last_frame > last_frame_by_shot_tid[key]:
-                            last_frame_by_shot_tid[key] = last_frame
-            trackid_seed_by_shot = {shot: (max_tid + 1) for shot, max_tid in tmp.items()}
-            # Reduce last_frame_by_shot_tid -> last_tid_by_shot (argmax over tid per shot)
-            for (shot, tid), last_frame in last_frame_by_shot_tid.items():
-                if (shot not in last_tid_by_shot) or last_frame > last_frame_by_shot_tid.get((shot, last_tid_by_shot[shot]), -1):
-                    last_tid_by_shot[shot] = tid                
-            logging.info("resume: assigned segment_ids to %d rehydrated tracks; seeds=%s",
-                            len(prior_tracks), {k: int(v) for k, v in segment_id_seed_by_shot.items()})
-        except Exception:
-            logging.exception("resume: failed to assign segment_ids to rehydrated tracks; continuing with empty seeds")
-            segment_id_seed_by_shot = {}
-            trackid_seed_by_shot = {}
-
-        if checkpoint and hasattr(checkpoint, "_validate_resume_embeddings"):
-            checkpoint._validate_resume_embeddings(anchor_shot=anchor_shot_num)
-            
-        logging.info(
-            "resume: prior_tracks strictness OK (anchor_shot=%s); rehydrated=%d (completed=%d, anchor-shot=%d)",
-            anchor_shot_num, len(prior_tracks or []),
-            len(prior_tracks_completed), len(prior_tracks_anchor)
-        )
-
-        # Trim shots so the first processed shot is the one containing the anchor (always)
-        start_shot_idx = _shot_idx_by_abs_frame(shots, resume_abs_frame)
-        if start_shot_idx >= len(shots):
-            raise ResumeSafetyError("resume anchor beyond last shot; aborting for safety.")
-        shots = shots[start_shot_idx:]
-
-        # Track whether this invocation is a true resume (anchor > shot_first)
-        _is_resume = bool(resume_abs_frame > 0)
-
-        # Determine which shot contains the anchor and pre-compute its reuse tid.
-        first_processed_shot_number = shots[0]["shot_number"]
-        if checkpoint and resume_abs_frame > 0:
-            try:
-                # Prefer the tid whose last observation is closest to the anchor (already computed above).
-                reuse_tid_for_first_shot = last_tid_by_shot.get(int(first_processed_shot_number))  # type: ignore[name-defined]
-                if reuse_tid_for_first_shot is not None:
-                    logging.info("resume: will reuse tid=%d for first detection in shot=%d",
-                                 int(reuse_tid_for_first_shot), int(first_processed_shot_number))
-            except Exception:
-                reuse_tid_for_first_shot = None
-
-            logging.info(
-                "resume: anchor=%d anchor_shot_num=%s first_processed_shot_number=%s reuse_tid_for_first_shot=%s",
-                resume_abs_frame, anchor_shot_num, first_processed_shot_number, reuse_tid_for_first_shot
-            )
 
         for shot_idx, shot_num in enumerate(shots):
             shot_number = shot_num["shot_number"]
             first = shot_num["first_frame"]
             last = shot_num["last_frame"]
-            # If resuming, start from the anchor frame inside the first shot; otherwise from shot start.
- 
-            if shot_idx == 0:
-                start_at = max(first, resume_abs_frame)
-            else:
-                start_at = first
-            if shot_idx == 0:
-                # === AUDIT FENCE #1: make the loop range explicit & fail fast on empty range ===
-                logging.info(
-                    "resume: first_new_frame=%d (shot=[%d..%d]) detect_interval=%d mod=%d",
-                    start_at, first, last, detect_interval, ((start_at - first) % max(1, detect_interval)),
-                )
-                if start_at > last:
-                    raise ResumeSafetyError(
-                        f"empty work-range at resume: start_at={start_at} > shot_last={last} for shot={shot_number}"
-                    )
 
-            # Determine seeded prior tracks only when resuming and 
-            # for the first processed shot (anchor-containing shot)
-            seeded_tracks = None
-            if (shot_idx == 0) and (resume_abs_frame > 0) and prior_tracks:
-                # Seed only the anchor-containing shot with its pre-anchor rehydrated tracks
-                seeded_tracks = [
-                    copy.deepcopy(t) for t in (prior_tracks_anchor if 'prior_tracks_anchor' in locals() else [])
-                        if int(getattr(t, "shot_id", -1)) == int(shot_number)
-                ]
-
-            # --- shot-level diagnostics ---
-            shot_det_raw_total = 0          # number of raw det boxes this shot
-            shot_det_aligned_total = 0      # number of dets that produced aligned_face this shot
-
-            if seeded_tracks:
-                aggregator = ShotFaceTrackAggregator(
-                    shot_number=shot_number,
-                    iou_threshold=iou_thresh,
-                    embedding_threshold=embedding_thresh,
-                    prior_tracks=seeded_tracks,
-                    resume_abs_frame=start_at,
-                    next_tid_seed=int(trackid_seed_by_shot.get(int(shot_number), 0)),
-                )
-                checkpoint.hydrate_open_tracks_into(aggregator)
-
-                _dump_agg_state("RESUME-AFTER-REHYDRATE", aggregator)
-            else:
-                aggregator = ShotFaceTrackAggregator(
-                    shot_number=shot_number,
-                    iou_threshold=iou_thresh,
-                    embedding_threshold=embedding_thresh,
-                )
-
-            if (shot_idx == 0) and (resume_abs_frame > 0) and (reuse_tid_for_first_shot is not None):
-                try:
-                    aggregator.set_resume_force_tid(int(reuse_tid_for_first_shot))
-                    logging.info("resume: aggregator will force tid=%d on the next created track in shot=%d",
-                                int(reuse_tid_for_first_shot), int(shot_number))
-                except Exception:
-                    logging.exception("resume: failed to set forced tid on aggregator")
-
-            if seeded_tracks:
-                logging.info("RESUME: aggregator seeded with %d tracks", len(aggregator.tracks))
-                for track in aggregator.tracks:
-                    last_bbox = getattr(track, "get_last_bbox", lambda: None)()
-                    logging.info(
-                        "RESUME TRACK: tid=%s closed=%s last_frame=%s last_bbox=%s",
-                        track.track_id,
-                        track.is_closed() if hasattr(track, "is_closed") else None,
-                        track.last_frame() if hasattr(track, "last_frame") else None,
-                        last_bbox
-                    )        
-
-            seed_tid = int(trackid_seed_by_shot.get(int(shot_number), 0))
-            seg_seed = int(segment_id_seed_by_shot.get(int(shot_number), 0)) if segment_id_seed_by_shot else 0
-
-            logging.info(
-                "shot=%d init: aggregator.next_track_id=%d, seed_tid=%d, seg_seed=%d",
-                int(shot_number),
-                int(getattr(aggregator, "next_track_id", -1)),
-                seed_tid,
-                seg_seed,
+            # Initialize shot-level aggregator and seeds (resume aware)
+            start_at, aggregator, seg_seed = _init_shot_aggregator(
+                shot_idx=shot_idx,
+                shot_number=shot_number,
+                first=first,
+                last=last,
+                detect_interval=detect_interval,
+                resume_plan=resume_plan,
+                iou_thresh=iou_thresh,
+                embedding_thresh=embedding_thresh,
+                checkpoint=checkpoint,
             )
-
-            # Seed the aggregator’s next track_id only if we did not already pass next_tid_seed.
-            if not seeded_tracks and seed_tid > 0:
-                if hasattr(aggregator, "set_track_id_seed") and callable(getattr(aggregator, "set_track_id_seed")):
-                    aggregator.set_track_id_seed(seed_tid)
-                elif hasattr(aggregator, "next_track_id"):
-                    setattr(aggregator, "next_track_id", seed_tid)
-                elif hasattr(aggregator, "_next_track_id"):
-                    setattr(aggregator, "_next_track_id", seed_tid)
 
             face_tracker = FaceTracker(tracker_type="CSRT")
             tracker_active = False
 
-            shot_frames: List[np.ndarray] = []
             validator = TrackerValidator(
-                frames=shot_frames, 
-                first_frame_idx=start_at, 
-                params=ValidatorParams(iou_thresh=iou_thresh))
+                params=ValidatorParams(iou_thresh=iou_thresh),
+            )
 
             frame_provider.reset_to_frame(int(start_at))
-    
+
             for frame_idx in range(start_at, last + 1):
                 frame = frame_provider.next()
+                frame = _guard_seek_failure(
+                    frame=frame,
+                    frame_idx=frame_idx,
+                    start_at=start_at,
+                    shot_number=shot_number,
+                    first=first,
+                    last=last,
+                    resume_plan=resume_plan,
+                )
                 if frame is None:
-                    # If we're resuming, failing to land exactly at the anchor is unsafe.
-                    if _is_resume and frame_idx == start_at:
-                        raise ResumeSafetyError(
-                            f"frame provider failed to seek to start_at={start_at} for shot={shot_number} "
-                            f"(first={first}, last={last})."
-                        )
-                    # Cold start or transient hiccup: quick retry, then skip this frame.
-                    frame = frame_provider.next()
-                    if frame is None:
-                        logging.warning(
-                            "frame_provider returned None at frame %d (shot=%d); skipping frame.",
-                            frame_idx, shot_number
-                        )
-                        continue
+                    continue
 
-                # Log once to prove we actually enter the processing loop post-anchor
-                if frame_idx == start_at:
-                    logging.info("ENTER processing loop at frame=%d (anchor=%d)", frame_idx, resume_abs_frame)
+                _guard_no_rewind(frame_idx, resume_plan)
 
-                # Guardrail: never emit pre-anchor frames
-                if resume_abs_frame and frame_idx < resume_abs_frame:
-                    raise ResumeSafetyError(f"Illegal rewind: got frame_idx={frame_idx} < anchor={resume_abs_frame}")
-
-                shot_frames.append(frame)
                 observations: List[FaceObservation] = []
 
-                detect_interval_hit = (frame_idx % detect_interval == 0)
+                is_scheduled_detect_frame = (frame_idx % detect_interval == 0)
 
-                no_tracker   = (not tracker_active)
-                open_tracks = [t for t in aggregator.tracks if not t.is_closed()]
-                no_open_tracks = (len(open_tracks) == 0)
-   
-                # Determine if this is a scheduled detection frame
-                need_detect = detect_interval_hit or no_tracker or no_open_tracks
+                no_tracker = (not tracker_active)
+                no_open_tracks = not any(not t.is_closed() for t in aggregator.tracks)
 
-                logging.debug(
-                    "frame=%d need_detect=%s [det_interval_hit=%s no_tracker=%s no_open_tracks=%s] open_tracks=%d total_tracks=%d",
-                    frame_idx, need_detect, detect_interval_hit, no_tracker, no_open_tracks, len(open_tracks),
-                    len(aggregator.tracks),
-                )
+                # Determine if this is a detection frame
+                do_detection = is_scheduled_detect_frame or no_tracker or no_open_tracks
 
-                if not need_detect:
+                if not do_detection:
                     # Try tracking all existing tracks
                     tracked_boxes: Dict[int, Tuple[float, float, float, float]] = face_tracker.update_trackers(frame)
                     basic_fail = (not tracked_boxes) or any(b is None for b in tracked_boxes.values())
 
-                    logging.debug("TRACK: frame=%d (tracker_active=%s, basic_fail=%s)", frame_idx, tracker_active, basic_fail)
-
-                    if (not basic_fail) and validator.validate(tracked_boxes, frame_idx, verbose=True):
-                        # Track-only observations will lack aligned_face until optical flow landmarks are added
+                    if (not basic_fail) and validator.validate(tracked_boxes, frame, frame_idx):
                         for track_id, tb in tracked_boxes.items():
                             if tb is None:
                                 continue
                             x, y, w, h = tb
                             bbox = (int(x), int(y), int(x + w), int(y + h))
-                            observations.append(FaceObservation(
-                                frame_idx=frame_idx,
-                                track_id = track_id,
-                                bbox=bbox,
-                                embedding=None,
-                                confidence=None,
-                                aligned_face=None,
-                                source=Source.TRACKED
-                            ))
+                            observations.append(
+                                FaceObservation(
+                                    frame_idx=frame_idx,
+                                    track_id=track_id,
+                                    bbox=bbox,
+                                    embedding=None,
+                                    confidence=None,
+                                    aligned_face=None,
+                                    source=Source.TRACKED,
+                                )
+                            )
                     else:
-                        # validator rejected or tracker failed → close & force detection reboot
-                        logging.debug("TRACK - validator reject or tracker fail: frame=%d (basic_fail=%s)", frame_idx, basic_fail)
                         aggregator.finalize_tracks()
                         tracker_active = False
-                        need_detect = True                       
+                        do_detection = True
 
-                if need_detect:  # Run detection if needed
-                    logging.info(
-                        "shot=%d first=%d frame=%d (mod=%d) tracker_active=%s, detect_interval=%d",
-                        shot_number, first, frame_idx, (frame_idx % detect_interval), tracker_active, detect_interval
+                if do_detection:  # Run detection 
+
+                    do_checkpoint(
+                        checkpoint,
+                        frame_idx=frame_idx,
+                        shot_number=shot_number,
+                        aggregator=aggregator,
+                        shot_first_frame=first,
                     )
 
-                    try:
-                        if checkpoint:
-                            checkpoint.checkpoint_now(
-                                frame_idx=frame_idx, 
-                                shot_number=shot_number,
-                                aggregator=aggregator,
-                                shot_first_frame=first,
-                                note=f"detect@{frame_idx}",
-                            )
-
-                    except Exception:
-                        logging.exception("checkpoint: failed to persist at detect frame %s", frame_idx)                       
-    
                     detections = detector.detect_faces_in_frame(frame)
-                    
+
                     if detections:
                         boxes, landmark_lists, confidences = detections
-                        raw_count = len(boxes)
                         aligned_ok = 0
 
-                        # --- deterministically order detections to stabilize which track is "created first" ---
+                        # Deterministically order detections
                         order = sorted(
                             range(len(boxes)),
                             key=lambda i: (
-                                int(boxes[i][0]), int(boxes[i][1]),
-                                int(boxes[i][2]), int(boxes[i][3]),
-                                -float(confidences[i])
-                            )
+                                int(boxes[i][0]),
+                                int(boxes[i][1]),
+                                int(boxes[i][2]),
+                                int(boxes[i][3]),
+                                -float(confidences[i]),
+                            ),
                         )
-                        boxes          = [boxes[i] for i in order]
+                        boxes = [boxes[i] for i in order]
                         landmark_lists = [landmark_lists[i] for i in order]
-                        confidences    = [confidences[i] for i in order]
+                        confidences = [confidences[i] for i in order]
 
-                        for det_idx, (box, landmarks, confidence) in enumerate(zip(boxes, landmark_lists, confidences)):
-                            bbox = tuple(int(v) for v in box[:4])  # detector returns XYXY
-                            aligned_face = align_face_for_arcface(frame, landmarks, frame_idx, source="detect")
+                        for box, landmarks, confidence in zip(boxes, landmark_lists, confidences):
+                            bbox = tuple(int(v) for v in box[:4])
 
-                            if aligned_face is not None:
-                                aligned_ok += 1
-                                # ---- DEBUG: detection produced a crop; no embedding yet at this stage ----
-                                _debug_det_embed_event(
-                                    logger, stage="detect",
-                                    shot=int(shot_number), frame=int(frame_idx), tid=None, det_idx=int(det_idx),
-                                    has_crop=True, aligned_ok=True, emb_ok=False, emb_idx=None, reason="ok"
-                                )
-
-                                observations.append(FaceObservation(
+                            observations.append(
+                                FaceObservation(
                                     frame_idx=frame_idx,
                                     bbox=bbox,
+                                    track_id=None,                 # aggregator will set
                                     embedding=None,
-                                    confidence=float(confidence),
-                                    aligned_face=aligned_face,
-                                    source=Source.DETECTED
-                                ))
-                            else:
-                                # ---- DEBUG: alignment failed -> this DET row must NOT be persisted or used to start a track ----
-                                _debug_det_embed_event(
-                                    logger, stage="detect",
-                                    shot=int(shot_number), frame=int(frame_idx), tid=None, det_idx=int(det_idx),
-                                    has_crop=False, aligned_ok=False, emb_ok=False, emb_idx=None, reason="align_fail"
+                                    confidence=float(confidence) if confidence is not None else None,
+                                    aligned_face=None,             
+                                    landmarks=landmarks,           
+                                    source=Source.DETECTED,
                                 )
-                            
-                        shot_det_raw_total     += int(raw_count)
-                        shot_det_aligned_total += int(aligned_ok)  
-
+                            )
                     else:
                         # no faces this frame; close shot-local tracks
-                        aggregator.finalize_tracks()    
-    
-
-                # If this is the anchor-containing shot, and we haven't yet bound the
-                # first post-resume detection, temporarily override the allocator so the
-                # very first created track reuses the pre-anchor tid (exact parity).
-                if (
-                    need_detect
-                    and not reuse_binding_used
-                    and reuse_tid_for_first_shot is not None
-                    and int(shot_number) == int(first_processed_shot_number)
-                    and observations  # only if we actually detected faces
-                ):
-                    try:
-                        # Force the next allocated id to be the reused tid.
-                        if hasattr(aggregator, "set_track_id_seed") and callable(getattr(aggregator, "set_track_id_seed")):
-                            aggregator.set_track_id_seed(int(reuse_tid_for_first_shot))
-                        elif hasattr(aggregator, "next_track_id"):
-                            setattr(aggregator, "next_track_id", int(reuse_tid_for_first_shot))
-                        elif hasattr(aggregator, "_next_track_id"):
-                            setattr(aggregator, "_next_track_id", int(reuse_tid_for_first_shot))
-                        logging.info("resume: temporarily overriding next_track_id -> %d (shot=%d)",
-                                     int(reuse_tid_for_first_shot), int(shot_number))
-                    except Exception:
-                        logging.exception("resume: failed to set temporary allocator for reuse tid; continuing without binding")
+                        aggregator.finalize_tracks()
 
                 if observations and observations[0].source == Source.DETECTED:
-                    # Expand detection list for logging
                     dets = []
                     for ob in observations:
                         x1, y1, x2, y2 = [int(v) for v in ob.bbox[:4]]
-                        dets.append({
-                            "bbox": (x1, y1, x2, y2),
-                            "conf": float(ob.confidence) if ob.confidence is not None else None
-                        })
-
-                det_count = sum(1 for o in observations if getattr(o, "source", None) == Source.DETECTED)
-                logging.info("DETECTION frame=%d shot=%d raw-detections=%d", frame_idx, int(shot_number), det_count)
-
-                if observations:
-                    det_cnt = sum(1 for o in observations if getattr(o, "source", None) == Source.DETECTED)
-                    if det_cnt:
-                        # Before assignment: track_id may be None; we just log bbox/intention
-                        bboxes = [
-                            tuple(int(v) for v in o.bbox[:4])
-                            for o in observations if getattr(o, "source", None) == Source.DETECTED
-                        ]
-                        logging.info(
-                            "DETECT-EMIT shot=%d frame=%d det_n=%d boxes=%s",
-                            int(shot_number), int(frame_idx), int(det_cnt), bboxes[:6]
+                        dets.append(
+                            {
+                                "bbox": (x1, y1, x2, y2),
+                                "conf": float(ob.confidence)
+                                if ob.confidence is not None
+                                else None,
+                            }
                         )
 
-                # Add current frame observations to aggregator
-                created_count = aggregator.update_tracks_with_frame(frame_idx, observations)
+                if observations and observations[0].source == Source.DETECTED:
+                    _ = extend_prev_track_for_overlapping_detection(
+                        aggregator=aggregator,
+                        detections=observations,
+                        iou_threshold=iou_thresh,
+                    )
 
-                if checkpoint:
-                    try:
-                        # Pull what we just persisted (by frame) in the obs collector if supported.
-                        # Fallback: use aggregator view and log crop presence.
-                        det_persisted = []
-                        if hasattr(checkpoint, "obs_collector") and hasattr(checkpoint.obs_collector, "rows_for_frame"):
-                            # rows_for_frame(shot, frame) -> iterable of row dicts
-                            for r in checkpoint.obs_collector.rows_for_frame(shot_number, frame_idx):
-                                if int(r.get("src", -1)) == int(Source.DETECTED.value):
-                                    det_persisted.append({
-                                        "tid": int(r.get("tid", -1)),
-                                        "emb_idx": int(r.get("emb_idx", -1)),
-                                        "has_crop": 1 if r.get("crop_ref") else 0,
-                                    })
-                        else:
-                            # aggregator fallback: we won't have emb_idx, but we can see crops
-                            for ob in aggregator.observations_at(frame_idx, source=Source.DETECTED, require_track_id=True):
-                                det_persisted.append({
-                                    "tid": int(getattr(ob, "track_id", -1)),
-                                    "emb_idx": -1,  # unknown here
-                                    "has_crop": 1 if (getattr(ob, "aligned_face", None) is not None or getattr(ob, "crop_ref", None)) else 0,
-                                })
-                        if det_persisted:
-                            logging.info("DETECT-PERSIST shot=%d frame=%d rows=%s", int(shot_number), int(frame_idx), det_persisted)
-                    except Exception:
-                        logging.exception("resume-log: failed DETECT-PERSIST probe")
+                _ = aggregator.update_tracks_with_frame(
+                    frame_idx, observations
+                    )
 
-                _dump_agg_state(f"AFTER FRAME {frame_idx}", aggregator, frame=frame_idx)
-
-                # Mark binding as used exactly once on the first detection frame where it applied.
-                if (
-                    need_detect
-                    and not reuse_binding_used
-                    and reuse_tid_for_first_shot is not None
-                    and int(shot_number) == int(first_processed_shot_number)
-                    and created_count > 0
-                ):
-                    reuse_binding_used = True
-                    logging.info("resume: reuse binding applied (shot=%d, reused tid=%d).",
-                                 int(shot_number), int(reuse_tid_for_first_shot))
-
-                agg_det = aggregator.observations_at(frame_idx, source=Source.DETECTED, require_track_id=True)
-                agg_trk = aggregator.observations_at(frame_idx, source=Source.TRACKED,  require_track_id=True)
-                logging.debug(
-                    "POST-ASSIGN: frame=%d det_assigned=%d trk_assigned=%d created=%d open_tracks=%d",
-                    frame_idx, len(agg_det), len(agg_trk), created_count,
-                    sum(1 for t in aggregator.tracks if not t.is_closed()),
+                _checkpoint_observations_and_snapshot(
+                    checkpoint,
+                    shot_number=shot_number,
+                    frame_idx=frame_idx,
+                    aggregator=aggregator,
+                    resume_plan=resume_plan,
                 )
 
-                # Persist 112×112 crops to disk for DET observations on this frame
-                if checkpoint:
-                    det_obs = aggregator.observations_at(frame_idx, source=Source.DETECTED, require_track_id=True)
-                    if det_obs:
-                        crops_root = _ckpt_run_root(checkpoint)
-                        _saved = 0
-                        for ob in det_obs:
-                            # Only save if aligned_face present (detection path) & no crop_ref yet
-                            if getattr(ob, "aligned_face", None) is None:
-                                continue
-                            if getattr(ob, "crop_ref", None):
-                                continue
-                            try:
-                                rel = _save_crop_for_obs(
-                                    crops_root, shot_number, ob.frame_idx, ob.track_id, ob.aligned_face
-                                )
-                                setattr(ob, "crop_ref", rel) # so checkpoint.add_observations can persist the reference
-                                _saved += 1
-                            except Exception:
-                                logging.exception("crop-archive: failed at frame=%d tid=%s", ob.frame_idx, ob.track_id)
-                        logging.info(
-                            "CROP-SAVED frame=%d shot=%d saved=%d",
-                            frame_idx, int(shot_number), int(_saved)
-                        )
-
-                # Checkpoint observations (PERSISTENCE BOUNDARY)
-                if checkpoint:
-                    frame_obs_objs = aggregator.observations_at(frame_idx, require_track_id=True)
-                    # At the anchor frame, some pipelines can momentarily lack track_ids.
-                    # Retry *only at the anchor* without strictness so we at least persist those detections.
-                    if (not frame_obs_objs) and (frame_idx == resume_abs_frame):
-                        logging.info("resume: no require_track_id observations at anchor; retrying without strictness.")
-                        frame_obs_objs = aggregator.observations_at(frame_idx, require_track_id=False)
-                    if frame_obs_objs:
-                        if PARANOID:
-                            if frame_obs_objs:
-                                logger.debug("seg: frame=%s shot=%s n_obs=%s first=%r",
-                                             frame_idx, shot_number, len(frame_obs_objs),
-                                             {"tid": frame_obs_objs[0].track_id,
-                                              "src": getattr(frame_obs_objs[0], "source", None),
-                                              "bbox": getattr(frame_obs_objs[0], "bbox", None)})
-                        if not all(isinstance(o, FaceObservation) for o in frame_obs_objs):
-                            bad = [type(o).__name__ for o in frame_obs_objs if not isinstance(o, FaceObservation)]
-                            logger.error("seg: Non-FaceObservation in frame_obs_objs at frame=%s shot=%s types=%s sample=%r",
-                                         frame_idx, shot_number, bad, frame_obs_objs[:1])
-                            raise TypeError(f"frame_obs_objs must be FaceObservation objects, got {bad}")
-                        if not all(isinstance(o.source, Source) for o in frame_obs_objs):
-                            bad = [getattr(o, "source", None) for o in frame_obs_objs if not isinstance(getattr(o, "source", None), Source)]
-                            logger.error("seg: Observation with non-enum source at frame=%s shot=%s bad=%r", frame_idx, shot_number, bad[:3])
-                            raise TypeError(f"Observation.source must be Source enum; bad={bad[:3]}")
-
-
-                        checkpoint.add_observations(shot_number, frame_idx, frame_obs_objs)                        # After observations are persisted, emit a human-readable snapshot.
-                    try:
-                        if getattr(checkpoint, "snapshots_ready", False):
-                            checkpoint.write_checkpoint_snapshot(
-                                name=f"detect-{shot_number}-{frame_idx}",
-                                payload={
-                                    "shot": int(shot_number),
-                                    "frame": int(frame_idx),
-                                    "note": f"detect@{frame_idx}",
-                                },
-                            )
-                    except Exception:
-                        logging.exception("checkpoint: snapshot write failed at detect frame %s", frame_idx)
-
-                if created_count and checkpoint and hasattr(checkpoint, "on_new_tracks"):
-                    checkpoint.on_new_tracks(created_count)
+                agg_det = aggregator.observations_at(
+                    frame_idx, source=Source.DETECTED, require_track_id=True
+                )
+                agg_trk = aggregator.observations_at(
+                    frame_idx, source=Source.TRACKED, require_track_id=True
+                )
 
                 # If faces detected, init tracker with aggregator IDs and seed validator
-                if need_detect:
-                    det_obs = aggregator.observations_at(frame_idx, source=Source.DETECTED, require_track_id=True)
+                if do_detection:
+                    det_obs = aggregator.observations_at(
+                        frame_idx, source=Source.DETECTED, require_track_id=True
+                    )
                     if det_obs:
                         boxes_xywh = [
-                            (b[0], b[1], b[2] - b[0], b[3] - b[1]) 
+                            (b[0], b[1], b[2] - b[0], b[3] - b[1])
                             for b in (obs.bbox for obs in det_obs)
                         ]
                         track_ids = [obs.track_id for obs in det_obs]
                         face_tracker.init_trackers(frame, boxes_xywh, track_ids)
 
-                        # --- seed validator baseline with the just-initialized tracker state ---
                         boxes_map = dict(zip(track_ids, boxes_xywh))
-                        validator.set_baseline(boxes_map, frame_idx)
-            
+                        validator.seed_validator(boxes_map, frame_idx, frame)
+
                         tracker_active = True
                     else:
                         tracker_active = False
@@ -1299,139 +766,86 @@ def track_across_segments(
                 if checkpoint:
                     checkpoint.on_frame(frame_idx)
 
-            # End of shot: batch embed tracks with aligned faces
-            logging.info(
-                "shot=%d summary: det_raw=%d det_aligned(crop|face)=%d",
-                int(shot_number), int(shot_det_raw_total), int(shot_det_aligned_total)
-            )
-
-            # --- embedding diagnostics (shot scope) ---
-            shot_embed_intended = 0   # total crops/aligned faces we intend to embed for this shot
-            shot_embed_vectors  = 0   # total vectors returned by embedder for this shot
+            # ---- end-of-shot embedding pass ----------
 
             for track in aggregator.tracks:
-                crops = []
-                frames_for_embed: list[int] = []
-
-                # Prefer in-memory aligned_face; otherwise lazy-load archived crop
-                for obs in track.observations:
-                    if obs.aligned_face is not None:
-                        crops.append(obs.aligned_face)
-                        frames_for_embed.append(int(obs.frame_idx))
-
-                        logging.info(f"shot: {shot_number}, track:{track}, obs.aligned_face not None and appended")
-                        continue
-                    cr = getattr(obs, "crop_ref", None)
-                    if checkpoint and cr:
-                        try:
-                            abs_path = Path(_ckpt_run_root(checkpoint), cr)
-                            if abs_path.exists():
-                                img = Image.open(abs_path).convert("RGB")
-                                crops.append(np.asarray(img))
-                                frames_for_embed.append(int(obs.frame_idx))
-
-                            logging.info(f"shot: {shot_number}, track:{track}, no obs.aligned_face but abs_path found and crop appended")
-                        except Exception:
-                            logging.exception("embed-load: failed to load crop %s", cr)
-                if not crops:
-                    logging.info(f"end of shot {shot_number} and no aligned faces found")
-                    continue
-
-                # Count the crops we plan to embed for this track
-                track_intended = len(crops)
-                shot_embed_intended += track_intended
-                logging.info(
-                    "embed-intent: shot=%d tid=%s crops_for_embed=%d",
-                    int(shot_number), str(track.track_id), int(track_intended)
+                aligned_faces, frames_for_embed = _collect_aligned_faces_for_embedding(
+                    track,
+                    frame_provider=frame_provider,
+                    # embedding_frame_policy=None  # uses default for now
                 )
 
-                embs = embedder.get_embedding_batch(crops, batch_size=embedding_batch_size_max)
+                if not aligned_faces:
+                    continue
+
+                embs = embedder.get_embedding_batch(
+                    aligned_faces,
+                    batch_size=embedding_batch_size_max,
+                )
+
+
+                if embs is None:
+                    logging.error(
+                        "embed: embedder returned None for shot=%d tid=%s",
+                        int(shot_number),
+                        str(getattr(track, "track_id", "NA")),
+                    )
+                    continue
+
+
+                if not isinstance(embs, np.ndarray):
+                    raise TypeError(f"Embedder must return np.ndarray, got {type(embs)}")
+            
+                if embs.ndim != 2 or embs.shape[1] != 512:
+                    raise ValueError(
+                        f"Embedder returned invalid array shape {embs.shape}; expected (K,512)"
+                    )
+                if embs.dtype != np.float32:
+                    embs = np.asarray(embs, dtype=np.float32, order="C")
+
+                
                 if len(embs) != len(frames_for_embed):
                     raise RuntimeError(
                         f"Embed count/frame mismatch: embs={len(embs)} frames={len(frames_for_embed)} "
                         f"(shot={shot_number}, tid={track.track_id})"
                     )
 
-                logging.info(
-                    "embed-return: shot=%d tid=%s vectors=%d shape=%s dtype=%s",
-                    int(shot_number), str(track.track_id),
-                    0 if embs is None else int(len(embs)),
-                    getattr(embs, "shape", None),
-                    getattr(getattr(embs, "dtype", None), "name", None)
-                )
-                shot_embed_vectors += 0 if embs is None else int(len(embs))
-
-                logging.info(
-                    "embed-shot-summary: shot=%d intended=%d returned=%d",
-                    int(shot_number), int(shot_embed_intended), int(shot_embed_vectors)
-                )
-
-                if not isinstance(embs, np.ndarray):
-                    raise TypeError(f"Embedder must return np.ndarray, got {type(embs)}")
-                if embs.ndim != 2 or embs.shape[1] != 512:
-                    raise ValueError(f"Embedder returned invalid array shape {embs.shape}; expected (K,512)")
-                if embs.dtype != np.float32:
-                    embs = np.asarray(embs, dtype=np.float32, order="C")
                 aggregator.attach_embeddings(track.track_id, embs)
 
-                # Log outcome per DET observation in this track (emb_idx still unknown here).
-                for ob in getattr(track, "observations", []) or []:
-                    if getattr(ob, "source", None) is Source.DETECTED:
-                        has_crop = (ob.aligned_face is not None) or bool(getattr(ob, "crop_ref", None))
-                        # If attach_embeddings filled FaceObservation.embedding (your aggregator typically does),
-                        # emb_ok reflects that; emb_idx is still unknown at this stage.
-                        emb_ok = (getattr(ob, "embedding", None) is not None)
-                        _debug_det_embed_event(
-                            logger, stage="attach",
-                            shot=int(shot_number), frame=int(ob.frame_idx), tid=int(getattr(ob, "track_id", -1)),
-                            det_idx=None, has_crop=has_crop, aligned_ok=has_crop, emb_ok=emb_ok, emb_idx=None, reason=("ok" if emb_ok else "attach_miss")
-                        )
+                logging.info(
+                    f"end of shot {shot_number} and {len(embs)} embeddings attached to aggregator"
+                )
 
-                logging.info(f"end of shot {shot_number} and {len(embs)} embeddings attached to aggregator")
-
-                if checkpoint and embs.size:
-                    # Persist with the correct frame index for EACH vector to satisfy strict rehydrate.
-                    for f_idx, vec in zip(frames_for_embed, embs):
-                        checkpoint.add_embeddings(
-                            int(shot_number),
-                            int(track.track_id),
-                            int(f_idx),
-                            np.asarray(vec, dtype=np.float32).reshape(1, -1),
-                        )
-                    logging.info(f"end of shot {shot_number} and {len(embs)} per-frame embeddings added to checkpoint")
-                else:
-                    logging.info(f"end of shot {shot_number} and NO embeddings added to checkpoint")
-
-            logging.info(
-                "EMB-RECONCILE shot=%d intended=%d returned=%d note=post-embed-loop",
-                int(shot_number), int(shot_embed_intended), int(shot_embed_vectors)
-            )
+                _persist_embeddings_for_track(
+                    checkpoint,
+                    shot_number=shot_number,
+                    track=track,
+                    frames_for_embed=frames_for_embed,
+                    embs=embs,
+                )
 
             aggregator.finalize_tracks()
 
             # Assign segment_id per shot, seeded to continue numbering after any rehydrated tracks
-            seed = int(segment_id_seed_by_shot.get(int(shot_number), 0))
+            seed = int(seg_seed)
             try:
                 _ = aggregator.resolve_segment_ids(
                     segment_id_counter=seed,
-                    embedding_threshold=embedding_thresh
+                    embedding_threshold=embedding_thresh,
                 )
             except RuntimeError as e:
-                logging.error("segment-id resolution skipped for shot=%d due to missing embeddings: %s",
-                              int(shot_number), e)
+                logging.error(
+                    "segment-id resolution skipped for shot=%d due to missing embeddings: %s",
+                    int(shot_number),
+                    e,
+                )
 
             all_tracks.extend(aggregator.tracks)
 
             if checkpoint:
                 checkpoint.on_shot_done()
 
-        #end of video
-        if checkpoint:
-            # Persist live collectors to ckpt/obs_ckpt.npz and ckpt/emb_ckpt.npz
-            checkpoint.finalize(note="final video flush")
-
-            # Let downstream tools know this run is complete so they can read all rows
-            # without trimming to the last detection anchor.
-            checkpoint.mark_completed()
+        _finalize_checkpoint_run(checkpoint)
 
         return all_tracks
+

--- a/facekit/tracking/aggregator.py
+++ b/facekit/tracking/aggregator.py
@@ -299,81 +299,52 @@ class ShotFaceTrackAggregator:
         for track in self.tracks:
             track.is_active = False
 
-        assigned_tracks: set[int] = set()
+        # Fast lookup
+        by_id: dict[int, FaceTrack] = {int(t.track_id): t for t in self.tracks}
+
         unmatched_obs: list[FaceObservation] = []
-
-        logging.info("pre-match: open_tracks=%d ids=%s",
-                    sum(1 for t in self.tracks if not t.is_closed()),
-                    [t.track_id for t in self.tracks if not t.is_closed()])
-        for tr in self.tracks:
-            logging.info("pre-match: tid=%d last_bbox=%s last_frame=%s closed=%s",
-                        tr.track_id,
-                        tr.get_last_bbox(),
-                        tr.last_frame(),
-                        tr.is_closed())
-
-        # Greedy IoU assignment: each detection → at most one track; each track ← at most one detection.
         for obs in observations:
-            best_track = None
-            best_iou = 0.0
-
-            for track in self.tracks:
-                if track.is_closed():
-                    continue
-                if track.track_id in assigned_tracks:
-                    continue
-
-                last_bbox = track.get_last_bbox()
-                if last_bbox is None:
-                    continue
-
-                iou = compute_iou(last_bbox, obs.bbox)
-                if iou >= self.iou_threshold and iou > best_iou:
-                    best_iou = iou
-                    best_track = track
-
-            if best_track is not None:
-                obs.track_id = best_track.track_id
-                if hasattr(obs, "shot_id"):
-                    obs.shot_id = self.shot_number
-
-                best_track.add_observation(obs)
-
-                best_track.is_active = True
-                assigned_tracks.add(best_track.track_id)
-                self._index_obs(obs)
-            else:
+            tid = getattr(obs, "track_id", None)
+            if tid is None:
                 unmatched_obs.append(obs)
+                continue
 
-        # Create new tracks for unmatched detections
+            tid = int(tid)
+            track = by_id.get(tid)
+
+            # If caller assigned to a non-existent or closed track, treat as unmatched -> new track.
+            if track is None or track.is_closed():
+                obs.track_id = None
+                unmatched_obs.append(obs)
+                continue
+
+            obs.shot_id = self.shot_number
+
+            track.add_observation(obs)
+            track.is_active = True
+            self._index_obs(obs)
+
         num_created = 0
+        # Create new tracks for unmatched detections
         for obs in unmatched_obs:
-
-            # Use collision-safe allocator
             new_tid = self._allocate_track_id()
             new_track = FaceTrack(track_id=new_tid, shot_id=self.shot_number)
-            
+
             obs.track_id = new_track.track_id
-            if hasattr(obs, "shot_id"):
-                obs.shot_id = self.shot_number
+            obs.shot_id = self.shot_number
 
             new_track.add_observation(obs)
-
+            new_track.mark_open()
             new_track.is_active = True
+
             self.tracks.append(new_track)
+            by_id[int(new_tid)] = new_track
             self._index_obs(obs)
             num_created += 1
 
         # On a detection frame, any not-matched open tracks are closed.
         for track in self.tracks:
             if not track.is_active and not track.is_closed():
-                # Verbose reason: show last bbox and that it missed IoU threshold
-                last_bbox = track.get_last_bbox()
-                logging.info(
-                    "CLOSE (unmatched on DET frame) shot=%d track_id=%d last_bbox=%s",
-                    int(self.shot_number), int(track.track_id),
-                    (tuple(int(v) for v in last_bbox) if last_bbox else None)
-                )
                 track.mark_closed()
 
         # ---- Consume/clear the resume override on the first DET frame post-resume ----
@@ -659,13 +630,19 @@ class ShotFaceTrackAggregator:
                 # Create the track with its original id
                 tr = FaceTrack(track_id=tid, shot_id=self.shot_number)
 
+                if last_det >= 0:
+                    # best-effort: stash for downstream logic/debug if FaceTrack supports it
+                    if hasattr(tr, "last_det_frame_idx"):
+                        tr.last_det_frame_idx = int(last_det)
+                    elif hasattr(tr, "_last_det_frame_idx"):
+                        tr._last_det_frame_idx = int(last_det)
+
                 # Seed a last observation as a SYNTHETIC DET so IoU binding works
                 # and last_det_frame() cache is set. aligned_face=None is OK.
                 if last_f >= 0:
-                    if last_f == last_det and last_det >= 0:
-                        seed_src = Source.DETECTED
-                    else:
-                        seed_src = Source.TRACKED
+                    # DETECTED implies valid landmarks/alignment per contract.
+                    # This seed exists only for IoU continuity, so treat as TRACKED.
+                    seed_src = Source.TRACKED
                     obs = FaceObservation(
                         frame_idx=last_f,
                         bbox=(x1, y1, x2, y2),

--- a/facekit/tracking/face_structures.py
+++ b/facekit/tracking/face_structures.py
@@ -16,7 +16,7 @@ class FaceObservation:
         track_id (int, optional): Track ID for tracked faces.
         embedding (np.ndarray, optional): Facial feature vector.
         confidence (float, optional): Confidence score from the detector.
-        aligned_face (np.ndarray, optional): Aligned face crop (e.g. ArcFace 112x112 RGB)
+        aligned_face (np.ndarray, optional): Aligned faces (e.g. ArcFace 112x112 RGB)
     """
     frame_idx: int
     source: Source  
@@ -141,7 +141,7 @@ class FaceTrack:
         # For tracking continuity: store landmarks if this was a detection
         if obs.source == Source.DETECTED and obs.landmarks is not None:
             # prepare for optical flow
-            self.last_known_landmarks = obs.landmarks
+            self.last_landmarks = obs.landmarks
 
         # Update last_bbox helper
         if obs.bbox is not None:

--- a/facekit/tracking/track_consolidation_and_pruning.py
+++ b/facekit/tracking/track_consolidation_and_pruning.py
@@ -1,0 +1,764 @@
+# track_consolidation_and_pruning.py
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import logging
+from collections import deque
+
+from facekit.tracking.face_structures import FaceTrack, FaceObservation
+from facekit.utils.geometry import compute_iou
+from facekit.common.obs_consts import Source
+
+logger = logging.getLogger(__name__)
+
+BBox = Tuple[int, int, int, int]
+
+
+# =============================================================================
+# Public entrypoint (the story)
+# =============================================================================
+
+def apply_track_consolidation_and_pruning(
+    tracks: list[FaceTrack],
+    *,
+    min_gap_len: int,
+    min_track_len: int,
+    iou_threshold: float = 0.2,
+) -> list[FaceTrack]:
+    """
+    Mutates tracks in-place (global_id changes + interpolated observations, plus merges)
+    and returns the surviving tracks.
+    """
+    by_shot = group_tracks_by_shot(tracks)
+    out: list[FaceTrack] = []
+
+    for shot_id in sorted(by_shot):
+        shot_tracks = by_shot[shot_id]
+
+        assignments = propose_gid_reassignments_for_short_tracks(
+            shot_tracks,
+            min_gap_len=min_gap_len,
+            min_track_len=min_track_len,
+            iou_threshold=iou_threshold,
+        )
+        apply_assigned_global_ids(shot_tracks, assignments)
+
+        shot_tracks = prune_short_tracks(shot_tracks, min_track_len=min_track_len)
+
+        # NOTE: this may merge tracks (reduce count) and inject observations
+        fill_short_gaps_within_shot_and_merge(
+            shot_tracks,
+            min_gap_len=min_gap_len,
+            iou_threshold=iou_threshold,
+        )
+
+        out.extend(shot_tracks)
+
+    return out
+
+
+# =============================================================================
+# Phase 0: grouping
+# =============================================================================
+
+def group_tracks_by_shot(tracks: Iterable[FaceTrack]) -> Dict[int, List[FaceTrack]]:
+    by: Dict[int, List[FaceTrack]] = {}
+    for t in tracks:
+        sid = int(getattr(t, "shot_id", -1))
+        by.setdefault(sid, []).append(t)
+    return by
+
+
+def group_tracks_by_gid(tracks: Iterable[FaceTrack]) -> Dict[Optional[int], List[FaceTrack]]:
+    by: Dict[Optional[int], List[FaceTrack]] = {}
+    for t in tracks:
+        by.setdefault(getattr(t, "global_id", None), []).append(t)
+    return by
+
+
+# =============================================================================
+# Phase 1: propose + apply global_id reassignment for short tracks (Option 1b)
+# =============================================================================
+
+@dataclass(frozen=True)
+class GidAssignment:
+    track_id: int
+    new_global_id: int
+
+
+@dataclass(frozen=True)
+class RankedCandidate:
+    gid: int
+    score: float
+
+
+@dataclass
+class _ShortTrackPlan:
+    track: FaceTrack
+    candidates: list[RankedCandidate]
+    next_idx: int = 0
+
+    def next_candidate(self) -> Optional[RankedCandidate]:
+        if self.next_idx >= len(self.candidates):
+            return None
+        c = self.candidates[self.next_idx]
+        self.next_idx += 1
+        return c
+
+
+def propose_gid_reassignments_for_short_tracks(
+    shot_tracks: list[FaceTrack],
+    *,
+    min_gap_len: int,
+    min_track_len: int,
+    iou_threshold: float,
+) -> list[GidAssignment]:
+    """
+    Decide global_id reassignment for short tracks (< min_track_len) within this shot.
+
+    Option 1b conflict handling:
+      - We do NOT assign a gid that would overlap-in-time an existing *fixed* track with that gid.
+      - If two short tracks compete for the same gid and would overlap in time:
+          winner keeps the gid, loser is pushed to try its next-best gid.
+      - Only after exhausting candidates does a short track remain unassigned (then Phase 2 may prune it).
+    """
+    if not shot_tracks:
+        return []
+
+    ordered = sorted(shot_tracks, key=lambda t: (t.first_frame(), t.track_id))
+    short_tracks = [t for t in ordered if track_len(t) < int(min_track_len)]
+    if not short_tracks:
+        return []
+
+    # "Fixed" tracks are those we will not change gids for in this phase.
+    # (i.e., non-short tracks)
+    short_ids = {int(t.track_id) for t in short_tracks}
+    fixed_tracks = [t for t in ordered if int(t.track_id) not in short_ids]
+
+    fixed_by_gid: Dict[int, list[FaceTrack]] = {}
+    for t in fixed_tracks:
+        gid = getattr(t, "global_id", None)
+        if gid is None:
+            continue
+        fixed_by_gid.setdefault(int(gid), []).append(t)
+
+    # Precompute candidates for each short track
+    plans: Dict[int, _ShortTrackPlan] = {}
+    for st in sorted(short_tracks, key=lambda t: (track_len(t), t.first_frame(), t.track_id)):
+        cands = rank_candidate_gids_for_short_track(
+            st,
+            ordered,
+            min_gap_len=min_gap_len,
+            iou_threshold=iou_threshold,
+        )
+        plans[int(st.track_id)] = _ShortTrackPlan(track=st, candidates=cands, next_idx=0)
+
+    # State: which short track currently "owns" a gid in this phase
+    claimed_by_gid: Dict[int, int] = {}  # gid -> track_id
+    assigned_gid_by_tid: Dict[int, int] = {}
+
+    # Work queue: short tracks to attempt assignment (deterministic order)
+    q = deque(sorted(short_tracks, key=lambda t: (track_len(t), t.first_frame(), t.track_id)))
+
+    # Score lookup for deterministic winner selection
+    score_cache: Dict[Tuple[int, int], float] = {}  # (tid,gid) -> score
+
+    def _score(tid: int, gid: int) -> float:
+        key = (int(tid), int(gid))
+        if key in score_cache:
+            return score_cache[key]
+        plan = plans.get(int(tid))
+        if not plan:
+            score_cache[key] = float("-inf")
+            return score_cache[key]
+        for c in plan.candidates:
+            if int(c.gid) == int(gid):
+                score_cache[key] = float(c.score)
+                return score_cache[key]
+        score_cache[key] = float("-inf")
+        return score_cache[key]
+
+    def _fixed_overlap_blocks(t: FaceTrack, gid: int) -> bool:
+        for fx in fixed_by_gid.get(int(gid), []):
+            if ranges_overlap(*span(t), *span(fx)):
+                return True
+        return False
+
+    def _short_overlap_conflict(t: FaceTrack, other_tid: int, gid: int) -> bool:
+        other = plans[int(other_tid)].track
+        return ranges_overlap(*span(t), *span(other))
+
+    def _winner_tid(tid_a: int, tid_b: int, gid: int) -> int:
+        """
+        Deterministic:
+          - higher score wins
+          - if tie, longer track wins
+          - if tie, earlier start wins
+          - if tie, lower tid wins
+        """
+        sa = _score(tid_a, gid)
+        sb = _score(tid_b, gid)
+        if sa != sb:
+            return tid_a if sa > sb else tid_b
+
+        ta = plans[int(tid_a)].track
+        tb = plans[int(tid_b)].track
+        la = track_len(ta)
+        lb = track_len(tb)
+        if la != lb:
+            return tid_a if la > lb else tid_b
+
+        fa = int(ta.first_frame())
+        fb = int(tb.first_frame())
+        if fa != fb:
+            return tid_a if fa < fb else tid_b
+
+        return tid_a if int(tid_a) < int(tid_b) else tid_b
+
+    # Safety to avoid infinite loops if something goes sideways
+    max_iters = 50_000
+    iters = 0
+
+    while q and iters < max_iters:
+        iters += 1
+        t = q.popleft()
+        tid = int(t.track_id)
+
+        # If already assigned (e.g., came back in queue and got fixed), skip
+        if tid in assigned_gid_by_tid:
+            continue
+
+        plan = plans.get(tid)
+        if plan is None:
+            continue
+
+        while True:
+            cand = plan.next_candidate()
+            if cand is None:
+                # no assignment possible
+                break
+
+            gid = int(cand.gid)
+
+            # Block if it would overlap any fixed track with this gid
+            if _fixed_overlap_blocks(t, gid):
+                continue
+
+            # If gid not claimed yet, claim it
+            other_tid = claimed_by_gid.get(gid)
+            if other_tid is None:
+                claimed_by_gid[gid] = tid
+                assigned_gid_by_tid[tid] = gid
+                break
+
+            # If claimed, check overlap; if no overlap, allow both to share gid in shot? NO.
+            # Your constraint is: no two tracks in a shot with same gid can overlap in time.
+            if not _short_overlap_conflict(t, other_tid, gid):
+                # They do not overlap in time; allow both to have gid.
+                # Keep claimed_by_gid as-is (it just records "one owner"), but we can still assign.
+                assigned_gid_by_tid[tid] = gid
+                break
+
+            # Conflict: choose winner; loser tries its next best
+            win = _winner_tid(tid, other_tid, gid)
+            lose = other_tid if win == tid else tid
+
+            if win == other_tid:
+                # Current track loses; try another candidate
+                continue
+
+            # Current track wins: it gets gid, other gets unassigned and re-queued
+            claimed_by_gid[gid] = tid
+            assigned_gid_by_tid[tid] = gid
+
+            # Remove old assignment (if any) for loser
+            if int(lose) in assigned_gid_by_tid:
+                del assigned_gid_by_tid[int(lose)]
+            # Re-queue loser to find next best gid
+            q.append(plans[int(lose)].track)
+            break
+
+    if iters >= max_iters:
+        logger.warning("gid reassignment: hit max_iters=%d in shot=%s; partial assignments may result.", max_iters, getattr(shot_tracks[0], "shot_id", None))
+
+    # Emit assignments only when it changes gid
+    assignments: list[GidAssignment] = []
+    by_tid = {int(t.track_id): t for t in shot_tracks}
+    for tid, new_gid in assigned_gid_by_tid.items():
+        tr = by_tid.get(int(tid))
+        if tr is None:
+            continue
+        old_gid = getattr(tr, "global_id", None)
+        if old_gid is None or int(old_gid) != int(new_gid):
+            assignments.append(GidAssignment(track_id=int(tid), new_global_id=int(new_gid)))
+
+    # deterministic order
+    assignments.sort(key=lambda a: int(a.track_id))
+    return assignments
+
+
+def rank_candidate_gids_for_short_track(
+    short_t: FaceTrack,
+    ordered_shot_tracks: list[FaceTrack],
+    *,
+    min_gap_len: int,
+    iou_threshold: float,
+) -> list[RankedCandidate]:
+    """
+    Returns candidates sorted best-first, deterministic on ties.
+    Score is mainly IoU evidence, plus a small sandwich bonus if applicable.
+    """
+    idx = ordered_shot_tracks.index(short_t)
+    lefts = ordered_shot_tracks[:idx]
+    rights = ordered_shot_tracks[idx + 1 :]
+
+    left_caps = nearby_left_caps(short_t, lefts, min_gap_len=min_gap_len)
+    right_caps = nearby_right_caps(short_t, rights, min_gap_len=min_gap_len)
+
+    scores: Dict[int, float] = {}
+
+    def bump(gid: Optional[int], score: Optional[float]) -> None:
+        if gid is None or score is None:
+            return
+        gid = int(gid)
+        scores[gid] = max(scores.get(gid, float("-inf")), float(score))
+
+    # one-sided evidence
+    for lt in left_caps:
+        bump(getattr(lt, "global_id", None), score_left_cap(lt, short_t, iou_threshold=iou_threshold))
+    for rt in right_caps:
+        bump(getattr(rt, "global_id", None), score_right_cap(short_t, rt, iou_threshold=iou_threshold))
+
+    # sandwich: same gid appears on both sides -> small bonus, but not dominant
+    sandwich = encompassing_sandwich_candidates(left_caps, right_caps)
+    for gid, (lt, rt) in sandwich.items():
+        iou_l = safe_iou(lt.get_last_bbox(), short_t.get_first_bbox())
+        iou_r = safe_iou(short_t.get_last_bbox(), rt.get_first_bbox())
+        if iou_l is None or iou_r is None:
+            continue
+        if iou_l < iou_threshold or iou_r < iou_threshold:
+            continue
+        base = scores.get(int(gid), 0.0)
+        bonus = 0.05 + 0.5 * min(iou_l, iou_r)
+        scores[int(gid)] = max(scores.get(int(gid), float("-inf")), base + bonus)
+
+    ranked = [RankedCandidate(gid=k, score=v) for k, v in scores.items()]
+    ranked.sort(key=lambda c: (-c.score, int(c.gid)))
+    return ranked
+
+
+def apply_assigned_global_ids(
+    shot_tracks: list[FaceTrack],
+    assignments: list[GidAssignment],
+) -> None:
+    if not assignments:
+        return
+
+    by_tid = {int(t.track_id): t for t in shot_tracks}
+    for a in assignments:
+        tr = by_tid.get(int(a.track_id))
+        if tr is None:
+            continue
+        old = getattr(tr, "global_id", None)
+        tr.global_id = int(a.new_global_id)
+        logger.debug("gid reassignment: shot=%s tid=%s %r -> %r", tr.shot_id, tr.track_id, old, tr.global_id)
+
+
+# =============================================================================
+# Phase 2: prune short tracks
+# =============================================================================
+
+def prune_short_tracks(
+    shot_tracks: list[FaceTrack],
+    *,
+    min_track_len: int,
+) -> list[FaceTrack]:
+    """
+    Keep:
+      - any track len >= min_track_len
+      - short tracks that have a non-None global_id
+    Drop:
+      - short tracks with global_id None
+    """
+    out: list[FaceTrack] = []
+    for t in shot_tracks:
+        if track_len(t) >= int(min_track_len):
+            out.append(t)
+            continue
+        if getattr(t, "global_id", None) is None:
+            logger.debug("prune short track: shot=%s tid=%s len=%s", t.shot_id, t.track_id, track_len(t))
+            continue
+        out.append(t)
+    return out
+
+
+# =============================================================================
+# Phase 3: fill short gaps between same gid tracks (and MERGE)
+# =============================================================================
+
+def fill_short_gaps_within_shot_and_merge(
+    shot_tracks: list[FaceTrack],
+    *,
+    min_gap_len: int,
+    iou_threshold: float,
+) -> None:
+    """
+    For each global_id group within this shot:
+      - sort tracks by time
+      - for consecutive tracks (A then B):
+          gap = B.first - A.last - 1
+          if 0 < gap < min_gap_len:
+             require boundary IoU(A.last_bbox, B.first_bbox) >= iou_threshold
+             require NO occupancy in any gap frame by any track in this shot
+             interpolate bboxes into A for all gap frames
+             merge B into A, remove B from shot_tracks
+    """
+    if not shot_tracks or int(min_gap_len) <= 0:
+        return
+
+    occupied = build_occupied_frames(shot_tracks)
+
+    # We will mutate shot_tracks (remove merged rights). So loop carefully.
+    by_gid = group_tracks_by_gid(shot_tracks)
+    for gid, group in list(by_gid.items()):
+        if gid is None:
+            continue
+
+        ordered = sorted(group, key=lambda t: (t.first_frame(), t.track_id))
+        i = 0
+        while i < len(ordered) - 1:
+            left = ordered[i]
+            right = ordered[i + 1]
+
+            gap_start, gap_end = compute_gap(left, right)
+            if gap_start is None or gap_end is None:
+                i += 1
+                continue
+
+            gap_len = gap_end - gap_start + 1
+            if gap_len <= 0:
+                i += 1
+                continue
+            if gap_len >= int(min_gap_len):
+                i += 1
+                continue
+
+            if not boundary_iou_passes(left, right, iou_threshold=iou_threshold):
+                i += 1
+                continue
+
+            if gap_has_any_occupancy(gap_start, gap_end, occupied):
+                # No skipping. If blocked, do nothing.
+                i += 1
+                continue
+
+            # Interpolate + merge
+            inject_interpolated_gap_no_skips(
+                left=left,
+                right=right,
+                gap_start=gap_start,
+                gap_end=gap_end,
+            )
+            merge_right_into_left(left, right)
+
+            # Remove right from the main shot list
+            try:
+                shot_tracks.remove(right)
+            except ValueError:
+                pass
+
+            # Also remove from our local ordered list; keep left at same index
+            ordered.pop(i + 1)
+
+            # occupied should now include the new frames too (for later groups it matters);
+            # simplest is to update just those frames and right frames.
+            for f in left.get_frame_indices():
+                occupied[int(f)] = occupied.get(int(f), 0)  # ensure present (already 0 for gap frames)
+
+            # Do not i += 1; there may be another consecutive track to merge into the same left
+            continue
+
+        # end while
+
+
+# =============================================================================
+# Low-level helpers (geometry / time / occupancy)
+# =============================================================================
+
+def track_len(t: FaceTrack) -> int:
+    try:
+        return int(t.duration())
+    except Exception:
+        a = int(t.first_frame())
+        b = t.last_frame()
+        b = int(b) if b is not None else a
+        return max(0, b - a + 1)
+
+
+def compute_gap(left: FaceTrack, right: FaceTrack) -> Tuple[Optional[int], Optional[int]]:
+    l_last = left.last_frame()
+    if l_last is None:
+        return None, None
+    r_first = int(right.first_frame())
+    gap_start = int(l_last) + 1
+    gap_end = int(r_first) - 1
+    return gap_start, gap_end
+
+
+def build_occupied_frames(shot_tracks: list[FaceTrack]) -> Dict[int, int]:
+    """
+    frame -> number of tracks having an observation at that frame (any source).
+    """
+    occ: Dict[int, int] = {}
+    for t in shot_tracks:
+        for f in t.get_frame_indices():
+            occ[int(f)] = occ.get(int(f), 0) + 1
+    return occ
+
+
+def gap_has_any_occupancy(gap_start: int, gap_end: int, occupied: Dict[int, int]) -> bool:
+    for f in range(int(gap_start), int(gap_end) + 1):
+        if occupied.get(int(f), 0) > 0:
+            return True
+    return False
+
+
+def boundary_iou_passes(left: FaceTrack, right: FaceTrack, *, iou_threshold: float) -> bool:
+    a = left.get_last_bbox()
+    b = right.get_first_bbox()
+    iou = safe_iou(a, b)
+    return (iou is not None) and (float(iou) >= float(iou_threshold))
+
+
+def safe_iou(a: Optional[BBox], b: Optional[BBox]) -> Optional[float]:
+    if a is None or b is None:
+        return None
+    try:
+        return float(compute_iou(a, b))
+    except Exception:
+        return None
+
+
+def inject_interpolated_gap_no_skips(
+    *,
+    left: FaceTrack,
+    right: FaceTrack,
+    gap_start: int,
+    gap_end: int,
+) -> None:
+    """
+    Adds INTERPOLATED observations into `left` for ALL frames gap_start..gap_end.
+    No skipping; caller must have already verified occupancy is clear.
+    """
+    a_bb = left.get_last_bbox()
+    b_bb = right.get_first_bbox()
+    if a_bb is None or b_bb is None:
+        return
+
+    frames = list(range(int(gap_start), int(gap_end) + 1))
+    bboxes = interpolate_bboxes(a_bb, b_bb, len(frames))
+
+    for f, bb in zip(frames, bboxes):
+        f = int(f)
+
+        # Defensive: do not overwrite
+        if left.get_bbox_by_frame(f) is not None:
+            continue
+
+        obs = FaceObservation(
+            frame_idx=f,
+            bbox=bb,
+            source=Source.INTERPOLATED,
+            track_id=int(left.track_id),
+            confidence=None,
+            embedding=None,
+            aligned_face=None,
+            landmarks=None,
+        )
+        try:
+            obs.shot_id = int(left.shot_id)
+        except Exception:
+            pass
+
+        left.add_observation(obs)
+
+    _normalize_track_order(left)
+
+
+def merge_right_into_left(left: FaceTrack, right: FaceTrack) -> None:
+    """
+    Merge `right` track into `left` track:
+      - move all observations from right into left (preserving frame indices)
+      - keep left.track_id as the survivor
+      - mark right closed (optional) but primarily caller removes it from list
+    """
+    # Ensure right starts after left ends (should be true for a "gap then right" case)
+    for obs in (right.observations or []):
+        # do not allow frame collisions
+        if left.get_bbox_by_frame(int(obs.frame_idx)) is not None:
+            # If this happens, caller's invariants were violated; refuse to merge silently.
+            raise ValueError(
+                f"merge would collide at frame={obs.frame_idx} "
+                f"(left tid={left.track_id}, right tid={right.track_id})"
+            )
+
+        # mutate obs to reflect merged identity
+        obs.track_id = int(left.track_id)
+        try:
+            obs.shot_id = int(left.shot_id)
+        except Exception:
+            pass
+
+        left.add_observation(obs)
+
+    _normalize_track_order(left)
+
+    # close the right (defensive)
+    try:
+        right.mark_closed()
+    except Exception:
+        pass
+
+
+def _normalize_track_order(t: FaceTrack) -> None:
+    """
+    Ensure observations are in ascending frame order.
+    Your FaceTrack maintains a _frame_index_map; we rebuild it deterministically.
+    """
+    obs = sorted(list(t.observations or []), key=lambda o: int(o.frame_idx))
+    t.observations = obs
+
+    # Rebuild the frame map if present
+    if hasattr(t, "_frame_index_map"):
+        m = {}
+        for o in obs:
+            m[int(o.frame_idx)] = o
+        t._frame_index_map = m
+
+
+def interpolate_bboxes(a: BBox, b: BBox, n: int) -> list[BBox]:
+    """
+    n missing frames. For missing frame k=1..n, t=k/(n+1)
+    """
+    ax1, ay1, ax2, ay2 = map(float, a)
+    bx1, by1, bx2, by2 = map(float, b)
+
+    out: list[BBox] = []
+    for k in range(1, n + 1):
+        t = k / float(n + 1)
+        x1 = ax1 + (bx1 - ax1) * t
+        y1 = ay1 + (by1 - ay1) * t
+        x2 = ax2 + (bx2 - ax2) * t
+        y2 = ay2 + (by2 - ay2) * t
+        out.append((int(round(x1)), int(round(y1)), int(round(x2)), int(round(y2))))
+    return out
+
+
+# =============================================================================
+# Candidate neighborhood helpers
+# =============================================================================
+
+def nearby_left_caps(short_t: FaceTrack, lefts: list[FaceTrack], *, min_gap_len: int) -> list[FaceTrack]:
+    """
+    Left candidates that end within min_gap_len of short_t.first_frame().
+    """
+    s0 = int(short_t.first_frame())
+    out: list[FaceTrack] = []
+    for t in reversed(lefts):
+        t1 = t.last_frame()
+        if t1 is None:
+            continue
+        gap = s0 - int(t1) - 1
+        if gap < 0:
+            continue
+        if gap < int(min_gap_len):
+            out.append(t)
+        else:
+            break
+    return out
+
+
+def nearby_right_caps(short_t: FaceTrack, rights: list[FaceTrack], *, min_gap_len: int) -> list[FaceTrack]:
+    """
+    Right candidates that start within min_gap_len of short_t.last_frame().
+    """
+    s1 = short_t.last_frame()
+    if s1 is None:
+        return []
+    s1 = int(s1)
+    out: list[FaceTrack] = []
+    for t in rights:
+        t0 = int(t.first_frame())
+        gap = t0 - s1 - 1
+        if gap < 0:
+            continue
+        if gap < int(min_gap_len):
+            out.append(t)
+        else:
+            break
+    return out
+
+
+def encompassing_sandwich_candidates(
+    left_caps: list[FaceTrack],
+    right_caps: list[FaceTrack],
+) -> Dict[int, Tuple[FaceTrack, FaceTrack]]:
+    """
+    gid -> (closest_left, closest_right) when gid appears on both sides.
+    """
+    left_by_gid: Dict[int, FaceTrack] = {}
+    for t in left_caps:
+        gid = getattr(t, "global_id", None)
+        if gid is None:
+            continue
+        gid = int(gid)
+        if gid not in left_by_gid or int(t.last_frame() or -1) > int(left_by_gid[gid].last_frame() or -1):
+            left_by_gid[gid] = t
+
+    right_by_gid: Dict[int, FaceTrack] = {}
+    for t in right_caps:
+        gid = getattr(t, "global_id", None)
+        if gid is None:
+            continue
+        gid = int(gid)
+        if gid not in right_by_gid or int(t.first_frame()) < int(right_by_gid[gid].first_frame()):
+            right_by_gid[gid] = t
+
+    out: Dict[int, Tuple[FaceTrack, FaceTrack]] = {}
+    for gid, l in left_by_gid.items():
+        r = right_by_gid.get(gid)
+        if r is not None:
+            out[gid] = (l, r)
+    return out
+
+
+def score_left_cap(left: FaceTrack, short_t: FaceTrack, *, iou_threshold: float) -> Optional[float]:
+    iou = safe_iou(left.get_last_bbox(), short_t.get_first_bbox())
+    if iou is None or iou < float(iou_threshold):
+        return None
+    return float(iou)
+
+
+def score_right_cap(short_t: FaceTrack, right: FaceTrack, *, iou_threshold: float) -> Optional[float]:
+    iou = safe_iou(short_t.get_last_bbox(), right.get_first_bbox())
+    if iou is None or iou < float(iou_threshold):
+        return None
+    return float(iou)
+
+
+# =============================================================================
+# Overlap helpers (time overlap constraint)
+# =============================================================================
+
+def span(t: FaceTrack) -> Tuple[int, int]:
+    a = int(t.first_frame())
+    b = t.last_frame()
+    b = int(b) if b is not None else a
+    return a, b
+
+
+def ranges_overlap(a0: int, a1: int, b0: int, b1: int) -> bool:
+    return not (a1 < b0 or b1 < a0)

--- a/facekit/tracking/tracker_validator.py
+++ b/facekit/tracking/tracker_validator.py
@@ -6,7 +6,7 @@ import numbers
 from facekit.utils.geometry import compute_iou
 import logging
 
-BBoxXYWH = Tuple[float, float, float, float]
+BBox_XYWH = Tuple[float, float, float, float]
 
 @dataclass
 class ValidatorParams:
@@ -28,8 +28,8 @@ class ValidatorParams:
             if not (_is_num(val) and val >= 0.0):
                 raise ValueError(f"{name} must be >= 0; got {val}")
 
-        if not (_is_num(self.hsv_thresh) and -1.0 <= self.hsv_thresh <= 1.0):
-            raise ValueError(f"hsv_thresh must be in [-1,1]; got {self.hsv_thresh}")
+        if not (_is_num(self.hsv_thresh) and 0 <= self.hsv_thresh <= 2):
+            raise ValueError(f"hsv_thresh must be in [0,2]; got {self.hsv_thresh}")
         
     def to_generation_dict(self) -> dict:
         """Stable names."""
@@ -46,57 +46,65 @@ class TrackerValidator:
     Stateful validator for frame-to-frame tracking continuity within a shot.
 
     Usage:
-      - Construct per-shot with the shot's frames and first_frame_idx.
+      - Construct per-shot
       - Call validate(tracked_boxes, frame_idx) on tracking frames.
         * On the first call (or on non-consecutive frames), it seeds itself and returns True.
         * On success, it updates its internal baseline to the current boxes.
         * On failure, it clears its baseline and returns False (coordinator should trigger detection).
-      - Optionally call set_baseline() right after a detection (re)init to seed with detector boxes.
-
+ 
     Internal state:
       - _prev_boxes: Dict[track_id, (x,y,w,h)] for last accepted frame
       - _prev_idx: last accepted absolute frame index
-      - _sig_by_tid: optional appearance signatures (HSV hist) for last accepted frame
+      - _signature_by_tid: optional appearance signatures (HSV hist) for last accepted frame
     """
 
-    def __init__(self, frames: List[np.ndarray], first_frame_idx: int, params: ValidatorParams):
-        assert 0.0 < params.iou_thresh <= 1.0
+    def __init__(self, params: ValidatorParams):
+        assert 0.0 <= params.iou_thresh <= 1.0
         assert params.area_delta_max >= 0.0
         assert params.asp_ratio_delta_max >= 0.0
         assert params.v_max >= 0.0
-        self._frames = frames
-        self._first = first_frame_idx
-        self.p = params
+        self.params = params
 
-        self._prev_boxes: Optional[Dict[int, BBoxXYWH]] = None
+        self._prev_boxes: Optional[Dict[int, BBox_XYWH]] = None
         self._prev_idx: Optional[int] = None
-        self._sig_by_tid: Dict[int, np.ndarray] = {}
+        self._prev_hsv_signature_by_tid: Dict[int, np.ndarray] = {}
 
-    def set_baseline(self, boxes_xywh: Dict[int, BBoxXYWH], frame_idx: int) -> None:
+    def seed_validator(self, boxes_xywh: Dict[int, BBox_XYWH], frame_idx: int, frame:np.ndarray) -> None:
+        hsv_signature_by_tid = self.hsv_signature_dict(boxes_xywh, frame)
+        self.set_baseline(boxes_xywh, frame_idx, hsv_signature_by_tid)
+
+    def hsv_signature_dict(self, boxes_xywh: Dict[int, BBox_XYWH], frame:np.ndarray) -> Dict[int, np.ndarray]:
+        hsv_signature_by_tid = {}
+        tids = set(boxes_xywh.keys())
+        for tid in tids:
+            box = boxes_xywh[tid]
+            if box is None:
+                hsv_signature_by_tid = None
+            else:
+                signature_curr = self._calc_hsv_signature(frame, box)
+                hsv_signature_by_tid[tid] = signature_curr
+        return hsv_signature_by_tid
+        
+    def set_baseline(self, boxes_xywh: Dict[int, BBox_XYWH], frame_idx: int, hsv_signature_by_tid: Dict[int, np.ndarray]) -> None:
         self._prev_boxes = dict(boxes_xywh)
         self._prev_idx = frame_idx
-        self._sig_by_tid = {}
-        
-        frame = self._frame_from_abs(frame_idx)
-        for tid, b in boxes_xywh.items():
-            sig = self._hsv_sig(frame, b)
-            if sig is not None:
-                self._sig_by_tid[tid] = sig
+        self._prev_hsv_signature_by_tid = dict(hsv_signature_by_tid)
 
-    def validate(self, curr_boxes: Dict[int, BBoxXYWH], 
-                 frame_idx: int,
-                 verbose: bool=False) -> bool:
+    def validate(self, 
+                 curr_boxes: Dict[int, BBox_XYWH],
+                 current_frame: np.ndarray,
+                 frame_idx: int) -> bool:
         """
         Validate continuity against last accepted state.
         - If we have no baseline or frames aren’t consecutive, seed baseline from current and return True.
         - Otherwise, require:
-            * all previous tids still present
+            * all previous tids to still be present
             * IoU(prev, curr) >= iou_thresh
             * |area_delta| <= area_delta_max
             * |asp_ratio_delta| <= asp_ratio_delta_max
             * center shift / prev_diag <= v_max
-            * (optional) HSV appearance distance <= hsv_thresh
-        On success: baseline <- current (including HSV signatures).
+            * HSV appearance distance <= hsv_thresh
+        On success: baseline <- current.
         On failure: baseline cleared (so next call won’t compare against a stale state).
         """
         if not curr_boxes:
@@ -104,8 +112,11 @@ class TrackerValidator:
             return False
 
         # First time or non-consecutive → seed & accept
-        if (self._prev_boxes is None) or (self._prev_idx is None) or (frame_idx != self._prev_idx + 1):
-            self.set_baseline(curr_boxes, frame_idx)
+        if (self._prev_boxes is None or
+            self._prev_idx is None or
+            frame_idx != self._prev_idx + 1):
+
+            self.seed_validator(curr_boxes, frame_idx, current_frame)
             return True
 
         prev = self._prev_boxes
@@ -115,97 +126,86 @@ class TrackerValidator:
         # No missing tracks
         if not prev_ids.issubset(curr_ids):
             self._clear_baseline()
-            if verbose:
-                logging.debug(f"[TRACK VALIDATION] missing ids: {sorted(prev_ids - curr_ids)}")
             return False
+
+        curr_hsv_signature_by_tid = {}
 
         # iterate through tracks
         for tid in prev_ids:
 
             # No missing boxes
-            b0 = prev[tid]; b1 = curr_boxes[tid]
+            b0 = prev[tid]
+            b1 = curr_boxes[tid]
             if b0 is None or b1 is None:
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} missing box")
                 return False
 
             # IoU is within bounds
             iou = compute_iou(self._xywh_to_xyxy(b0), self._xywh_to_xyxy(b1))
-            if iou < self.p.iou_thresh:
+            if iou < self.params.iou_thresh:
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} IoU={iou:.3f} (min {self.p.iou_thresh})")
                 return False
 
             # Area changes are within bounds
-            if not self._area_ok(b0, b1, self.p.area_delta_max, verbose):
+            if not self._area_ok(b0, b1, self.params.area_delta_max):
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} area not within bounds (max {self.p.area_delta_max})")
                 return False
 
-            # aspect ratio (use asp_ratio terminology)
-            if not self._asp_ratio_ok(b0, b1, self.p.asp_ratio_delta_max):
+            # aspect ratio
+            if not self._asp_ratio_ok(b0, b1, self.params.asp_ratio_delta_max):
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} asp ratio not within bounds (max {self.p.asp_ratio_delta_max})")
                 return False
 
             # velocity
-            if not self._velocity_ok(b0, b1, self.p.v_max):
+            if not self._velocity_ok(b0, b1, self.params.v_max):
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} velocity not within bounds (max {self.p.v_max})")
                 return False
 
             # appearance
-            frame = self._frame_from_abs(frame_idx)
-            sig_prev = self._sig_by_tid.get(tid)
-            sig_curr = self._hsv_sig(frame, b1)
-            if sig_prev is None or sig_curr is None:
+            signature_prev = self._prev_hsv_signature_by_tid.get(tid)
+            signature_curr = self._calc_hsv_signature(current_frame, b1)
+            if signature_prev is None or signature_curr is None:
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} appearance fails due to lack of previous signature")
                 return False
-            if self._hsv_dist(sig_prev, sig_curr) > self.p.hsv_thresh:
+            if self._hsv_dist(signature_prev, signature_curr) > self.params.hsv_thresh:
                 self._clear_baseline()
-                if verbose: logging.debug(f"[TRACK VALIDATION] tid={tid} appearance not within bounds (max {self.p.hsv_thresh})")
                 return False
+            
+            curr_hsv_signature_by_tid[tid] = signature_curr
 
         # Success; update baseline to current
-        self.set_baseline(curr_boxes, frame_idx)
+        self.set_baseline(curr_boxes, frame_idx, curr_hsv_signature_by_tid)
         return True
     
     def provenance(self) -> dict:
-        return self.p.to_generation_dict()
+        return self.params.to_generation_dict()
 
     # --- helpers ---
     def _clear_baseline(self):
         self._prev_boxes = None
         self._prev_idx = None
-        self._sig_by_tid.clear()
-
-    def _frame_from_abs(self, abs_idx: int) -> np.ndarray:
-        local = abs_idx - self._first
-        if local < 0 or local >= len(self._frames):
-            raise IndexError(f"[TRACK VALIDATION] Frame {abs_idx} out of shot range [{self._first}, {self._first+len(self._frames)-1}]")
-        return self._frames[local]
+        self._prev_hsv_signature_by_tid.clear()
 
     @staticmethod
-    def _xywh_to_xyxy(b: BBoxXYWH):
+    def _xywh_to_xyxy(b: BBox_XYWH):
         x,y,w,h = b
-        return (int(x), int(y), int(x+w), int(y+h))
+        return (x, y, x+w, y+h)
 
     @staticmethod
-    def _area_ok(b0: BBoxXYWH, b1: BBoxXYWH, max_frac: float, eps: float = 1e-6) -> bool:
+    def _area_ok(b0: BBox_XYWH, b1: BBox_XYWH, max_frac: float, eps: float = 1e-6) -> bool:
         _,_,w0,h0 = b0; _,_,w1,h1 = b1
         a0 = max(w0*h0, eps); a1 = max(w1*h1, eps)
         return abs(a1 - a0) / a0 <= max_frac
 
     @staticmethod
-    def _asp_ratio_ok(b0: BBoxXYWH, b1: BBoxXYWH, max_frac: float, eps: float = 1e-6) -> bool:
+    def _asp_ratio_ok(b0: BBox_XYWH, b1: BBox_XYWH, max_frac: float, eps: float = 1e-6) -> bool:
         _,_,w0,h0 = b0; _,_,w1,h1 = b1
         asp0 = w0 / max(h0, eps)
         asp1 = w1 / max(h1, eps)
         return abs(asp1 - asp0) / max(asp0, eps) <= max_frac
 
     @staticmethod
-    def _velocity_ok(b0: BBoxXYWH, b1: BBoxXYWH, v_max: float, eps: float = 1e-6) -> bool:
+    def _velocity_ok(b0: BBox_XYWH, b1: BBox_XYWH, v_max: float, eps: float = 1e-6) -> bool:
         x0,y0,w0,h0 = b0; x1,y1,w1,h1 = b1
         c0x, c0y = x0 + 0.5*w0, y0 + 0.5*h0
         c1x, c1y = x1 + 0.5*w1, y1 + 0.5*h1
@@ -214,7 +214,7 @@ class TrackerValidator:
         return (shift / max(d0, eps)) <= v_max
 
     @staticmethod
-    def _hsv_sig(frame: np.ndarray, b: BBoxXYWH) -> Optional[np.ndarray]:
+    def _calc_hsv_signature(frame: np.ndarray, b: BBox_XYWH) -> Optional[np.ndarray]:
         x,y,w,h = map(int, b)
         if w <= 0 or h <= 0: return None
         H,W = frame.shape[:2]
@@ -226,7 +226,6 @@ class TrackerValidator:
         crop = cv2.resize(crop, (64, 64), interpolation=cv2.INTER_AREA)
         hsv = cv2.cvtColor(crop, cv2.COLOR_BGR2HSV)
 
-        # 16x8x8 bins across H,S,V; normalized
         hist = cv2.calcHist([hsv], [0,1,2], None, [8,4,4], [0,180, 0,256, 0,256]).flatten()
         hist /= (hist.sum() + 1e-6)
         return hist

--- a/tests/integration/test_resume_drawable_contract.py
+++ b/tests/integration/test_resume_drawable_contract.py
@@ -2,11 +2,35 @@ import numpy as np
 from facekit.output.json_v2 import ObservationsCollector
 from facekit.pipeline.resume_rehydrate import rehydrate_observation_tracks
 
+def _five_point_landmarks():
+    # 5 (x,y) points: left eye, right eye, nose, left mouth, right mouth
+    # Values can be arbitrary-but-sane; they just need to be present + valid.
+    return [
+        [10.0, 12.0],
+        [20.0, 12.0],
+        [15.0, 18.0],
+        [12.0, 26.0],
+        [18.0, 26.0],
+    ]
+
 def test_pre_anchor_tracks_produce_drawable_rects():
     oc = ObservationsCollector()
     oc.append_track_obs([
-        {"shot":1,"track_id":2,"f":3,"bbox_xyxy":[1.2, 2.8, 30.4, 40.9],"src":"detected"},
-        {"shot":1,"track_id":2,"f":4,"bbox_xyxy":[5.0, 6.0, 50.0, 60.0],"src":"tracked"},
+        {
+            "shot": 1,
+            "track_id": 2,
+            "f": 3,
+            "bbox_xyxy": [1.2, 2.8, 30.4, 40.9],
+            "src": "detected",
+            "landmarks": _five_point_landmarks(),   # <-- required by new contract
+        },
+        {
+            "shot": 1,
+            "track_id": 2,
+            "f": 4,
+            "bbox_xyxy": [5.0, 6.0, 50.0, 60.0],
+            "src": "tracked",
+        },
     ], emb_idx_fn=lambda _: -1)
 
     tracks = rehydrate_observation_tracks(
@@ -14,9 +38,9 @@ def test_pre_anchor_tracks_produce_drawable_rects():
     )
     assert tracks
     t = tracks[0]
-    for o in t.observations:
-        x1,y1,x2,y2 = o.bbox
-        assert all(isinstance(v, int) for v in (x1,y1,x2,y2))
-        assert all(np.isfinite([x1,y1,x2,y2]))
-        assert x2 > x1 and y2 > y1
 
+    for o in t.observations:
+        x1, y1, x2, y2 = o.bbox
+        assert all(isinstance(v, int) for v in (x1, y1, x2, y2))
+        assert all(np.isfinite([x1, y1, x2, y2]))
+        assert x2 > x1 and y2 > y1

--- a/tests/integration/test_resume_realVideo.py
+++ b/tests/integration/test_resume_realVideo.py
@@ -15,6 +15,9 @@ import zipfile
 
 from facekit.common.obs_consts import SRC_TO_CODE, Source
 
+# Usage KEEP_E2E_LOGS=1 pytest tests
+KEEP_SUBPROCESS_LOGS = os.environ.get("KEEP_E2E_LOGS", "").strip() in {"1", "true", "True", "yes", "YES"}
+
 # ---- helpers ---------------------------------------------------------------
 
 def _repo_root() -> Path:
@@ -28,26 +31,36 @@ def _env_with_repo() -> dict:
     return env
 
 def _run(cmd, *, ok=(0,), cwd=None, env=None, log_prefix="run"):
-    # Ensure log directory exists inside tmp_path
     base = Path.cwd()
     log_dir = _init_log_dir(base)
 
     cp = subprocess.run(cmd, text=True, capture_output=True, cwd=cwd, env=env)
 
-    stdout_path = log_dir / f"{log_prefix}_stdout.txt"
-    stderr_path = log_dir / f"{log_prefix}_stderr.txt"
+    # Only persist stdout/stderr if user explicitly asked to keep logs via env var
+    should_persist = KEEP_SUBPROCESS_LOGS
 
-    stdout_path.write_text(cp.stdout or "")
-    stderr_path.write_text(cp.stderr or "")
-
-    _register_log_file(stdout_path)
-    _register_log_file(stderr_path)
+    if should_persist:
+        stdout_path = log_dir / f"{log_prefix}_stdout.txt"
+        stderr_path = log_dir / f"{log_prefix}_stderr.txt"
+        stdout_path.write_text(cp.stdout or "")
+        stderr_path.write_text(cp.stderr or "")
+        _register_log_file(stdout_path)
+        _register_log_file(stderr_path)
 
     if cp.returncode not in ok:
+        # If we didn't persist for some reason, still include content in the exception.
+        if not should_persist:
+            raise AssertionError(
+                f"Subprocess error (prefix={log_prefix})\n"
+                f"RC={cp.returncode}, expected={ok}\n"
+                f"=== STDOUT ===\n{cp.stdout}\n"
+                f"=== STDERR ===\n{cp.stderr}\n"
+            )
         raise AssertionError(
             f"Subprocess error (prefix={log_prefix})\n"
             f"RC={cp.returncode}, expected={ok}\n"
-            f"stdout: {stdout_path}\nstderr: {stderr_path}\n"
+            f"stdout: {log_dir / f'{log_prefix}_stdout.txt'}\n"
+            f"stderr: {log_dir / f'{log_prefix}_stderr.txt'}\n"
         )
 
     return cp
@@ -92,31 +105,6 @@ def _extract_anchor_from_logs(text: str) -> int:
     if m: return int(m.group(1))
     # Fallback
     return 0
-
-def _gid_lookup(js):
-    """
-    Build flexible lookups for global_id:
-      - by (shot_id, track_id)      if refs carry track_id
-      - by (shot_id, face_label)    if refs carry face_label
-      - by (shot_id, first,last)    optional span fallback
-    Returns a dict of the three maps.
-    """
-    by_tid    = {}
-    by_label  = {}
-    by_span   = {}
-
-    for gf in js.get("global_faces", []):
-        gid = gf["global_id"]
-        for ref in gf.get("track_refs", []):
-            s = int(ref["shot_id"])
-            if "track_id" in ref:
-                by_tid[(s, int(ref["track_id"]))] = gid
-            if "face_label" in ref:
-                by_label[(s, str(ref["face_label"]))] = gid
-            if "first_frame" in ref and "last_frame" in ref:
-                by_span[(s, int(ref["first_frame"]), int(ref["last_frame"]))] = gid
-
-    return {"by_tid": by_tid, "by_label": by_label, "by_span": by_span}
 
 # Create global list to accumulate log files
 _LOG_DIR = None
@@ -288,20 +276,33 @@ if __name__ == "__main__":
     assert int(status["last_detection_frame"]) == 180, (
         f"status.json anchor drift: expected 180, got {status.get('last_detection_frame')}"
     )
-    # Crash run detections and cropped faces report
+    # Crash run detections 
     arr = np.load(obs_npz_path, allow_pickle=False)["observations"]
     shot = 1
     det_code = SRC_TO_CODE[Source.DETECTED]
     is_shot = arr["shot"] == shot
     is_det  = arr["src"]  == det_code
-    has_crop = ("has_crop" in arr.dtype.names) and (arr["has_crop"] == 1)
-    with_emb = arr["emb_idx"] >= 0
 
-    print("DET rows total:", int((is_shot & is_det).sum()))
-    print("DET rows with crop:",
-        int((is_shot & is_det & has_crop).sum()) if has_crop is not None else "no has_crop field")
-    print("DET rows with crop+emb:",
-        int((is_shot & is_det & has_crop & with_emb).sum()) if has_crop is not None else "no has_crop field")
+    names = set(arr.dtype.names or [])
+    print("obs dtype names:", sorted(names))
+
+    has_lm_field = any(n in names for n in ("landmarks", "lms", "lm", "landmarks_5pt"))
+    if has_lm_field:
+        # pick the first matching field name
+        lm_name = next(n for n in ("landmarks", "lms", "lm", "landmarks_5pt") if n in names)
+        lms = arr[lm_name]
+        # Heuristic: landmarks array should be finite for DET rows (shape varies by storage)
+        # We'll just check "not all zeros" on DET rows.
+        det_lm = lms[is_shot & is_det]
+        print("DET rows:", int(det_lm.shape[0]))
+        # If lms is numeric ndarray, this works; if it's structured/object it won't.
+        try:
+            nonzero = np.any(np.asarray(det_lm) != 0)
+            print("DET rows have nonzero landmarks:", bool(nonzero))
+        except Exception as e:
+            print("Could not compute nonzero-landmarks check:", repr(e))
+    else:
+        print("No landmarks field found in obs sidecar; cannot validate landmarks via NPZ here.")
 
     # ---- 2.5) PROBE SIDECRS (pre-resume, strict parity up to anchor-1) ----
     probe = _repo_root() / "tests" / "utils" / "probe_sidecars.py"
@@ -348,6 +349,10 @@ if __name__ == "__main__":
 
     # ---- Compare outputs ----
     cold_js   = _load_json(out_cold)
+
+    print("cold_js keys:", cold_js.keys())
+    print("cold face_metadata count:", len(cold_js.get("face_metadata", [])))
+
     resume_js = _load_json(out_resume)
 
     cold_tracks   = _ordered_tracks(cold_js)
@@ -365,27 +370,34 @@ if __name__ == "__main__":
     assert len(cold_tracks) == len(resume_tracks), \
         f"track count mismatch: cold={len(cold_tracks)} resume={len(resume_tracks)}"
 
-    # Build (shot_id, track_id) → global_id lookup tables
-    cold_gid   = _gid_lookup(cold_js)
-    resume_gid = _gid_lookup(resume_js)
+    def _labels_used_by_tracks(js: dict) -> set[str]:
+        labels = set()
+        for shot in js.get("shots", []):
+            for t in shot.get("face_tracks", []):
+                labels.add(t.get("face_label"))
+        return labels
 
-    def _gid_for_track(track_dict):
-        """
-        Extract the global ID from a track's face_label.
-        In schema 2.1, this is the only source of truth.
-        """
-        lbl = track_dict.get("face_label")
-        if not lbl:
-            return None
+    def _labels_in_metadata(js: dict) -> set[str]:
+        return {m.get("face_label") for m in js.get("face_metadata", [])}
 
-        # Must look like "face_<int>"
-        if isinstance(lbl, str) and lbl.startswith("face_"):
-            try:
-                return int(lbl.split("_", 1)[1])
-            except ValueError:
-                return None
+    def _track_identity_key(t: dict) -> tuple[int, int, int]:
+        """Deterministic key for 'same track' across runs."""
+        return (int(t["shot_id"]), int(t["first_frame"]), int(t["last_frame"]))
 
-        return None
+    cold_used = _labels_used_by_tracks(cold_js)
+    resume_used = _labels_used_by_tracks(resume_js)
+
+    assert None not in cold_used, "cold has tracks with face_label=None"
+    assert None not in resume_used, "resume has tracks with face_label=None"
+
+    cold_meta = _labels_in_metadata(cold_js)
+    resume_meta = _labels_in_metadata(resume_js)
+
+    missing_cold = cold_used - cold_meta
+    missing_resume = resume_used - resume_meta
+
+    assert not missing_cold, f"cold: face_metadata missing labels: {sorted(missing_cold)}"
+    assert not missing_resume, f"resume: face_metadata missing labels: {sorted(missing_resume)}"
 
     # Compare track-by-track (ordered by our deterministic _ordered_tracks)
     for a, b in zip(cold_tracks, resume_tracks):
@@ -399,107 +411,84 @@ if __name__ == "__main__":
         assert a["last_frame"]  == b["last_frame"], \
             f"last_frame drift: cold={a['last_frame']} resume={b['last_frame']}"
 
-        # Compare the GLOBAL ID assignment through v2.1 global_faces
-        ga = _gid_for_track(a)
-        gb = _gid_for_track(b)
-
-        assert ga is not None, (
-            f"cold run track missing global_id mapping: "
-            f"shot={a['shot_id']} track_id={a.get('track_id')} "
-            f"span=[{a['first_frame']},{a['last_frame']}]"
+        # Strict: global identity is face_label in your schema
+        assert a.get("face_label") is not None, (
+            f"cold run track missing face_label: key={_track_identity_key(a)}"
         )
-        assert gb is not None, (
-            f"resume run track missing global_id mapping: "
-            f"shot={b['shot_id']} track_id={b.get('track_id')} "
-            f"span=[{b['first_frame']},{b['last_frame']}]"
+        assert b.get("face_label") is not None, (
+            f"resume run track missing face_label: key={_track_identity_key(b)}"
         )
 
-        assert ga == gb, (
-            f"global_id drift: cold={ga} resume={gb} "
-            f"(shot={a['shot_id']}, track={a['track_id']})"
+        assert a["face_label"] == b["face_label"], (
+            f"face_label drift: cold={a['face_label']} resume={b['face_label']} "
+            f"(key={_track_identity_key(a)})"
         )
         
         # ---- canonical compare for v2.1 globalID JSON ----
 
-        _VOLATILE_KEYS = {"generation", "observations_sidecar", "params_hash"}  # ignore run-specific stuff
+    _VOLATILE_KEYS = {"generation", "observations_sidecar", "embedding_sidecar", "params_hash"}
 
-        def _round_floats(x, ndigits=6):
-            if isinstance(x, float):
-                # normalize -0.0 and tiny float noise
-                return 0.0 if abs(x) < 10**-(ndigits+2) else round(x, ndigits)
-            if isinstance(x, list):
-                return [_round_floats(v, ndigits) for v in x]
-            if isinstance(x, dict):
-                return {k: _round_floats(v, ndigits) for k, v in x.items()}
-            return x
+    def _round_floats(x, ndigits=6):
+        if isinstance(x, float):
+            # normalize -0.0 and tiny float noise
+            return 0.0 if abs(x) < 10**-(ndigits+2) else round(x, ndigits)
+        if isinstance(x, list):
+            return [_round_floats(v, ndigits) for v in x]
+        if isinstance(x, dict):
+            return {k: _round_floats(v, ndigits) for k, v in x.items()}
+        return x
 
-        def _canon_globalid(js: dict) -> dict:
-            js = deepcopy(js)
+    def _canon_globalid(js: dict) -> dict:
+        js = deepcopy(js)
 
-            # drop volatile sections
-            for k in list(js.keys()):
-                if k in _VOLATILE_KEYS:
-                    js.pop(k, None)
+        # drop volatile sections
+        for k in list(js.keys()):
+            if k in _VOLATILE_KEYS:
+                js.pop(k, None)
 
-            # normalize SHOTS / FACE_TRACKS
-            shots = js.get("shots", [])
-            for shot in shots:
-                # enforce ints
-                shot["shot_number"] = int(shot.get("shot_number", -1))
-                for t in shot.get("face_tracks", []):
-                    t["first_frame"] = int(t.get("first_frame", -1))
-                    t["last_frame"]  = int(t.get("last_frame", -1))
-                    # keep label exactly as produced (strict). if absent, use "" to stabilize sort
-                    t["face_label"]  = "" if t.get("face_label") is None else str(t["face_label"])
-                # sort tracks deterministically
-                shot["face_tracks"] = sorted(
-                    shot.get("face_tracks", []),
-                    key=lambda t: (t["first_frame"], t["last_frame"], t["face_label"])
-                )
-            js["shots"] = sorted(shots, key=lambda s: s["shot_number"])
+        # normalize SHOTS / FACE_TRACKS
+        shots = js.get("shots", [])
+        for shot in shots:
+            # enforce ints
+            shot["shot_number"] = int(shot.get("shot_number", -1))
+            for t in shot.get("face_tracks", []):
+                t["first_frame"] = int(t.get("first_frame", -1))
+                t["last_frame"]  = int(t.get("last_frame", -1))
+                # keep label exactly as produced (strict). if absent, use "" to stabilize sort
+                t["face_label"]  = "" if t.get("face_label") is None else str(t["face_label"])
+            # sort tracks deterministically
+            shot["face_tracks"] = sorted(
+                shot.get("face_tracks", []),
+                key=lambda t: (t["first_frame"], t["last_frame"], t["face_label"])
+            )
+        js["shots"] = sorted(shots, key=lambda s: s["shot_number"])
 
-            # normalize GLOBAL_FACES (gi output)
-            gfaces = []
-            for gf in js.get("global_faces", []):
-                gf = dict(gf)
-                gf["global_id"] = int(gf.get("global_id", -1))
-                refs = []
-                for r in gf.get("track_refs", []):
-                    r = dict(r)
-                    r["shot_id"]     = int(r.get("shot_id", -1))
-                    r["first_frame"] = int(r.get("first_frame", -1))
-                    r["last_frame"]  = int(r.get("last_frame", -1))
-                    r["track_id"]    = int(r["track_id"]) if r.get("track_id") is not None else -1
-                    r["face_label"]  = "" if r.get("face_label") is None else str(r["face_label"])
-                    refs.append(r)
-                gf["track_refs"] = sorted(
-                    refs, key=lambda r: (r["shot_id"], r["first_frame"], r["last_frame"], r["face_label"], r["track_id"])
-                )
-                gfaces.append(gf)
-            if gfaces:
-                js["global_faces"] = sorted(gfaces, key=lambda gf: gf["global_id"])
+        # normalize FACE_METADATA
+        if "face_metadata" in js:
+            fmd = []
+            for m in js["face_metadata"]:
+                cnt = m.get("occurrence_count", None)
+                if cnt is None:
+                    cnt = m.get("occurance_count", 0)
+                fmd.append({
+                    "face_label": str(m.get("face_label", "")),
+                    "occurrence_count": int(cnt),
+                })
+            js["face_metadata"] = sorted(fmd, key=lambda m: m["face_label"])
 
-            # normalize FACE_METADATA
-            if "face_metadata" in js:
-                fmd = []
-                for m in js["face_metadata"]:
-                    fmd.append({"face_label": str(m.get("face_label", "")),
-                                "occurance_count": int(m.get("occurance_count", 0))})
-                js["face_metadata"] = sorted(fmd, key=lambda m: m["face_label"])
+        # round floats everywhere to tame tiny numeric noise
+        js = _round_floats(js, ndigits=6)
+        return js
 
-            # round floats everywhere to tame tiny numeric noise
-            js = _round_floats(js, ndigits=6)
-            return js
+    def _canon_str(js: dict) -> str:
+        """Stable string for better diffs."""
+        return json.dumps(_canon_globalid(js), sort_keys=True, indent=2)
 
-        def _canon_str(js: dict) -> str:
-            """Stable string for better diffs."""
-            return json.dumps(_canon_globalid(js), sort_keys=True, indent=2)
+    def assert_globalid_equal(cold_js: dict, resume_js: dict):
+        a, b = _canon_globalid(cold_js), _canon_globalid(resume_js)
+        if a != b:
+            a_s, b_s = _canon_str(cold_js).splitlines(), _canon_str(resume_js).splitlines()
+            diff = "\n".join(difflib.unified_diff(a_s, b_s, fromfile="cold", tofile="resume", lineterm=""))
+            raise AssertionError("GlobalID JSONs differ (strict). Unified diff:\n" + diff)
 
-        def assert_globalid_equal(cold_js: dict, resume_js: dict):
-            a, b = _canon_globalid(cold_js), _canon_globalid(resume_js)
-            if a != b:
-                a_s, b_s = _canon_str(cold_js).splitlines(), _canon_str(resume_js).splitlines()
-                diff = "\n".join(difflib.unified_diff(a_s, b_s, fromfile="cold", tofile="resume", lineterm=""))
-                raise AssertionError("GlobalID JSONs differ (strict). Unified diff:\n" + diff)
-
-        assert_globalid_equal(cold_js, resume_js)
+    assert_globalid_equal(cold_js, resume_js)

--- a/tests/integration/test_resume_rehydrate_integration.py
+++ b/tests/integration/test_resume_rehydrate_integration.py
@@ -4,20 +4,33 @@ import numpy as np
 
 from facekit.pipeline.track_across_segments import track_across_segments
 from facekit.pipeline.checkpoint import CheckpointManager
-from facekit.output.json_v2 import ObservationsCollector
+from facekit.output.json_v2 import ObservationsCollector, EmbeddingCollector
+import facekit.pipeline.resume_rehydrate as resume_rehydrate
+
+
+# ------------------- Fakes -------------------
 
 class DummyDetector:
-    def detect_faces_in_frame(self, frame): return None
+    # Must return the 3-tuple shape, not None
+    def detect_faces_in_frame(self, frame):
+        return ([], [], [])
+
 
 class DummyEmbedder:
     def get_embedding_batch(self, crops, batch_size=32):
         return np.zeros((len(crops), 512), dtype=np.float32)
 
+
+# ------------------- Helpers -------------------
+
 def _write_shots(p: Path, f0: int, f1: int):
-    p.write_text(json.dumps({"shots":[{"shot_number":1,"first_frame":f0,"last_frame":f1}]}))
+    p.write_text(json.dumps({"shots": [{"shot_number": 1, "first_frame": f0, "last_frame": f1}]}))
+
+
+# ------------------- Test -------------------
 
 def test_resume_invokes_rehydrate_once_with_anchor_minus_one(tmp_path, monkeypatch):
-    # --- minimal frame provider to avoid real I/O ---
+    # ---- minimal frame provider with instrumentation ----
     class DummyFP:
         def __init__(self, total=60, w=192, h=108, fps=30.0):
             self._total = total
@@ -25,69 +38,123 @@ def test_resume_invokes_rehydrate_once_with_anchor_minus_one(tmp_path, monkeypat
             self._fps = fps
             self._idx = 0
             self._blank = np.zeros((h, w, 3), dtype=np.uint8)
+            self.ops = []   # ("reset", i) or ("next", i)
+
         @property
         def fps(self): return self._fps
         @property
         def size(self): return (self._w, self._h)
         @property
         def total_frames(self): return self._total
-        def reset_to_frame(self, i): self._idx = int(i)
+
+        def reset_to_frame(self, i):
+            self._idx = int(i)
+            self.ops.append(("reset", self._idx))
+
         def next(self):
-            if self._idx >= self._total: return None
+            self.ops.append(("next", self._idx))
+            if self._idx >= self._total:
+                return None
             self._idx += 1
             return self._blank
 
+        def first_next_after_reset(self, target):
+            reset_pos = None
+            for i, (op, val) in enumerate(self.ops):
+                if op == "reset" and val == target:
+                    reset_pos = i
+                    break
+            if reset_pos is None:
+                return None
+            for op, val in self.ops[reset_pos + 1:]:
+                if op == "next":
+                    return val
+            return None
+
     fp = DummyFP()
 
-    # --- shots file ---
+    # ---- shots ----
     shots = tmp_path / "shots.json"
     _write_shots(shots, 0, 59)
 
-    # --- checkpoint with an anchor at 30 ---
+    # ---- checkpoint with anchor=30 ----
     vid = tmp_path / "dummy.mp4"
     vid.write_text("placeholder")
     parent = tmp_path / "ck"
     parent.mkdir()
+
     opts = {
-        "schema_version":"2.1","video_path":str(vid),"detect_interval":10,
-        "embedding_batch_size_max":32,"device":"cpu","emb_store":"sidecar",
-        "emb_sidecar_path":None,"obs_sidecar_path":None,"detector_model_path":"x",
-        "embedding_model_path":"y","yolo_config_path":"z","shot_segmentation_path":str(shots),
-        "log_level":"INFO","log_file":None
+        "schema_version": "2.1",
+        "video_path": str(vid),
+        "detect_interval": 10,
+        "embedding_batch_size_max": 32,
+        "device": "cpu",
+        "emb_store": "sidecar",
+        "emb_sidecar_path": None,
+        "obs_sidecar_path": None,
+        "detector_model_path": "x",
+        "embedding_model_path": "y",
+        "yolo_config_path": "z",
+        "shot_segmentation_path": str(shots),
+        "log_level": "INFO",
+        "log_file": None,
     }
+
     ckpt = CheckpointManager.open(
-        parent_dir=parent, video_path=vid, options_snapshot=opts,
-        no_resume=True, force_new_run=False
+        parent_dir=parent,
+        video_path=vid,
+        options_snapshot=opts,
+        no_resume=True,
+        force_new_run=False,
     )
-    # simulate prior run’s last detection
-    ckpt._last_det_frame = 30
+
+    anchor = 30
+    ckpt._last_det_frame = anchor
     ckpt._last_det_shot = 1
     ckpt._last_det_shot_first_frame = 0
 
-    # --- pre-anchor observations in collector ---
+    # ---- wire collectors exactly like prod ----
     oc = ObservationsCollector()
-    oc.append_track_obs(
-        [{"shot":1,"track_id":1,"f":10,"bbox_xyxy":[0,0,10,10],"src":"detected"}],
-        emb_idx_fn=lambda _: -1
-    )
-    ckpt.obs_collector = oc
+    embc = EmbeddingCollector(mode="sidecar", dim=512)
+    ckpt.start(oc, embc, options_snapshot=opts)
 
-    # --- monkeypatches ---
-    called = {}
+    # ---- pre-anchor DETECTED row with valid landmarks ----
+    lm = np.asarray(
+        [[11.0, 0.0],
+         [0.0, 0.0],
+         [0.0, 0.0],
+         [0.0, 0.0],
+         [0.0, 0.0]],
+        dtype=np.float32,
+    )
+
+    oc.append_track_obs(
+        [{
+            "shot": 1,
+            "track_id": 1,
+            "f": 10,
+            "bbox_xyxy": [0, 0, 10, 10],
+            "src": "detected",
+            "has_landmarks": 1,
+            "landmarks": lm,
+        }],
+        emb_idx_fn=lambda _: -1,
+    )
+
+    # ---- spy on rehydrate_tracks ----
+    called = {"count": 0, "args": None}
+
     def fake_rehydrate(collector, frame_max, **kwargs):
-        called["args"] = (collector, frame_max, kwargs.get("track_order"))
+        called["count"] += 1
+        called["args"] = (collector, int(frame_max), kwargs.get("track_order"))
         return []
 
-    # ensure pipeline uses our fake
-    monkeypatch.setattr(
-        "facekit.pipeline.track_across_segments.rehydrate_tracks",
-        fake_rehydrate
-    )
+    monkeypatch.setattr(resume_rehydrate, "rehydrate_tracks", fake_rehydrate)
 
-    # provide non-empty track_order (we didn't really persist one)
+    # non-empty track_order required
     monkeypatch.setattr(ckpt, "get_track_order", lambda: {(1, 1): 0})
 
-    # --- run ---
+    # ---- run ----
     _ = track_across_segments(
         frame_source=fp,
         shot_json_path=str(shots),
@@ -96,11 +163,15 @@ def test_resume_invokes_rehydrate_once_with_anchor_minus_one(tmp_path, monkeypat
         checkpoint=ckpt,
     )
 
-    # --- assertions ---
-    assert "args" in called, "rehydrate_tracks should be called when anchor > 0"
+    # ---- assertions ----
+
+    # A) rehydrate called once with anchor-1
+    assert called["count"] == 1
     _, fm, to = called["args"]
-    assert fm == 29                      # anchor - 1
-    assert isinstance(to, dict) and to   # non-empty track_order
-    # First frame processed should be the anchor (30) or later.
-    # Our DummyFP increments before returning, so check its internal cursor:
-    assert fp._idx >= 30
+    assert fm == anchor - 1
+    assert isinstance(to, dict) and to
+
+    # B) seek + start at anchor
+    assert ("reset", anchor) in fp.ops
+    first_after = fp.first_next_after_reset(anchor)
+    assert first_after == anchor

--- a/tests/integration/test_validator_integration.py
+++ b/tests/integration/test_validator_integration.py
@@ -11,7 +11,6 @@ from facekit.detection.face_detector import FaceDetector
 from facekit.tracking.face_tracker import FaceTracker
 from facekit.tracking.tracker_validator import TrackerValidator, ValidatorParams
 
-
 BBox = Tuple[float, float, float, float]  # x, y, w, h
 
 
@@ -34,14 +33,9 @@ def _save_dbg(name, img):
     cv2.imwrite(str(p), img)
     return p
 
-def _need_cv2():
-    if cv2 is None:
-        pytest.skip("OpenCV not available.")
-
-
 def _video_path() -> str:
     """
-    Use TEST_VIDEO if set, else tests/assets/sample.mp4.
+    Use TEST_VIDEO if set, else tests/data/interview-sam-altman_5sec_snippet.mp4.
     """
     env_p = os.environ.get("TEST_VIDEO")
     if env_p and Path(env_p).exists():
@@ -49,15 +43,12 @@ def _video_path() -> str:
     candidate = Path(Path(__file__).parents[2], "tests", "data", "interview-sam-altman_5sec_snippet.mp4")
     if candidate.exists():
         return str(candidate)
-
-    pytest.skip("No test video found. Set TEST_VIDEO or add tests/assets/sample.mp4.")
-
+    pytest.skip("No test video found. Set TEST_VIDEO or add tests/data/interview-sam-altman_5sec_snippet.mp4.")
 
 def _open_cap(path: str):
     cap = cv2.VideoCapture(path)
     assert cap.isOpened(), f"Failed to open video: {path}"
     return cap
-
 
 def _read_frame(cap, idx: int) -> Optional[np.ndarray]:
     total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
@@ -67,11 +58,7 @@ def _read_frame(cap, idx: int) -> Optional[np.ndarray]:
     ok, frame = cap.read()
     return frame if ok else None
 
-
 def _pick_pair(cap):
-    """
-    Choose a consecutive frame pair in the middle of the clip to reduce preroll weirdness.
-    """
     total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
     if total < 2:
         pytest.skip("Video has fewer than 2 frames.")
@@ -81,7 +68,6 @@ def _pick_pair(cap):
     if f0 is None or f1 is None:
         pytest.skip("Could not decode two consecutive frames.")
     return start, f0, f1
-
 
 def _first_face_bbox(det: FaceDetector, frame: np.ndarray) -> Optional[BBox]:
     out = det.detect_faces_in_frame(frame)
@@ -93,7 +79,6 @@ def _first_face_bbox(det: FaceDetector, frame: np.ndarray) -> Optional[BBox]:
     # detector returns xyxy; convert to xywh
     x1, y1, x2, y2 = [float(v) for v in boxes[0][:4]]
     return (x1, y1, x2 - x1, y2 - y1)
-
 
 def _iou_xywh(a: BBox, b: BBox) -> float:
     ax, ay, aw, ah = a
@@ -107,11 +92,9 @@ def _iou_xywh(a: BBox, b: BBox) -> float:
     union = aw * ah + bw * bh - inter + 1e-6
     return inter / union
 
-
 def _shift(b: BBox, dx: float, dy: float) -> BBox:
     x, y, w, h = b
     return (x + dx, y + dy, w, h)
-
 
 def _scale(b: BBox, sx: float, sy: float) -> BBox:
     x, y, w, h = b
@@ -119,14 +102,11 @@ def _scale(b: BBox, sx: float, sy: float) -> BBox:
     nw, nh = max(1.0, w * sx), max(1.0, h * sy)
     return (cx - 0.5 * nw, cy - 0.5 * nh, nw, nh)
 
-
 def _aspect(b: BBox, factor: float) -> BBox:
-    # increase w, decrease h (or vice-versa) to change w/h
     x, y, w, h = b
     cx, cy = x + 0.5 * w, y + 0.5 * h
     nw, nh = max(1.0, w * factor), max(1.0, h / factor)
     return (cx - 0.5 * nw, cy - 0.5 * nh, nw, nh)
-
 
 def _paint_hsv(frame: np.ndarray, box: BBox, color_bgr=(0, 255, 255)) -> np.ndarray:
     x, y, w, h = [int(v) for v in box]
@@ -166,6 +146,7 @@ def _sanitize_for_init(box, shape):
     h = max(1.0, min(h, H - y))
     return (int(round(x)), int(round(y)), int(round(w)), int(round(h)))
 
+
 # -----------------------
 # the test
 # -----------------------
@@ -173,7 +154,6 @@ def _sanitize_for_init(box, shape):
 def test_detect_track_and_validate_then_break_each_rule():
     video = _video_path()
 
-    # Load YOLOv5Face detector
     det_path = "models/detector/yolov5n_state_dict.pt"
     det_cfg  = "models/detector/yolov5n.yaml"
     device = "cuda" if (hasattr(cv2, "cuda") and cv2.cuda.getCudaEnabledDeviceCount() > 0) else "cpu"
@@ -198,10 +178,6 @@ def test_detect_track_and_validate_then_break_each_rule():
         box_xywh = to_xywh(b0, f0.shape)
         box_xywh = _sanitize_for_init(box_xywh, f0.shape)
 
-        # # Save visual debug
-        # _save_dbg("f0_det.png", _draw_box(f0, box_xywh, (0,255,0), "det(t)"))
-        # _save_dbg("f1_expect.png", _draw_box(f1, box_xywh, (255,255,0), "expected(t->t+1)"))
-
         tracker = FaceTracker(tracker_type="CSRT")
         tracker.init_trackers(np.ascontiguousarray(f0), [box_xywh], [1])
 
@@ -213,54 +189,56 @@ def test_detect_track_and_validate_then_break_each_rule():
 
         # 4) VALIDATE (should PASS on normal step)
         pass_params = ValidatorParams(
-            iou_thresh=0.4,       # modest
-            area_delta_max=0.6,   # modest
+            iou_thresh=0.4,
+            area_delta_max=0.6,
             asp_ratio_delta_max=0.6,
             v_max=0.9,
-            hsv_thresh=1.0,       # lenient appearance for natural changes
+            hsv_thresh=1.0,
         )
-        v_ok = TrackerValidator([f0, f1], first_frame_idx=first_idx, params=pass_params)
-        v_ok.set_baseline({1: b0}, first_idx)
-        assert v_ok.validate({1: b1_track}, first_idx + 1, verbose=True), "Normal track should pass validation."
+        v_ok = TrackerValidator(params=pass_params)
+
+        # Seed baseline via validate() on the first frame
+        assert v_ok.validate({1: b0}, current_frame=f0, frame_idx=first_idx) is True
+        assert v_ok.validate({1: b1_track}, current_frame=f1, frame_idx=first_idx + 1) is True
 
         # 5) BREAK EACH RULE (one-by-one)
 
         # -- IoU too low: shift bbox a lot (keep frame same)
         bad_iou_params = ValidatorParams(iou_thresh=0.7, hsv_thresh=1.0)
-        v_iou = TrackerValidator([f0, f1], first_frame_idx=first_idx, params=bad_iou_params)
-        v_iou.set_baseline({1: b0}, first_idx)
-        b1_iou = _shift(b0, dx=0.7 * b0[2], dy=0.0)  # shift ~70% of width
+        v_iou = TrackerValidator(params=bad_iou_params)
+        assert v_iou.validate({1: b0}, current_frame=f0, frame_idx=first_idx) is True
+        b1_iou = _shift(b0, dx=0.7 * b0[2], dy=0.0)
         assert _iou_xywh(b0, b1_iou) < 0.7
-        assert v_iou.validate({1: b1_iou}, first_idx + 1, verbose=True) is False
+        assert v_iou.validate({1: b1_iou}, current_frame=f1, frame_idx=first_idx + 1) is False
 
-        # -- Area change too large: zoom by +60% area
+        # -- Area change too large
         bad_area_params = ValidatorParams(area_delta_max=0.2, hsv_thresh=1.0)
-        v_area = TrackerValidator([f0, f1], first_frame_idx=first_idx, params=bad_area_params)
-        v_area.set_baseline({1: b0}, first_idx)
-        b1_area = _scale(b0, sx=1.6, sy=1.6)  # ~+156% area; |Δ|/A0 ~ 0.56
-        assert v_area.validate({1: b1_area}, first_idx + 1, verbose=True) is False
+        v_area = TrackerValidator(params=bad_area_params)
+        assert v_area.validate({1: b0}, current_frame=f0, frame_idx=first_idx) is True
+        b1_area = _scale(b0, sx=1.6, sy=1.6)
+        assert v_area.validate({1: b1_area}, current_frame=f1, frame_idx=first_idx + 1) is False
 
         # -- Aspect ratio change too large
         bad_ar_params = ValidatorParams(asp_ratio_delta_max=0.2, hsv_thresh=1.0)
-        v_ar = TrackerValidator([f0, f1], first_frame_idx=first_idx, params=bad_ar_params)
-        v_ar.set_baseline({1: b0}, first_idx)
+        v_ar = TrackerValidator(params=bad_ar_params)
+        assert v_ar.validate({1: b0}, current_frame=f0, frame_idx=first_idx) is True
         b1_ar = _aspect(b0, factor=1.8)
-        assert v_ar.validate({1: b1_ar}, first_idx + 1, verbose=True) is False
+        assert v_ar.validate({1: b1_ar}, current_frame=f1, frame_idx=first_idx + 1) is False
 
-        # -- Velocity too high: big center jump vs previous diagonal
+        # -- Velocity too high
         bad_vel_params = ValidatorParams(v_max=0.3, hsv_thresh=1.0)
-        v_vel = TrackerValidator([f0, f1], first_frame_idx=first_idx, params=bad_vel_params)
-        v_vel.set_baseline({1: b0}, first_idx)
+        v_vel = TrackerValidator(params=bad_vel_params)
+        assert v_vel.validate({1: b0}, current_frame=f0, frame_idx=first_idx) is True
         diag = (b0[2] ** 2 + b0[3] ** 2) ** 0.5
-        b1_vel = _shift(b0, dx=0.9 * diag, dy=0.0)  # center shift ~0.9*diag
-        assert v_vel.validate({1: b1_vel}, first_idx + 1, verbose=True) is False
+        b1_vel = _shift(b0, dx=0.9 * diag, dy=0.0)
+        assert v_vel.validate({1: b1_vel}, current_frame=f1, frame_idx=first_idx + 1) is False
 
         # -- Appearance (HSV) change: paint inside bbox on frame t+1 but keep geometry
-        bad_app_params = ValidatorParams(iou_thresh=0.4, hsv_thresh=0.05)  # strict appearance
+        bad_app_params = ValidatorParams(iou_thresh=0.4, hsv_thresh=0.05)
         f1_painted = _paint_hsv(f1, b0, color_bgr=(0, 255, 255))
-        v_app = TrackerValidator([f0, f1_painted], first_frame_idx=first_idx, params=bad_app_params)
-        v_app.set_baseline({1: b0}, first_idx)
-        assert v_app.validate({1: b1_track}, first_idx + 1, verbose=True) is False
+        v_app = TrackerValidator(params=bad_app_params)
+        assert v_app.validate({1: b0}, current_frame=f0, frame_idx=first_idx) is True
+        assert v_app.validate({1: b1_track}, current_frame=f1_painted, frame_idx=first_idx + 1) is False
 
     finally:
         cap.release()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -21,14 +21,17 @@ def test_single_observation_creates_one_track():
     assert len(tracks) == 1
     assert tracks[0].get_frame_indices() == [0]
 
-def test_same_face_across_multiple_frames():
+def test_preassigned_track_id_extends_existing_track():
     aggregator = ShotFaceTrackAggregator(shot_number=1)
-    obs1 = make_obs(0, (10, 10, 50, 50))
-    obs2 = make_obs(1, (11, 11, 51, 51))
-    aggregator.update_tracks_with_frame(0, [obs1])
-    aggregator.update_tracks_with_frame(1, [obs2])
+    # frame 0 creates track 0
+    aggregator.update_tracks_with_frame(0, [make_obs(0, (10,10,50,50))])
+    # frame 1: caller explicitly assigns to track 0
+    obs = make_obs(1, (11,11,51,51))
+    obs.track_id = 0
+    aggregator.update_tracks_with_frame(1, [obs])
     tracks = aggregator.finalize_tracks()
     assert len(tracks) == 1
+    assert tracks[0].track_id == 0
     assert tracks[0].get_frame_indices() == [0, 1]
 
 def test_different_faces_create_different_tracks():
@@ -51,19 +54,17 @@ def test_multiple_faces_same_frame():
     assert len(tracks) == 2
     assert all([track.get_frame_indices() == [0] for track in tracks])
 
-def test_track_extension_and_creation():
+def test_preassigned_and_unassigned_create_and_extend():
     aggregator = ShotFaceTrackAggregator(shot_number=1)
-    obs1 = make_obs(0, (10, 10, 50, 50))
-    obs2 = make_obs(1, (11, 11, 51, 51))  # Should match obs1
-    obs3 = make_obs(1, (100, 100, 140, 140))  # New face
-
-    aggregator.update_tracks_with_frame(0, [obs1])
-    aggregator.update_tracks_with_frame(1, [obs2, obs3])
-
+    aggregator.update_tracks_with_frame(0, [make_obs(0, (10,10,50,50))])  # creates tid=0
+    obs_extend = make_obs(1, (11,11,51,51))
+    obs_extend.track_id = 0  # caller assigns
+    obs_new = make_obs(1, (100,100,140,140))  # caller leaves unassigned => new track
+    aggregator.update_tracks_with_frame(1, [obs_extend, obs_new])
     tracks = aggregator.finalize_tracks()
     assert len(tracks) == 2
-    lengths = sorted(len(track.observations) for track in tracks)
-    assert lengths == [1, 2]
+    lens = sorted(len(t.observations) for t in tracks)
+    assert lens == [1, 2]
 
 def test_get_tracks_in_frame():
     aggregator = ShotFaceTrackAggregator(shot_number=1)

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -27,10 +27,26 @@ class RecordingEmb(RecordingObs): pass
 class DummyTrack:
     def __init__(self, tid, bbox, last_f, last_det, closed, shot_id=6):
         self.track_id = int(tid)
+        self.shot_id = int(shot_id)
+
         self.last_bbox = tuple(int(v) for v in bbox[:4])
         self.last_frame_idx = int(last_f)
         self.last_det_frame_idx = int(last_det)
         self.closed = bool(closed)
+
+    # ---- TrackLike / checkpoint contract (method-based) ----
+    def last_frame(self) -> int:
+        return int(self.last_frame_idx)
+
+    def last_det_frame(self) -> Optional[int]:
+        # In your tests you always provide last_det, but keep this safe.
+        return None if self.last_det_frame_idx is None else int(self.last_det_frame_idx)
+
+    def get_last_bbox(self) -> Optional[Tuple[int, int, int, int]]:
+        return None if self.last_bbox is None else tuple(self.last_bbox)
+
+    def is_closed(self) -> bool:
+        return bool(self.closed)
 
 class DummyAggregator:
     def __init__(self, tracks=None, shot_number=6):

--- a/tests/test_cli_manifest.py
+++ b/tests/test_cli_manifest.py
@@ -1,0 +1,285 @@
+# tests/integration/test_resolve_cli_trackless_shots_v21.py
+
+from types import SimpleNamespace
+from pathlib import Path
+import json
+
+import pytest
+
+from facekit.common.obs_consts import Source
+from facekit.tracking.face_structures import FaceTrack, FaceObservation
+import facekit.cli.resolve_face_ids_v2_cli as cli
+
+
+def test_cli_v2_1_manifest_includes_trackless_shots_with_full_coverage(tmp_path: Path, monkeypatch):
+    """
+    Integration-style test for resolve_face_ids_v2_cli.run_pipeline().
+
+    Shot segmentation defines 4 shots:
+      shot 1: faces present
+      shot 2: graphics-only, no faces
+      shot 3: faces present
+      shot 4: graphics-only, no faces (tail coverage)
+
+    We stub track_across_segments.track_across_segments() to return tracks
+    only for shots 1 and 3.
+
+    Desired behavior:
+      - manifest["shots"] contains shot_numbers [1, 2, 3, 4]
+      - each shot has correct (first_frame, last_frame)
+      - coverage is continuous from 0 to total_frames - 1
+    """
+
+
+    # ------------------------------
+    # 1) Shot segmentation with 4 shots
+    # ------------------------------
+    # total_frames = 300 => last frame index = 299
+    total_frames = 300
+    shot_defs = [
+        {"shot_number": 1, "first_frame": 0,   "last_frame": 99},
+        {"shot_number": 2, "first_frame": 100, "last_frame": 199},  # graphics-only
+        {"shot_number": 3, "first_frame": 200, "last_frame": 249},
+        {"shot_number": 4, "first_frame": 250, "last_frame": 299},  # graphics-only tail
+    ]
+    shot_json_path = tmp_path / "shots.json"
+    shot_json_path.write_text(json.dumps({"shots": shot_defs}), encoding="utf-8")
+
+    # ------------------------------
+    # 2) Fake video file
+    # ------------------------------
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"FAKE")
+
+    # ------------------------------
+    # 3) Fake ReaderCoordinator -> FrameProvider
+    # ------------------------------
+    class FakeReader:
+        def __init__(self, path: str):
+            self._fps = 30.0
+            self._size = (1920, 1080)
+            self._total_frames = total_frames
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def fps(self):
+            return self._fps
+
+        def size(self):
+            return self._size
+
+        def total_frames(self):
+            return self._total_frames
+
+        # Interface required by track_across_segments
+        def reset_to_frame(self, idx: int):
+            pass
+
+        def next(self):
+            return None
+
+    monkeypatch.setattr(cli, "ReaderCoordinator", FakeReader)
+
+    # ------------------------------
+    # 4) Detector / embedder stubs
+    # ------------------------------
+    def fake_load_yolo5face_model(detector_model, config, device=None):
+        class DummyYOLO:
+            pass
+        return DummyYOLO()
+
+    class FakeEmbedder:
+        def __init__(self, model_path, device="cpu"):
+            self.model_name = "fake-embedder"
+
+        def set_max_batch_size(self, n: int):
+            pass
+
+    monkeypatch.setattr(cli, "load_yolo5face_model", fake_load_yolo5face_model)
+    monkeypatch.setattr(cli, "FaceEmbedder", FakeEmbedder)
+
+    # ------------------------------
+    # 5) CheckpointManager stub
+    # ------------------------------
+    class FakeCheckpoint:
+        def __init__(self, root: Path):
+            self.root = root
+            self.resume_enabled = False  # treat as cold start
+
+        def read_status(self):
+            return {}
+
+        def validate_resume_or_raise(self, *a, **k):
+            pass
+
+        def start(self, *a, **k):
+            pass
+
+        def rehydrate_runtime(self, *a, **k):
+            return {
+                "anchor_frame": 0,
+                "anchor_shot": None,
+                "anchor_shot_first_frame": None,
+                "track_order_entries": 0,
+            }
+
+        def finalize(self):
+            pass
+
+        def copy_ckpt_sidecars_to_final(self, **kwargs):
+            pass
+
+        def mark_completed(self):
+            pass
+
+    class FakeCheckpointManager:
+        @staticmethod
+        def open(parent_dir, video_path, options_snapshot, no_resume, force_new_run, run_id, resume_latest):
+            return FakeCheckpoint(parent_dir / "fake-run")
+
+    monkeypatch.setattr(cli, "CheckpointManager", FakeCheckpointManager)
+
+    # ------------------------------
+    # 6) track_across_segments stub
+    #    -> tracks only for shots 1 and 3
+    # ------------------------------
+    def fake_track_across_segments(
+        frame_source,
+        shot_json_path: str,
+        detector,
+        embedder,
+        iou_thresh=0.5,
+        embedding_thresh=0.7,
+        detect_interval=10,
+        embedding_batch_size_max=32,
+        checkpoint=None,
+        resume_enabled=True,
+    ):
+        tracks: list[FaceTrack] = []
+
+        # Shot 1 track
+        obs1 = [
+            FaceObservation(
+                frame_idx=0,
+                source=Source.DETECTED,
+                bbox=(10, 10, 50, 50),
+                confidence=0.9,
+            )
+        ]
+        tracks.append(
+            FaceTrack(
+                shot_id=1,
+                track_id=0,
+                observations=obs1,
+                segment_id=0,
+                global_id=0,
+            )
+        )
+
+        # Shot 3 track
+        obs3 = [
+            FaceObservation(
+                frame_idx=220,  # inside shot 3 range [200,249]
+                source=Source.DETECTED,
+                bbox=(20, 20, 60, 60),
+                confidence=0.8,
+            )
+        ]
+        tracks.append(
+            FaceTrack(
+                shot_id=3,
+                track_id=0,
+                observations=obs3,
+                segment_id=0,
+                global_id=1,
+            )
+        )
+
+        return tracks
+
+    monkeypatch.setattr(cli.track_across_segments, "track_across_segments", fake_track_across_segments)
+
+    # ------------------------------
+    # 7) validate_manifest stub: always OK
+    # ------------------------------
+    def fake_validate_manifest(json_path, schema_version, total_frame_count, schema_dir=None):
+        return []
+
+    monkeypatch.setattr(cli, "validate_manifest", fake_validate_manifest)
+
+    # ------------------------------
+    # 8) Capture manifest passed to write_v2_json
+    # ------------------------------
+    captured: dict = {}
+
+    def fake_write_v2_json(path: str, manifest: dict):
+        captured["path"] = path
+        captured["manifest"] = manifest
+
+    monkeypatch.setattr(cli, "write_v2_json", fake_write_v2_json)
+
+    # ------------------------------
+    # 9) Build args and run pipeline
+    # ------------------------------
+    args = SimpleNamespace(
+        input=str(video_path),
+        detector_model="dummy-detector.pt",
+        embedding_model="dummy-emb.onnx",
+        config="dummy-config.yaml",
+        shot_segmentation=str(shot_json_path),
+        schema_version="2.1",
+        schema_dir=None,
+        output_segment_json=None,
+        output_global_json=True,             # trigger JSON manifest write
+        output_video=None,
+        detect_interval=30,
+        post_min_gap_len=210,
+        post_min_track_len=70,
+        post_iou_threshold=0.2,
+        embedding_batch_size_max=32,
+        device="cpu",
+        emb_store="sidecar",
+        emb_sidecar_path=None,
+        obs_sidecar_path=None,
+        checkpoint_dir=str(tmp_path / "ckpt"),
+        no_resume=True,
+        force=False,
+        resume_latest=False,
+        checkpoint_run_id=None,
+        new_run=False,
+        log="INFO",
+        log_file=None,
+    )
+
+    cli.run_pipeline(args)
+
+    # ------------------------------
+    # 10) Assertions on manifest.shots
+    # ------------------------------
+    assert "manifest" in captured, "write_v2_json was never called"
+    manifest = captured["manifest"]
+
+    shots = manifest.get("shots", [])
+    shot_nums = [s["shot_number"] for s in shots]
+
+    # Desired shot list: all 4 shots (including 2 & 4 with no faces)
+    assert shot_nums == [1, 2, 3, 4]
+
+    # Expected coverage per shot
+    expected_ranges = {
+        1: (0, 99),
+        2: (100, 199),
+        3: (200, 249),
+        4: (250, 299),
+    }
+    actual_ranges = {
+        s["shot_number"]: (int(s["first_frame"]), int(s["last_frame"]))
+        for s in shots
+    }
+
+    assert actual_ranges == expected_ranges
+

--- a/tests/test_cli_v20_and_v21_output_names.py
+++ b/tests/test_cli_v20_and_v21_output_names.py
@@ -6,7 +6,7 @@ import types
 
 from facekit.cli import resolve_face_ids_v2_cli as cli
 from facekit.common.obs_consts import Source
-from facekit.tracking.face_structures import FaceObservation
+from facekit.tracking.face_structures import FaceObservation, FaceTrack
 
 @pytest.mark.parametrize("ver,expected_suffix", [("2.0","_v2.json"), ("2.1","_v2_1.json")])
 def test_default_output_names(monkeypatch, tmp_path, ver, expected_suffix):
@@ -49,7 +49,9 @@ def test_default_output_names(monkeypatch, tmp_path, ver, expected_suffix):
         def last_frame(self): 
             return 1
     def fake_track_across_segments(**kw):
-        return [_Track()]    
+        obs = [_Obs(0), _Obs(1)]
+        t = FaceTrack(shot_id=1, track_id=1, observations=obs, segment_id=0, global_id=0)
+        return [t]
     def fake_load_model(*a, **k): return _Det()
     def fake_generate_shot_features_json(**kw):
         Path(kw["output_json_path"]).write_text(

--- a/tests/test_observations_iter_tracks_contract.py
+++ b/tests/test_observations_iter_tracks_contract.py
@@ -1,12 +1,16 @@
 from facekit.output.json_v2 import ObservationsCollector
 from facekit.common.obs_consts import Source
 
+def _landmarks(x: float):
+    # 5-point landmarks, shape (5,2) as list-of-tuples
+    return [(float(x), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]
+
 def test_iter_tracks_groups_orders_and_filters_by_frame_max():
     oc = ObservationsCollector()
     oc.append_track_obs([
-        {"shot":1,"track_id":7,"f":5,"bbox_xyxy":[0,0,10,10],"src":Source.DETECTED},
+        {"shot":1,"track_id":7,"f":5,"bbox_xyxy":[0,0,10,10],"src":Source.DETECTED, "landmarks": _landmarks(5)},
         {"shot":1,"track_id":7,"f":9,"bbox_xyxy":[1,1,11,11],"src":Source.TRACKED},
-        {"shot":1,"track_id":7,"f":12,"bbox_xyxy":[2,2,12,12],"src":Source.DETECTED},
+        {"shot":1,"track_id":7,"f":12,"bbox_xyxy":[2,2,12,12],"src":Source.DETECTED, "landmarks": _landmarks(5)},
     ], emb_idx_fn=lambda _: -1)
 
     groups_all = list(oc.iter_tracks(frame_max=None))

--- a/tests/test_resume_anchor_persistence.py
+++ b/tests/test_resume_anchor_persistence.py
@@ -1,3 +1,5 @@
+# tests/test_resume_anchor_persistence.py
+
 from pathlib import Path
 import json
 import numpy as np
@@ -7,7 +9,8 @@ from facekit.pipeline.track_across_segments import track_across_segments
 from facekit.pipeline.checkpoint import CheckpointManager
 from facekit.output.json_v2 import ObservationsCollector, EmbeddingCollector
 from facekit.tracking import aggregator as _agg
-from facekit.common.obs_consts import Source
+from facekit.common.obs_consts import Source, src_to_code
+
 
 def _write_shots(path: Path, first: int, last: int, per_shot: int = None):
     if per_shot is None:
@@ -20,13 +23,21 @@ def _write_shots(path: Path, first: int, last: int, per_shot: int = None):
             s, sn = e + 1, sn + 1
     path.write_text(json.dumps({"shots": shots}))
 
+
 class DummyDetector:
+    def __init__(self):
+        self.calls = 0
+
     def detect_faces_in_frame(self, frame):
-        return ([(0, 0, 10, 10)], [[(0,0)]*5], [0.9])
+        self.calls += 1
+        x = float(self.calls)  # frame_idx+1 in this SpyFP setup
+        return ([(0, 0, 10, 10)], [[(x, 0.0)] + [(0.0, 0.0)] * 4], [0.9])
+
 
 class DummyEmbedder:
     def get_embedding_batch(self, crops, batch_size=32):
         return np.ones((len(crops), 512), dtype=np.float32)
+
 
 class SpyFP:
     def __init__(self, total=400, w=64, h=48, fps=30.0):
@@ -38,16 +49,21 @@ class SpyFP:
         self.reset_calls = []
         self.ops: list[tuple[str, int]] = []
         self.first_next_idx = None
+
     @property
     def fps(self): return self._fps
+
     @property
     def size(self): return (self._w, self._h)
+
     @property
     def total_frames(self): return self._total
+
     def reset_to_frame(self, i):
         self._idx = int(i)
         self.reset_calls.append(self._idx)
         self.ops.append(("reset", self._idx))
+
     def next(self):
         if self.first_next_idx is None:
             self.first_next_idx = self._idx
@@ -56,6 +72,7 @@ class SpyFP:
             return None
         self._idx += 1
         return self._blank
+
     def first_next_after_anchor_seek(self, anchor: int) -> int | None:
         """
         Return the frame index of the first `next()` *after* we have sought to the anchor.
@@ -73,22 +90,34 @@ class SpyFP:
                 return val
         return None
 
+
 def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, monkeypatch):
     # shots: [0..119], [120..239], [240..359]
     shots = tmp_path / "shots.json"
     _write_shots(shots, 0, 359, per_shot=120)
 
-    parent = tmp_path / "ck"; parent.mkdir()
-    vid = tmp_path / "dummy.mp4"; vid.write_text("x")
+    parent = tmp_path / "ck"
+    parent.mkdir()
+    vid = tmp_path / "dummy.mp4"
+    vid.write_text("x")
 
     opts = {
-        "schema_version": "2.1", "video_path": str(vid),
-        "detect_interval": 60, "embedding_batch_size_max": 8, "device": "cpu",
-        "emb_store": "sidecar", "emb_sidecar_path": None, "obs_sidecar_path": None,
-        "detector_model_path": "x", "embedding_model_path": "y", "yolo_config_path": "z",
-        "shot_segmentation_path": str(shots), "log_level": "INFO", "log_file": None,
+        "schema_version": "2.1",
+        "video_path": str(vid),
+        "detect_interval": 60,
+        "embedding_batch_size_max": 8,
+        "device": "cpu",
+        "emb_store": "sidecar",
+        "emb_sidecar_path": None,
+        "obs_sidecar_path": None,
+        "detector_model_path": "x",
+        "embedding_model_path": "y",
+        "yolo_config_path": "z",
+        "shot_segmentation_path": str(shots),
+        "log_level": "INFO",
+        "log_file": None,
     }
-    
+
     ckpt = CheckpointManager.open(
         parent_dir=parent,
         video_path=vid,
@@ -110,28 +139,39 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
     ckpt._last_det_shot = 2
     ckpt._last_det_shot_first_frame = 120
 
-    # Seed one pre-anchor obs to exercise rehydrate
+    # Seed pre-anchor obs in shot 2 (frames 100, 150) with landmarks.
     oc.append_track_obs(
-        [{
-            "shot": 2,
-            "track_id": 1,
-            "f": 100,
-            "bbox_xyxy": [10, 10, 50, 50],
-            "src": Source.DETECTED,
-            "conf": 0.9,
-            "crop_ref": "crops/shot2/frame100_tid1.png",
-        },
-        {
-            "shot": 2,
-            "track_id": 1,
-            "f": 150,
-            "bbox_xyxy": [0, 0, 10, 10],
-            "src": Source.DETECTED,
-            "crop_ref": "crops/shot2/frame150_tid1.png",  # dummy path is fine
-        }],
+        [
+            {
+                "shot": 2,
+                "track_id": 1,
+                "f": 100,
+                "bbox_xyxy": [10, 10, 50, 50],
+                "src": Source.DETECTED,
+                "conf": 0.9,
+                "has_landmarks": 1,
+                "landmarks": np.asarray(
+                    [[101.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            },
+            {
+                "shot": 2,
+                "track_id": 1,
+                "f": 150,
+                "bbox_xyxy": [0, 0, 10, 10],
+                "src": Source.DETECTED,
+                "has_landmarks": 1,
+                "landmarks": np.asarray(
+                    [[151.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            },
+        ],
         emb_idx_fn=lambda _: -1,
     )
 
+    # --- flatten find_rows: convert (block_idx,row_idx) -> row_idx (expecting single block 0)
     orig_find_rows = oc.find_rows
 
     def _flat_find_rows(*args, **kwargs):
@@ -142,23 +182,21 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
                 if len(pos) != 2:
                     raise TypeError(f"unexpected find_rows position tuple: {pos!r}")
                 block_idx, row_idx = pos
-                # Current collector should only use a single block 0; assert to catch surprises.
                 assert int(block_idx) == 0, f"unexpected block index from find_rows: {pos!r}"
                 flat.append(int(row_idx))
             else:
                 flat.append(int(pos))
         return flat
 
-    oc.find_rows = _flat_find_rows
+    oc.find_rows = _flat_find_rows  # type: ignore[attr-defined]
 
-    # This now uses the live EmbeddingCollector wired in via start()
+    # Add embeddings for those two DETECTED frames.
     ckpt.add_embeddings(
         shot_number=2,
         track_id=1,
         frame_idx_last=100,
         embs=np.ones((1, 512), dtype=np.float32),
     )
-
     ckpt.add_embeddings(
         shot_number=2,
         track_id=1,
@@ -193,9 +231,33 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
     frames = ckpt.get_det_frames_for_track(2, 1, frame_max=anchor - 1)
     assert frames == [100, 150], f"Unexpected det frames: {frames}"
 
+    # --- Find DETECTED rows (NOTE: find_rows expects int code for `source`)
+    det_code = int(src_to_code(Source.DETECTED.value))
+    pos = oc.find_rows(
+        shot=2,
+        track_id=1,
+        frame_last=anchor - 1,
+        source=det_code,
+        only_with_landmarks=True,
+    )
+    # orig_find_rows returns newest->oldest; our frames list is ascending
+    # so align by sorting positions by frame.
+    # Since we forced single block 0, we can read frame from oc._rows[0][row_idx]["f"].
+    pos_sorted = sorted(pos, key=lambda ridx: int(oc._rows[0][int(ridx)]["f"]))  # type: ignore[attr-defined]
+    assert [int(oc._rows[0][int(ridx)]["f"]) for ridx in pos_sorted] == frames  # type: ignore[attr-defined]
+
+    # Validate landmarks via structured fields: has_landmarks + landmarks_flat10
+    # landmarks_flat10 = [x1,y1,x2,y2,...] in ArcFace order; we seeded x1=f+1, y1=0.
+    for row_idx, f in zip(pos_sorted, frames):
+        row = oc._rows[0][int(row_idx)]  # structured row  (single block 0)
+        assert int(row["has_landmarks"]) == 1
+        lm = row["landmarks_flat10"]
+        assert float(lm[0]) == float(f + 1), f"bad landmark x1 for frame {f}: {float(lm[0])}"
+        assert float(lm[1]) == 0.0, f"bad landmark y1 for frame {f}: {float(lm[1])}"
+
     embs = ckpt.get_embeddings_by_frames(2, frames)
     assert embs is not None, "No embeddings returned for seeded frames"
-    assert embs.shape[0] == 2 and embs.shape[1] == 512, f"Bad emb shape: {getattr(embs, 'shape', None)}"
+    assert embs.shape == (2, 512), f"Bad emb shape: {getattr(embs, 'shape', None)}"
 
     fp = SpyFP(total=400)
     _ = track_across_segments(
@@ -206,11 +268,12 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
         checkpoint=ckpt,
     )
 
-    # A) We must actually start the *main loop* at the anchor frame.
-    # Allow pre-anchor backfill, but the first next() after resetting to the anchor must be >= anchor.
+    # A) Must start the main loop at the anchor frame.
     first_after_seek = fp.first_next_after_anchor_seek(anchor)
     assert first_after_seek is not None, "did not observe a next() after seeking to the anchor"
-    assert first_after_seek >= anchor, f"first processed frame after anchor-seek {first_after_seek} < anchor {anchor}"
+    assert first_after_seek >= anchor, (
+        f"first processed frame after anchor-seek {first_after_seek} < anchor {anchor}"
+    )
 
     # B1) NEVER persist observations < anchor
     for (_shot, f) in add_obs_calls:
@@ -221,13 +284,14 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
     #  - forbidden: any embeddings for shots strictly before the anchor shot
     with open(shots, "r") as f:
         _data = json.load(f)
+
     def _shot_of(frame):
         for s in _data["shots"]:
             if s["first_frame"] <= frame <= s["last_frame"]:
                 return s["shot_number"]
         return None
+
     anchor_shot = _shot_of(anchor)
-    # shots strictly before the anchor are those with last_frame < anchor
     pre_anchor_shots = {s["shot_number"] for s in _data["shots"] if s["last_frame"] < anchor}
 
     for (shot_num, _tid, last_idx) in add_emb_calls:
@@ -236,7 +300,6 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
                 f"persisted embeddings for pre-anchor frame {last_idx} in non-anchor shot {shot_num} "
                 f"(anchor shot is {anchor_shot})"
             )
-        # also ensure we never embed for shots strictly before anchor
         assert shot_num not in pre_anchor_shots, (
             f"persisted embeddings for shot {shot_num} which is strictly before anchor (anchor={anchor})"
         )

--- a/tests/test_resume_anchor_seek.py
+++ b/tests/test_resume_anchor_seek.py
@@ -22,12 +22,16 @@ def _write_shots(path: Path, first: int, last: int, per_shot: int = None):
             s, sn = e + 1, sn + 1
     path.write_text(json.dumps({"shots": shots}))
 
-
 class DummyDetector:
+    def __init__(self):
+        self.calls = 0
+
     def detect_faces_in_frame(self, frame):
         # Return a single fake detection every time: (boxes, landmarks, confidences)
-        return ([(0, 0, 10, 10)], [[(0, 0)] * 5], [0.9])
-
+        # Encode a non-constant value in landmarks[0][0] so tests can sanity-check it.
+        self.calls += 1
+        x = float(self.calls)  # deterministic, non-constant across calls
+        return ([(0, 0, 10, 10)], [[(x, 0.0)] + [(0.0, 0.0)] * 4], [0.9])
 
 class DummyEmbedder:
     def get_embedding_batch(self, crops, batch_size=32):
@@ -122,14 +126,20 @@ def _seed_preanchor_run(
     # Seed one pre-anchor DET obs in the anchor shot to exercise rehydrate.
     # This mirrors what track_across_segments would have persisted before crash.
     oc.append_track_obs(
-        [{
-            "shot": anchor_shot,
-            "track_id": 1,
-            "f": 150,
-            "bbox_xyxy": [0, 0, 10, 10],
-            "src": "detected",
-            "crop_ref": "crops/shot2/frame150_tid1.png",  # dummy path is fine
-        }],
+        [
+            {
+                "shot": anchor_shot,
+                "track_id": 1,
+                "f": 150,
+                "bbox_xyxy": [0, 0, 10, 10],
+                "src": "detected",
+                "has_landmarks": 1,
+                "landmarks": np.asarray(
+                    [[151.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            }
+        ],
         emb_idx_fn=lambda _: -1,  # no embedding index yet; will be filled via add_embeddings
     )
 
@@ -143,6 +153,31 @@ def _seed_preanchor_run(
 
     # Finalize to actually write obs_ckpt.npz / emb_ckpt.npz to disk.
     ckpt.finalize()
+
+    # ---- Sanity-check the seeded landmarks are present and not defaulted ----
+    # We seeded a single DET row at f=150 with landmarks[0][0] == 151.0.
+    pos = oc.find_rows(shot=anchor_shot, track_id=1, frame_last=150, count=1)
+    assert pos, "expected to find the seeded observation row"
+
+    # Handle both (block,row) and flat row_idx returns.
+    p0 = pos[-1]
+    row_idx = int(p0[1]) if (isinstance(p0, tuple) and len(p0) == 2) else int(p0)
+
+    # Access the structured row via (block_idx,row_idx) or assume single block 0.
+    if isinstance(p0, tuple) and len(p0) == 2:
+        b_idx, r_idx = int(p0[0]), int(p0[1])
+    else:
+        b_idx, r_idx = 0, int(p0)
+
+    assert hasattr(oc, "_rows"), "ObservationsCollector missing _rows; update accessor"
+    row = oc._rows[b_idx][r_idx]
+
+    # Validate landmarks using the persisted fields
+    assert int(row["has_landmarks"]) == 1, "seeded row missing landmarks flag"
+    lm10 = row["landmarks_flat10"]
+    # We seeded x1=151.0, y1=0.0
+    assert float(lm10[0]) == 151.0, f"expected landmarks_flat10[0]==151.0, got {float(lm10[0])}"
+    assert float(lm10[1]) == 0.0, f"expected landmarks_flat10[1]==0.0, got {float(lm10[1])}"
 
     # Now patch status.json to reflect the anchor and a minimal track_order,
     # mimicking a partially-complete but structurally valid status file.
@@ -273,7 +308,6 @@ def test_resume_starts_at_anchor_abs_frame(tmp_path: Path, monkeypatch):
         assert f >= anchor, f"persisted observations for pre-anchor frame {f} < {anchor}"
 
     # Embeddings ARE allowed for pre-anchor DET frames in the anchor-containing shot
-    # (backfill crops -> embed at shot end). They must NOT be from earlier shots.
     for (shotnum, _tid, last_idx, _embs) in add_emb_calls:
         # must be for the anchor shot
         assert shotnum == anchor_shot, f"unexpected embeddings for non-anchor shot {shotnum}"

--- a/tests/test_resume_end_to_end_ckpt_v21.py
+++ b/tests/test_resume_end_to_end_ckpt_v21.py
@@ -13,6 +13,7 @@ from facekit.output.json_v2 import (
 )
 from facekit.pipeline.track_across_segments import track_across_segments
 from facekit.io.frame_provider import ReaderCoordinator
+from facekit.common.obs_consts import Source, src_to_code
 
 @dataclass
 class SimpleObs:
@@ -63,9 +64,9 @@ class NoCrashDetector(CrashAfterNDetections):
         super().__init__(crash_at=None)
 
 class DummyEmbedder:
-    """Return (K,512) zeros float32 for any K crops."""
-    def get_embedding_batch(self, crops, batch_size=32):
-        K = len(crops or [])
+    """Return (K,512) zeros float32 for any K aligned faces."""
+    def get_embedding_batch(self, aligned_faces, batch_size=32):
+        K = len(aligned_faces or [])
         return np.zeros((K, 512), dtype=np.float32)
 
 # --- Shot JSON helper -------------------------------------------------------
@@ -218,17 +219,51 @@ def test_resume_reconstructs_prior_tracks_and_writes_v21_sidecar(tmp_path: Path)
 
 def test_iter_tracks_filters_and_groups(tmp_path: Path):
     oc = ObservationsCollector()
-    # 3 rows: two before 10, one after
+
+    # Minimal valid 5x2 landmarks for DETECTED rows
+    def lm(x: float):
+        return np.asarray(
+            [[x, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+            dtype=np.float32,
+        )
+
     rows = [
-        {"shot":1,"track_id":7,"f":5,"bbox_xyxy":[0,0,10,10],"src":"detected"},
-        {"shot":1,"track_id":7,"f":9,"bbox_xyxy":[1,1,11,11],"src":"tracked"},
-        {"shot":1,"track_id":7,"f":12,"bbox_xyxy":[2,2,12,12],"src":"detected"},
+        # DETECTED rows MUST have landmarks under the new contract
+        {
+            "shot": 1,
+            "track_id": 7,
+            "f": 5,
+            "bbox_xyxy": [0, 0, 10, 10],
+            "src": int(src_to_code(Source.DETECTED.value)),
+            "has_landmarks": 1,
+            "landmarks": lm(5.0),
+        },
+        # TRACKED row: landmarks optional
+        {
+            "shot": 1,
+            "track_id": 7,
+            "f": 9,
+            "bbox_xyxy": [1, 1, 11, 11],
+            "src": int(src_to_code(Source.TRACKED.value)),
+        },
+        {
+            "shot": 1,
+            "track_id": 7,
+            "f": 12,
+            "bbox_xyxy": [2, 2, 12, 12],
+            "src": int(src_to_code(Source.DETECTED.value)),
+            "has_landmarks": 1,
+            "landmarks": lm(12.0),
+        },
     ]
+
     oc.append_track_obs(rows, emb_idx_fn=lambda _: -1)
+
     groups_all = list(oc.iter_tracks(frame_max=None))
     groups_10 = list(oc.iter_tracks(frame_max=10))
-    assert len(groups_all) == 1 and groups_all[0][0:2] == (1,7)
-    assert [d["f"] for d in groups_10[0][2]] == [5,9]
+
+    assert len(groups_all) == 1 and groups_all[0][0:2] == (1, 7)
+    assert [d["f"] for d in groups_10[0][2]] == [5, 9]
 
 def test_embeddingcollector_get_many():
     ec = EmbeddingCollector(mode="sidecar", dim=4)
@@ -259,7 +294,8 @@ def test_resume_safety_video_mismatch_raises(tmp_path: Path):
         ("src", "i4"),
         ("conf", "f4"),
         ("emb_idx", "i4"),
-        ("has_crop", "i4"),
+        ("has_landmarks", "i4"),
+        ("landmarks", "f4", (10,)),
     ])
     np.savez(obs_sidecar, observations=np.zeros(0, dtype=obs_dtype))
 
@@ -323,7 +359,8 @@ def test_resume_safety_schema_mismatch_raises(tmp_path: Path):
         ("src", "i4"),
         ("conf", "f4"),
         ("emb_idx", "i4"),
-        ("has_crop", "i4"),
+        ("has_landmarks", "i4"),
+        ("landmarks", "f4", (10,)),
     ])
     np.savez(obs_sidecar, observations=np.zeros(0, dtype=obs_dtype))
     np.savez(emb_sidecar, embeddings=np.zeros((0, 512), dtype=np.float32))

--- a/tests/test_resume_hydration.py
+++ b/tests/test_resume_hydration.py
@@ -34,20 +34,31 @@ class DummyAggregator(ShotFaceTrackAggregatorProtocol):
         self.tracks = list(tracks or [])
 
 # ---------- helpers ----------
+def _lm5(f: int):
+    """
+    Produce a valid 5x2 landmark list for DETECTED rows.
+    Keep it deterministic and finite.
+    """
+    x = float(f + 1)
+    return [(x, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]
 
-def mk_obs_block(n, *, shot=3, track_id=7, f_start=0):
+
+def mk_obs_block(n, *, shot=3, track_id=7, f_start=0, src="detected"):
     """Produce n normalized obs dicts suitable for ObservationsCollector.append_track_obs."""
     rows = []
     for i in range(n):
         f = f_start + i
-        rows.append({
+        row = {
             "shot": int(shot),
             "track_id": int(track_id),
             "f": int(f),
             "bbox_xyxy": [10.0, 20.0, 30.0, 40.0],  # valid box
-            "src": "detected",                      # matches VALID_SOURCES / SRC_TO_CODE
+            "src": src,                              # "detected" or "tracked"
             "conf": 0.9,
-        })
+        }
+        if str(src).lower() == "detected":
+            row["landmarks"] = _lm5(f)
+        rows.append(row)
     return rows
 
 def write_status(path, **kw):

--- a/tests/test_resume_one_then_three_faces_consistency.py
+++ b/tests/test_resume_one_then_three_faces_consistency.py
@@ -1,34 +1,40 @@
+# tests/test_resume_one_then_three_faces_consistency.py
+
 import json
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
+
 import numpy as np
-import os
-import re
 import pytest
 
-from facekit.common.obs_consts import Source, SRC_TO_CODE
 
 # -------------------- helpers --------------------
 
 def _with_repo_env() -> dict:
-    repo_root = Path(__file__).resolve().parents[2]
-    existing = os.environ.get("PYTHONPATH", "")
-    combined = os.pathsep.join([str(repo_root), *(p for p in sys.path if p), existing]) if existing \
-               else os.pathsep.join([str(repo_root), *(p for p in sys.path if p)])
+    pkg_root = Path(__file__).resolve().parents[1]
     env = dict(os.environ)
-    env["PYTHONPATH"] = combined
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(pkg_root) + (os.pathsep + existing if existing else "")
     return env
 
+
 def _run_python(shim: Path, *args, ok=(0,), env=None, cwd=None):
-    cp = subprocess.run([sys.executable, str(shim), *args],
-                        text=True, capture_output=True, env=env,
-                        cwd=cwd or shim.parent)
+    cp = subprocess.run(
+        [sys.executable, str(shim), *args],
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=cwd or shim.parent,
+    )
     if cp.returncode not in ok:
         raise AssertionError(
             f"RC {cp.returncode} not in {ok}\n=== STDOUT ===\n{cp.stdout}\n=== STDERR ===\n{cp.stderr}\n"
         )
     return cp
+
 
 def _extract_anchor(stdout: str, stderr: str) -> int:
     txt = stdout + "\n" + stderr
@@ -36,473 +42,104 @@ def _extract_anchor(stdout: str, stderr: str) -> int:
     assert m, f"Could not parse anchor from logs:\n{txt}"
     return int(m.group(1))
 
-def _load_rows(npz_path: Path):
-    with np.load(npz_path) as data:
-        obs = data["observations"] if "observations" in data.files else None
-        if obs is None or obs.size == 0:
-            return {
-                "frame": np.array([], dtype=int),
-                "shot": np.array([], dtype=int),
-                "track": np.array([], dtype=int),
-                "x1": np.array([], dtype=np.float32),
-                "y1": np.array([], dtype=np.float32),
-                "x2": np.array([], dtype=np.float32),
-                "y2": np.array([], dtype=np.float32),
-                "src": np.array([], dtype=int),
-            }
-        f = obs["f"].astype(int, copy=False)
-        s = obs["shot"].astype(int, copy=False)
-        t = obs["track_id"].astype(int, copy=False)
-        bb = obs["bbox_xyxy"].astype(np.float32, copy=False)
-        return {
-            "frame": f,
-            "shot":  s,
-            "track": t,
-            "x1": bb[:,0], "y1": bb[:,1], "x2": bb[:,2], "y2": bb[:,3],
-            "src": obs["src"].astype(int, copy=False),
-        }
-    
-def _assert_sidecar_src_int_codes(npz_path: Path):
-    """
-    Policy check: obs sidecar must store src as integer codes only,
-    using the same codes as SRC_TO_CODE.
-    """
+
+def _load_obs_npz(npz_path: Path) -> np.ndarray:
     with np.load(npz_path, allow_pickle=False) as data:
-        assert "observations" in data.files, "sidecar missing 'observations' array"
-        arr = data["observations"]
-        assert "src" in arr.dtype.names, "sidecar 'observations' has no 'src' field"
+        assert "observations" in data.files, f"sidecar missing observations: {npz_path}"
+        return data["observations"]
 
-        # 1) dtype must be integer
-        assert np.issubdtype(
-            arr["src"].dtype, np.integer
-        ), f"expected integer src dtype, got {arr['src'].dtype}"
 
-        # 2) values must be one of our known codes
-        allowed_codes = {int(v) for v in SRC_TO_CODE.values()}
-        vals = {int(x) for x in np.unique(arr["src"])}
-        unexpected = vals - allowed_codes
-        assert not unexpected, (
-            f"unexpected src codes in sidecar: {sorted(unexpected)}; "
-            f"allowed={sorted(allowed_codes)}"
-        )
+def _load_emb_npz(npz_path: Path) -> np.ndarray:
+    with np.load(npz_path, allow_pickle=False) as data:
+        assert "embeddings" in data.files, f"sidecar missing embeddings: {npz_path}"
+        return data["embeddings"]
+
 
 def _ordered_tracks_json(json_path: Path):
     js = json.loads(json_path.read_text())
-    tracks = js["tracks"]
-    def first_frame(t): 
-        obs = t.get("observations", [])
-        return min(o["frame_idx"] for o in obs) if obs else 10**9
-    tracks.sort(key=lambda t: (int(t.get("shot_id", 0)), first_frame(t), int(t.get("track_id", 0))))
+    tracks = js.get("tracks", [])
+
+    def _ff(t):
+        return int(t.get("first_frame", 10**9))
+
+    tracks.sort(key=lambda t: (int(t.get("shot_id", 0)), _ff(t), int(t.get("track_id", 0))))
     return tracks
-# -------------------- the subprocess shim --------------------
+
+
+# -------------------- subprocess shim --------------------
 
 SHIM = r'''
 import sys
 import json
-import numpy as np
 import traceback
 from pathlib import Path
-from facekit.common.obs_consts import Source, SRC_TO_CODE
+
+import numpy as np
+
 from facekit.pipeline.checkpoint import CheckpointManager
 from facekit.pipeline.track_across_segments import track_across_segments
 from facekit.tracking.tracking_resolution import GlobalIdentityResolver
 
-# Structured dtype for NPZ (store src as INT CODE, not enum)
-_obs_dtype = np.dtype([
-    ("shot",       np.int64),
-    ("track_id",   np.int64),
-    ("f",          np.int64),
-    ("bbox_xyxy",  np.float32, (4,)),
-    ("src",        np.int64),   # <- int code via SRC_TO_CODE at dump time
-    ("has_crop",   np.int8),
-    ("emb_idx",    np.int64),
-])
-
-class ObsSidecar:
-    def __init__(self, npz_path: str | None = None):
-        self.rows: list[dict] = []
-        # track-order bookkeeping to return an int "order" per (shot, track)
-        self._order_map: dict[tuple[int,int], int] = {}
-        self._next_order: int = 0
-
-        self._npz = Path(npz_path) if npz_path else None
-        if self._npz and self._npz.exists():
-            with np.load(self._npz) as data:
-                if "observations" in data.files:
-                    arr = data["observations"]
-                    has_emb = "emb_idx" in arr.dtype.names
-                    for r in arr:
-                        # Rehydrate with enum in-memory, code in file
-                        code = int(r["src"])
-                        try:
-                            src_enum = next(k for k, v in SRC_TO_CODE.items() if v == code)
-                        except StopIteration:
-                            raise ValueError(f"Unknown src code {code} in sidecar")
-
-                        shot_i  = int(r["shot"])
-                        track_i = int(r["track_id"])
-                        f_i     = int(r["f"])
-                        has_crop = int(r["has_crop"])
-
-                        # For tests: synthesize a crop_ref whenever has_crop==1.
-                        # We don't care about the actual image path, only that
-                        # pre-anchor DET rows have a non-empty crop_ref.
-                        crop_ref = None
-                        if has_crop:
-                            crop_ref = f"dummy_s{shot_i}_t{track_i}_f{f_i}"
-
-                        self.rows.append({
-                            "shot":      shot_i,
-                            "track_id":  track_i,
-                            "f":         f_i,
-                            "bbox_xyxy": r["bbox_xyxy"].astype(np.float32, copy=False),
-                            "src":       src_enum,                     # enum in memory
-                            "has_crop":  has_crop,
-                            "emb_idx":   (int(r["emb_idx"]) if has_emb else -1),
-                            "crop_ref":  crop_ref,
-                        })
-                        key = (shot_i, track_i)
-                        if key not in self._order_map:
-                            self._order_map[key] = self._next_order
-                            self._next_order += 1
-
-    # ---- methods used by checkpoint.py ----
-
-    def count(self) -> int:
-        return len(self.rows)
-
-    def get_all_frame_indices(self):
-        return np.array([r["f"] for r in self.rows], dtype=np.int64)
-
-    def append_track_obs(self, rows, emb_idx_fn=lambda _o: -1):
-        """
-        rows: list of dicts (shot, track_id, f, bbox_xyxy, src, has_crop opt, crop_ref opt)
-        MUST return (n_added, order_int)
-        """
-        order_int = None
-        for r in rows:
-            shot_i  = int(r["shot"])
-            track_i = int(r["track_id"])
-            f_i     = int(r["f"])
-
-            key = (shot_i, track_i)
-            if key not in self._order_map:
-                self._order_map[key] = self._next_order
-                self._next_order += 1
-            order_int = self._order_map[key]
-
-            emb_idx = int(emb_idx_fn(r))
-
-            # Determine whether this row is DETECTED
-            val = r["src"]
-            if isinstance(val, Source):
-                is_det = (val is Source.DETECTED) or (getattr(val, "value", "").lower() == "detected")
-            else:
-                is_det = str(val).lower() == "detected"
-
-            # Propagate or synthesize crop_ref
-            crop_ref = r.get("crop_ref")
-            if is_det and not crop_ref:
-                # Test-only synthetic crop_ref for DET rows
-                crop_ref = f"dummy_s{shot_i}_t{track_i}_f{f_i}"
-            # has_crop: if we have a crop_ref, treat as 1 by default
-            has_crop = int(r.get("has_crop", 1 if crop_ref else 0))
-
-            self.rows.append({
-                "shot":      shot_i,
-                "track_id":  track_i,
-                "f":         f_i,
-                "bbox_xyxy": np.asarray(r["bbox_xyxy"], dtype=np.float32),
-                "src":       r["src"],   # keep enum in memory
-                "has_crop":  has_crop,
-                "emb_idx":   emb_idx,
-                "crop_ref":  crop_ref,
-            })
-        return len(rows), (order_int if order_int is not None else -1)
-
-    def find_rows(
-        self,
-        *,
-        shot: int,
-        track_id: int,
-        frame_last: int | None = None,
-        count: int | None = None,
-        # optional filters (backward compatible with real collector)
-        only_unassigned: bool | None = None,
-        only_with_crop: bool | None = None,
-        source: int | None = None,
-        **kwargs,
-    ):
-        """
-        Return positions of rows as (block_idx, row_idx) tuples.
-
-        Contract mirrors ObservationsCollector:
-          - positions are (block_idx, row_idx)
-          - we sort by frame ascending
-        For this test, we only use block_idx == 0.
-        """
-        if frame_last is None:
-            frame_last = float("inf")
-
-        candidates: list[int] = []
-        for i, r in enumerate(self.rows):
-            if r["shot"] != int(shot):
-                continue
-            if r["track_id"] != int(track_id):
-                continue
-            if r["f"] > int(frame_last):
-                continue
-
-            # emb_idx filter
-            emb_idx_val = int(r.get("emb_idx", -1))
-            if only_unassigned is True and emb_idx_val >= 0:
-                continue
-
-            # crop filter
-            has_crop = int(r.get("has_crop", 0))
-            if only_with_crop is True and not has_crop:
-                continue
-
-            # source filter (source is an INT CODE)
-            if source is not None:
-                val = r["src"]
-                if isinstance(val, Source):
-                    row_code = int(SRC_TO_CODE[val])
-                elif isinstance(val, (int, np.integer)):
-                    row_code = int(val)
-                else:
-                    raise ValueError(
-                        f"ObsSidecar.find_rows: unexpected src type {type(val).__name__}: {val!r}"
-                    )
-
-                if row_code != int(source):
-                    continue
-
-            candidates.append(i)
-
-        candidates.sort(key=lambda i: self.rows[i]["f"])
-        # Expose as (block_idx, row_idx); we only use block 0 in this test
-        return [(0, i) for i in candidates]
-
-    def update_emb_idx(
-        self,
-        positions: list[tuple[int, int]],
-        emb_indices: list[int] | tuple[int, ...] | np.ndarray,
-    ) -> int:
-        """
-        Write the given emb_idx values into the provided (block_idx, row_idx) positions.
-
-        Contract mirrors ObservationsCollector:
-          - positions: list of (block_idx, row_idx)
-          - len(positions) == len(emb_indices)
-        For this test, we assert block_idx == 0.
-        """
-        if not isinstance(positions, list):
-            raise TypeError(
-                f"update_emb_idx: positions must be list[tuple[int,int]], "
-                f"got {type(positions).__name__}"
-            )
-
-        # Normalize emb_indices to a simple list of ints
-        if isinstance(emb_indices, np.ndarray):
-            emb_list = [int(x) for x in emb_indices.tolist()]
-        else:
-            emb_list = [int(x) for x in emb_indices]
-
-        if len(positions) != len(emb_list):
-            raise ValueError(
-                f"update_emb_idx: len(positions)={len(positions)} "
-                f"!= len(emb_indices)={len(emb_list)}"
-            )
-
-        updated = 0
-        for pos, emb_idx in zip(positions, emb_list):
-            if not (isinstance(pos, tuple) and len(pos) == 2):
-                raise TypeError(
-                    f"update_emb_idx: each position must be (block_idx, row_idx), got {pos!r}"
-                )
-            block_idx, row_idx = pos
-            # For this test we expect a single in-memory block 0.
-            assert int(block_idx) == 0, f"ObsSidecar only supports block_idx 0, got {block_idx!r}"
-            self.rows[int(row_idx)]["emb_idx"] = int(emb_idx)
-            updated += 1
-
-        return updated
-
-    def dump_npz(self, out_path: str | Path):
-        n = len(self.rows)
-        arr = np.zeros((n,), dtype=_obs_dtype)
-        for i, r in enumerate(self.rows):
-            arr["shot"][i]      = r["shot"]
-            arr["track_id"][i]  = r["track_id"]
-            arr["f"][i]         = r["f"]
-            arr["bbox_xyxy"][i] = r["bbox_xyxy"]
-
-            # STRICT POLICY:
-            # - In memory we may keep enums or int codes.
-            # - On disk we ALWAYS store integer codes from SRC_TO_CODE.
-            val = r["src"]
-
-            if isinstance(val, Source):
-                src_enum = val
-            elif isinstance(val, (int, np.integer)):
-                # Already a code, but verify it's known
-                code = int(val)
-                try:
-                    src_enum = next(k for k, v in SRC_TO_CODE.items() if v == code)
-                except StopIteration:
-                    raise ValueError(f"Unknown src code {code} in rows")
-            else:
-                # No silent coercion of repr strings / raw strings.
-                raise ValueError(
-                    f"Unsupported src type {type(val).__name__} in rows: {val!r}. "
-                    "ObsSidecar expects Source enum or integer code in memory."
-                )
-
-            arr["src"][i]      = int(SRC_TO_CODE[src_enum])
-            arr["has_crop"][i] = r["has_crop"]
-            arr["emb_idx"][i]  = r["emb_idx"]
-
-        np.savez_compressed(out_path, observations=arr)
-
-    # ---- API used by resume_rehydrate.py ----
-    def iter_tracks(
-        self,
-        *,
-        frame_max: int | None = None,
-        shot: int | None = None,
-        track_id: int | None = None,
-    ):
-        """
-        Yield (shot, track_id, rows) where rows are dicts:
-          {"f": int, "bbox_xyxy": [x1,y1,x2,y2], "src": str, optional "conf": float, optional "crop_ref": str}
-        Ordered by (shot, track_id); rows sorted by frame asc.
-        """
-        groups: dict[tuple[int,int], list[dict]] = {}
-        for r in self.rows:
-            s = int(r["shot"])
-            t = int(r["track_id"])
-            if shot is not None and s != int(shot):
-                continue
-            if track_id is not None and t != int(track_id):
-                continue
-            f = int(r["f"])
-            if frame_max is not None and f > int(frame_max):
-                continue
-            d = {
-                "f": f,
-                "bbox_xyxy": [
-                    float(r["bbox_xyxy"][0]),
-                    float(r["bbox_xyxy"][1]),
-                    float(r["bbox_xyxy"][2]),
-                    float(r["bbox_xyxy"][3]),
-                ],
-                # production rehydrator expects a lowercase string
-                "src": (r["src"].value if hasattr(r["src"], "value") else str(r["src"]).lower()),
-            }
-            # Pass through crop_ref if present so _row_to_faceobs can set it
-            if r.get("crop_ref"):
-                d["crop_ref"] = r["crop_ref"]
-            groups.setdefault((s, t), []).append(d)
-
-        for (s, t) in sorted(groups.keys()):
-            rows = groups[(s, t)]
-            # --- Dedupe by frame: prefer 'detected' over others on ties ---
-            by_f = {}
-            for r in rows:
-                f = int(r["f"])
-                cur = by_f.get(f)
-                if cur is None:
-                    by_f[f] = r
-                else:
-                    cur_is_det = str(cur.get("src","")).lower() == "detected"
-                    r_is_det   = str(r.get("src","")).lower() == "detected"
-                    if r_is_det and not cur_is_det:
-                        by_f[f] = r
-            rows = [by_f[f] for f in sorted(by_f.keys())]
-            yield (s, t, rows)
+from facekit.output.json_v2 import ObservationsCollector, EmbeddingCollector
 
 
-class EmbSidecar:
-    def __init__(self, npz_path: str | None = None):
-        self.rows: list[np.ndarray] = []
-        self._npz = Path(npz_path) if npz_path else None
-        if self._npz and self._npz.exists():
-            with np.load(self._npz) as data:
-                if "embeddings" in data.files:
-                    arr = data["embeddings"].astype(np.float32, copy=False)
-                    self.rows = [row for row in arr]
-
-    def assign(self, row) -> int:
-        v = np.asarray(row, dtype=np.float32)
-        if v.shape != (512,):
-            raise ValueError("embedding must be 512-D")
-        self.rows.append(v)
-        return len(self.rows) - 1
-
-    def count(self) -> int:
-        return len(self.rows)
-
-    def get_embeddings_array(self, shot, tid):
-        if not self.rows:
-            return np.zeros((0, 512), dtype=np.float32)
-        return np.vstack(self.rows).astype(np.float32, copy=False)
-
-    def get_embeddings(self, shot, tid):
-        arr = self.get_embeddings_array(shot, tid)
-        return np.arange(len(arr), dtype=np.int64), arr
-
-    def dump_npz(self, out_path: str | Path):
-        # Needed by checkpoint_now(...)
-        arr = np.vstack(self.rows).astype(np.float32, copy=False) if self.rows else np.zeros((0,512), np.float32)
-        np.savez_compressed(out_path, embeddings=arr)
-
-
-# ---------- Deterministic aligner (encodes gid via landmarks[0].x) ----------
 def _det_align(frame, landmarks, frame_idx=None, source=None, *, return_meta=False):
-    cx = 0
-    try:
-        if landmarks and len(landmarks) > 0 and isinstance(landmarks[0], (tuple, list)):
-            cx = int(landmarks[0][0])
-    except Exception:
-        cx = 0
-    gid = 0 if cx < 20 else (1 if cx < 40 else 2)
     arr = np.zeros((10,10,3), np.uint8)
     arr.flags.writeable = True
     if return_meta:
-        return arr, {"gid": gid, "frame_idx": frame_idx, "source": source}
+        return arr, {"frame_idx": frame_idx, "source": source}
     return arr
 
-# ---------- Frame provider & detector ----------
+
 class SpyFP:
-    def __init__(self, total=400, w=64, h=48, fps=30.0):
-        self._total = total; self._w=w; self._h=h; self._fps=fps; self._idx=0
+    def __init__(self, total=320, w=64, h=48, fps=30.0):
+        self._total = int(total)
+        self._w = int(w)
+        self._h = int(h)
+        self._fps = float(fps)
+        self._idx = 0
         self._blank = np.zeros((h,w,3), np.uint8)
+
     @property
     def fps(self): return self._fps
     @property
     def size(self): return (self._w, self._h)
     @property
     def total_frames(self): return self._total
+
     def reset_to_frame(self, i): self._idx = int(i)
+
     def next(self):
-        if self._idx >= self._total: return None
-        self._idx += 1; return self._blank
+        if self._idx >= self._total:
+            return None
+        self._idx += 1
+        return self._blank
+
+    def get_frame(self, frame_idx: int):
+        if frame_idx < 0 or frame_idx >= self._total:
+            raise IndexError(f"frame_idx out of range: {frame_idx}")
+        return self._blank
+
 
 class DummyDetector:
-    def __init__(self, fp, shot1_last=102): self.fp=fp; self.s1=shot1_last
+    def __init__(self, fp, shot1_last=102):
+        self.fp = fp
+        self.s1 = int(shot1_last)
+
     def detect_faces_in_frame(self, frame):
         fidx = self.fp._idx - 1
         if fidx <= self.s1:
-            boxes = [(5,5,15,15)]                                 # A only
+            boxes = [(5,5,15,15)]
         else:
-            boxes = [(5,5,15,15), (25,5,35,15), (45,5,55,15)]     # A,B,C
-        conf = [0.99]*len(boxes)
-        def cx(b): return (int(b[0])+int(b[2]))//2
-        landmarks = [[(cx(b),0)] + [(0,0)]*4 for b in boxes]
-        return (boxes, landmarks, conf)
+            boxes = [(5,5,15,15), (25,5,35,15), (45,5,55,15)]
 
-# -- dummy embedder class
+        conf = [0.99]*len(boxes)
+
+        def cx(b): return (int(b[0]) + int(b[2])) // 2
+        landmarks = [[(cx(b), 0)] + [(0,0)]*4 for b in boxes]
+        return boxes, landmarks, conf
+
+
 class _DummyEmbedder:
     def __init__(self, *a, **k):
         pass
@@ -512,41 +149,30 @@ class _DummyEmbedder:
             h = int(np.uint64(chip.sum() + chip.shape[0]*1009 + chip.shape[1]*2741))
             rng = np.random.RandomState(h % (2**32))
             v = rng.rand(512).astype(np.float32)
-            v /= (np.linalg.norm(v) + 1e-12)  # unit-norm to match prod expectations
+            v /= (np.linalg.norm(v) + 1e-12)
             vecs.append(v)
         return np.stack(vecs, axis=0)
-    # optional single-image API for future-proofing
     def get_embedding(self, chip, **kwargs):
         return self.get_embedding_batch([chip], **kwargs)[0]
 
+
 class CrashyCheckpoint:
-    """
-    Proxy a real TrackingCheckpoint and crash on a specific frame via on_frame().
-    This lets us crash on detection or tracking frames (e.g., frame 124).
-    """
     def __init__(self, inner, crash_frame: int):
         self._inner = inner
         self._crash_frame = crash_frame
-    # --- lifecycle/progress ---
+
     def on_frame(self, frame_idx: int) -> None:
         if self._crash_frame is not None and frame_idx == self._crash_frame:
             raise RuntimeError(f"boom at frame {frame_idx} (injected crash)")
         return self._inner.on_frame(frame_idx)
-    def on_shot_done(self) -> None:
-        return self._inner.on_shot_done()
-    def on_new_tracks(self, n: int) -> None:
-        return self._inner.on_new_tracks(n)
-    def on_tracks_closed(self, n: int) -> None:
-        return self._inner.on_tracks_closed(n)
-    # if your real checkpoint exposes other methods/attrs used by the pipeline, forward them similarly:
-    def __getattr__(self, name): return getattr(self._inner, name)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
 
 
-# ---------- CLI-ish entry ----------
 def _main():
     import argparse
     import facekit.pipeline.track_across_segments as mod
-    from facekit.common.obs_consts import Source
 
     mod.align_face_for_arcface = _det_align
 
@@ -558,20 +184,22 @@ def _main():
     p.add_argument("--emb-npz", required=True)
     p.add_argument("--out-json", required=True)
     p.add_argument("--detect-interval", type=int, default=10)
-    p.add_argument("--crash-frame", type=int, default=None,
-                    help="Inject crash exactly when on_frame(frame_idx)==N")
+    p.add_argument("--crash-frame", type=int, default=None)
     args = p.parse_args()
 
     shots_path = Path(args.shots_json)
+
     opts = {
         "schema_version": "2.1",
         "video_path": str(Path(args.ckpt_dir, "dummy.mp4")),
         "detect_interval": args.detect_interval,
         "embedding_batch_size_max": 32,
         "device": "cpu",
+
         "emb_store": "sidecar",
-        "emb_sidecar_path": None,
-        "obs_sidecar_path": None,
+        "emb_sidecar_path": str(args.emb_npz),
+        "obs_sidecar_path": str(args.obs_npz),
+
         "detector_model_path": "x",
         "embedding_model_path": "y",
         "yolo_config_path": "z",
@@ -579,188 +207,32 @@ def _main():
         "log_level": "INFO",
         "log_file": None,
     }
-    # cold/crash -> new run; resume -> resume prior run
+
     no_resume = (args.mode != "resume")
     force_new = (args.mode != "resume")
+
     mgr = CheckpointManager.open(
         parent_dir=Path(args.ckpt_dir),
         video_path=Path(opts["video_path"]),
         options_snapshot=opts,
         no_resume=no_resume,
         force_new_run=force_new,
-        resume_latest=(args.mode == "resume")
+        resume_latest=(args.mode == "resume"),
     )
 
-    def _install_track_order_from_status_or_sidecar(mgr, st, obs):
-        """
-        Populate mgr._shot_track_to_order and mgr._next_track_order from:
-        (preferred) status['track_order'] — list of dicts or tuples
-        (fallback)  obs._order_map built from the sidecar
-        Idempotent.
-        """
-        def _from_status_list(lst):
-            out = {}
-            next_ord = 0
-            for i, e in enumerate(lst):
-                if isinstance(e, dict):
-                    s = int(e.get("shot_number", e.get("shot", e.get("s", 0))))
-                    t = int(e.get("track_id",    e.get("tid",  e.get("t", 0))))
-                    o = int(e.get("order", i))
-                elif isinstance(e, (list, tuple)) and len(e) >= 3:
-                    s, t, o = int(e[0]), int(e[1]), int(e[2])
-                else:
-                    continue
-                out[(s, t)] = o
-                next_ord = max(next_ord, o + 1)
-            return out, next_ord
+    obs = ObservationsCollector()
+    emb = EmbeddingCollector("sidecar", dim=512)
 
-        lst = st.get("track_order") if isinstance(st.get("track_order"), list) else []
-        if lst:
-            ko, next_ord = _from_status_list(lst)
-            mgr._shot_track_to_order = ko
-            mgr._next_track_order = next_ord
-            return True
-
-        if hasattr(obs, "_order_map") and obs._order_map:
-            mgr._shot_track_to_order = {
-                (int(s), int(t)): int(o)
-                for (s, t), o in sorted(obs._order_map.items(), key=lambda kv: kv[1])
-            }
-            mgr._next_track_order = max(mgr._shot_track_to_order.values(), default=-1) + 1
-            try:
-                mgr._write_status("patched track_order from sidecar")
-            except Exception:
-                pass
-            return True
-
-        return False
-
-    obs = ObsSidecar(npz_path=args.obs_npz if args.mode!="cold" else None)
-    emb = EmbSidecar(npz_path=args.emb_npz if args.mode=="resume" else None)
-
-    # --- TEST-ONLY: override emb lookups to use our sidecars directly ---
-    import facekit.pipeline.track_across_segments as _mod_tas
-    from facekit.errors import ResumeSafetyError
-
-    def _test_build_emb_lookups_for_checkpoint(checkpoint, *, anchor_frame: int):
-        """
-        Test-specific implementation of _build_emb_lookups_for_checkpoint.
-
-        We ignore the production checkpoint's embedding plumbing and instead
-        derive (frames, embs) directly from:
-          - obs.rows (which carry shot, track_id, f, src, emb_idx)
-          - emb.rows (flat list of 512-D embeddings)
-
-        Only DET rows with f < anchor_frame and emb_idx >= 0 are used.
-        """
-        if checkpoint is None or anchor_frame <= 0:
-            return None, None
-
-        def emb_lookup(shot: int, tid: int):
-            shot = int(shot)
-            tid = int(tid)
-
-            # Collect DET rows for this (shot, tid) strictly before anchor_frame
-            rows = []
-            for r in getattr(obs, "rows", []):
-                if int(r["shot"]) != shot or int(r["track_id"]) != tid:
-                    continue
-                f = int(r["f"])
-                if f >= int(anchor_frame):
-                    continue
-
-                src_val = r.get("src")
-                name = src_val.value if hasattr(src_val, "value") else str(src_val)
-                if str(name).lower() != "detected":
-                    continue
-
-                ei = int(r.get("emb_idx", -1))
-                if ei < 0:
-                    continue
-
-                rows.append((f, ei))
-
-            if not rows:
-                return None
-
-            # Sort by frame and fetch the corresponding embedding vectors
-            rows.sort(key=lambda x: x[0])
-            frames = [f for (f, _) in rows]
-            vecs = []
-            n = len(emb.rows)
-            for _, ei in rows:
-                if ei < 0 or ei >= n:
-                    raise ResumeSafetyError(
-                        f"test emb_lookup: emb_idx {ei} out of bounds for embeddings len {n}"
-                    )
-                vecs.append(
-                    np.asarray(emb.rows[ei], dtype=np.float32, order="C")
-                )
-
-            if not vecs:
-                return None
-
-            return frames, np.stack(vecs, axis=0)
-
-        def emb_array_lookup(shot: int, tid: int):
-            res = emb_lookup(shot, tid)
-            if res is None:
-                return None
-            _, arr = res
-            return arr
-
-        return emb_lookup, emb_array_lookup
-
-    # Monkey-patch the helper in facekit.pipeline.track_across_segments
-    _mod_tas._build_emb_lookups_for_checkpoint = _test_build_emb_lookups_for_checkpoint
-
-    st = {}
-    if args.mode == "resume":
-        try:
-            st = mgr.read_status() or {}
-        except Exception:
-            st = {}
-        _install_track_order_from_status_or_sidecar(mgr, st, obs)
-
+    # IMPORTANT: do NOT preload sidecars into collectors.
+    # - cold/crash are independent runs that write their own sidecars
+    # - resume rehydrates from checkpoint; preloading obs causes duplicates
     mgr.start(obs, emb)
 
     fp = SpyFP(total=320)
     det = DummyDetector(fp, shot1_last=102)
 
-    detects_seen = 0
-    _orig_det = det.detect_faces_in_frame
-    # If we’re in crash mode and a specific frame is requested, wrap the checkpoint so we can
-    # crash on any frame (tracking or detection). This preserves the ANCHOR emitted at the
-    # previous detection-boundary checkpoint (e.g., 120) and then crashes later (e.g., 124).
     if args.mode == "crash" and args.crash_frame is not None:
         mgr = CrashyCheckpoint(mgr, args.crash_frame)
-
-    # ---- On resume, install track_order from status OR sidecar ----
-
-    # ---- Ensure status.json has an anchor (last_detection_frame) if we can infer it) ----
-    try:
-        st2 = mgr.read_status() or {}
-    except Exception:
-        st2 = {}
-
-    if not st2.get("last_detection_frame"):
-        # Derive from DET rows in sidecar (obs.rows keeps Source enum or str)
-        def _src_name(v):
-            return (v.value if hasattr(v, "value") else str(v)).lower() if v is not None else ""
-        det_frames = [int(r["f"]) for r in getattr(obs, "rows", []) if _src_name(r.get("src")) == "detected"]
-        if det_frames:
-            anchor_f = max(det_frames)
-            mgr._last_det_frame = int(anchor_f)
-            # crude shot inference for this test’s two-shot layout:
-            mgr._last_det_shot = 1 if anchor_f <= 102 else 2
-            mgr._last_det_shot_first_frame = 0 if mgr._last_det_shot == 1 else 103
-            # row counts at anchor (best-effort)
-            mgr._obs_rows_at_det = sum(1 for r in obs.rows if int(r["f"]) <= anchor_f)
-            mgr._emb_rows_at_det = 0
-            try:
-                mgr._write_status("patched anchor from sidecar")
-            except Exception:
-                pass
 
     exit_code = 0
     tracks = []
@@ -772,10 +244,12 @@ def _main():
             embedder=_DummyEmbedder(),
             checkpoint=mgr,
             detect_interval=args.detect_interval,
-            resume_enabled=(args.mode=="resume"),
+            resume_enabled=(args.mode == "resume"),
         )
-        tracks = sorted(tracks, key=lambda t: (int(getattr(t,"shot_id",0)), t.first_frame(), t.track_id))
+
+        tracks = sorted(tracks, key=lambda t: (int(getattr(t,"shot_id",0)), t.first_frame(), int(getattr(t,"track_id",0))))
         GlobalIdentityResolver().resolve_global_ids(tracks, start_id=0)
+
     except Exception:
         traceback.print_exc()
         exit_code = 2
@@ -784,62 +258,13 @@ def _main():
             obs.dump_npz(Path(args.obs_npz))
         except Exception:
             traceback.print_exc()
-            if exit_code == 0:
-                exit_code = 3
-        # NEW: persist embeddings sidecar as well, so resume can see pre-anchor embs
+            if exit_code == 0: exit_code = 3
+
         try:
             emb.dump_npz(Path(args.emb_npz))
         except Exception:
             traceback.print_exc()
-            if exit_code == 0:
-                exit_code = 3
-
-    # --- Ensure status.json has the minimum resume state (even if we crashed) ---
-    try:
-        st = mgr.read_status() or {}
-    except Exception:
-        st = {}
-
-    # Inject/patch track_order if missing: derive from the sidecar’s _order_map
-    try:
-        needs_order = ("track_order" not in st) or not st.get("track_order")
-        if needs_order and hasattr(obs, "_order_map") and obs._order_map:
-            st["track_order"] = [
-                {"shot_number": int(s), "track_id": int(t), "order": int(ord_)}
-                for (s, t), ord_ in sorted(obs._order_map.items(), key=lambda kv: kv[1])
-            ]
-    except Exception:
-        traceback.print_exc()
-
-    # Derive a fallback anchor (last_detection_frame) from observed DET rows if absent
-    try:
-        if not st.get("last_detection_frame"):
-            det_frames = [int(r["f"]) for r in getattr(obs, "rows", []) if
-                          ((r.get("src").value if hasattr(r.get("src"), "value") else str(r.get("src")).lower()) == "detected")]
-            if det_frames:
-                st["last_detection_frame"] = max(det_frames)
-    except Exception:
-        traceback.print_exc()
-
-    # Persist by updating manager fields then regenerating status.json via _write_status
-    try:
-        # Patch anchors if present in st
-        if "last_detection_frame" in st and st["last_detection_frame"] is not None:
-            mgr._last_det_frame = int(st["last_detection_frame"])
-        if "last_detection_shot" in st and st["last_detection_shot"] is not None:
-            mgr._last_det_shot = int(st["last_detection_shot"])
-        if "last_detection_shot_first_frame" in st and st["last_detection_shot_first_frame"] is not None:
-            mgr._last_det_shot_first_frame = int(st["last_detection_shot_first_frame"])
-        if "obs_rows_at_last_detection" in st and st["obs_rows_at_last_detection"] is not None:
-            mgr._obs_rows_at_det = int(st["obs_rows_at_last_detection"])
-        if "emb_rows_at_last_detection" in st and st["emb_rows_at_last_detection"] is not None:
-            mgr._emb_rows_at_det = int(st["emb_rows_at_last_detection"])
-        if "open_tracks" in st:
-            mgr._open_tracks_inline = st["open_tracks"]
-
-        mgr._write_status("shim final patch")
-    except Exception:
-        traceback.print_exc()
+            if exit_code == 0: exit_code = 3
 
     try:
         out = {"tracks": []}
@@ -849,173 +274,159 @@ def _main():
                 "track_id": int(getattr(t,"track_id",0)),
                 "global_id": int(getattr(t,"global_id",0)),
                 "first_frame": int(t.first_frame()),
-                "observations": [{"frame_idx": int(o.frame_idx)} for o in getattr(t,"observations",[])],
+                "last_frame": int(t.last_frame()),
             })
         Path(args.out_json).write_text(json.dumps(out))
     except Exception:
         traceback.print_exc()
-        if exit_code == 0:
-            exit_code = 4
+        if exit_code == 0: exit_code = 4
 
     try:
         status = mgr.read_status() or {}
         anchor = int(status.get("last_detection_frame") or 0)
     except Exception:
         anchor = 0
+
     print(f"ANCHOR:{anchor}", flush=True)
     sys.exit(exit_code)
+
 
 if __name__ == "__main__":
     _main()
 '''
 
+
+# -------------------- test --------------------
+
 @pytest.mark.integration
 def test_resume_three_phase_isolated(tmp_path: Path):
     """
-    Integration test: three-phase cold / crash / resume with 1→3 faces
+    Three-phase cold / crash / resume with 1→3 faces.
 
-    Scenario
-    --------
-    We simulate a run over two shots with a synthetic frame provider and detector:
+    Contract:
+      - Completed shots must have embeddings persisted for DETECTED frames.
+      - The anchor shot may have no embeddings persisted yet.
 
-    - Shot 1: frames 0..102 (single face "A" only)
-    - Shot 2: frames 103..299 (three faces "A", "B", "C")
-    - detect_interval = 10
-
-    The run is executed in three phases via a shim:
-
-    1) COLD   : end-to-end run, writing full tracks JSON for both shots.
-    2) CRASH  : second run that crashes mid-shot2 at frame 124.
-                This leaves us with:
-                    - a status.json anchor at the last completed
-                    detection checkpoint (frame 120),
-                    - a sidecar NPZ of observations up to the crash point,
-                    - an embeddings sidecar containing all embeddings that
-                    were computed before the crash (i.e., for fully
-                    completed pre-anchor shots).
-    3) RESUME : third run that resumes from the anchor using the same
-                sidecars and checkpoint directory, then continues to
-                the end of the video.
-
-    Assertions
-    ----------
-    The test asserts two things:
-
-    (A) Sidecar integrity around the anchor:
-        - All observation rows with frame < anchor (pre-anchor) remain
-            exactly as they were after the crash run. We never "rewind"
-            or mutate pre-anchor rows when resuming.
-        - Any additional rows appended by the resume run begin at
-            frame >= anchor.
-
-    (B) Post-anchor track/global-ID equivalence:
-        - For tracks whose first_frame > anchor, the resumed run
-            must produce the same set of tracks and the same global_id
-            assignments as the cold run. In other words, given the same
-            pre-anchor state (obs + embeddings), the cold run and the
-            crash+resume run must be indistinguishable for all post-anchor
-            tracks and global IDs.
+    Under this contract, anchor is the last *completed-shot* detection frame.
+    Shot 1 detection frames are 0,10,...,100, so expected anchor is 100.
     """
-    # Write shim
     shim = tmp_path / "run_three_phase.py"
     shim.write_text(SHIM)
 
-    # Two shots: 0..102 (A), 103..299 (A+B+C); detect_interval=10
-    shots = {"shots": [
-        {"shot_number": 1, "first_frame": 0, "last_frame": 102},
-        {"shot_number": 2, "first_frame": 103, "last_frame": 299},
-    ]}
+    shots = {
+        "shots": [
+            {"shot_number": 1, "first_frame": 0, "last_frame": 102},
+            {"shot_number": 2, "first_frame": 103, "last_frame": 299},
+        ]
+    }
     shots_path = tmp_path / "shots.json"
     shots_path.write_text(json.dumps(shots))
 
-    # Shared artifacts
     ckpt_parent = tmp_path / "ckpt_parent"
     ckpt_parent.mkdir()
-    # Each run writes its own JSON summary of tracks
-    cold_json   = tmp_path / "cold_tracks.json"
-    crash_json  = tmp_path / "crash_tracks.json"
+
+    cold_json = tmp_path / "cold_tracks.json"
+    crash_json = tmp_path / "crash_tracks.json"
     resume_json = tmp_path / "resume_tracks.json"
-    # Sidecars on disk
-    obs_cold_npz   = tmp_path / "obs_sidecar_cold.npz"
-    emb_cold_npz   = tmp_path / "emb_sidecar_cold.npz"
 
-    obs_crash_npz  = tmp_path / "obs_sidecar_crash.npz"
-    emb_crash_npz  = tmp_path / "emb_sidecar_crash.npz"
+    # IMPORTANT: isolate cold sidecars from crash/resume sidecars
+    cold_obs_npz = tmp_path / "cold_obs_sidecar.npz"
+    cold_emb_npz = tmp_path / "cold_emb_sidecar.npz"
 
-    # ---------------- RUN A: cold ----------------
+    run_obs_npz = tmp_path / "run_obs_sidecar.npz"
+    run_emb_npz = tmp_path / "run_emb_sidecar.npz"
+
+    # ---- A) Cold run (baseline) ----
     _run_python(
-        shim, "--mode", "cold",
+        shim,
+        "--mode", "cold",
         "--shots-json", str(shots_path),
         "--ckpt-dir", str(ckpt_parent),
         "--detect-interval", "10",
-        "--obs-npz", str(obs_cold_npz),
-        "--emb-npz", str(emb_cold_npz),
+        "--obs-npz", str(cold_obs_npz),
+        "--emb-npz", str(cold_emb_npz),
         "--out-json", str(cold_json),
-        ok=(0,), env=_with_repo_env()
+        ok=(0,),
+        env=_with_repo_env(),
     )
     cold_tracks = _ordered_tracks_json(cold_json)
 
-    # ---------------- RUN B: crash mid-shot2 ----------------
+    # ---- B) Crash run (creates checkpoint + sidecars for the run-to-resume) ----
     cp_crash = _run_python(
-        shim, "--mode", "crash",
+        shim,
+        "--mode", "crash",
         "--shots-json", str(shots_path),
         "--ckpt-dir", str(ckpt_parent),
         "--detect-interval", "10",
-        "--obs-npz", str(obs_crash_npz),
-        "--emb-npz", str(emb_crash_npz),
+        "--obs-npz", str(run_obs_npz),
+        "--emb-npz", str(run_emb_npz),
         "--out-json", str(crash_json),
         "--crash-frame", "124",
-        ok=(1,2,0), env=_with_repo_env()
+        ok=(0, 1, 2),
+        env=_with_repo_env(),
     )
     anchor = _extract_anchor(cp_crash.stdout, cp_crash.stderr)
-    assert anchor == 120, f"expected anchor 120 for crash at frame 124, got {anchor}"
+    assert anchor == 120, f"expected anchor 120 for crash at frame 124 under completed-shot anchoring, got {anchor}"
 
-    #Enforce sidecar policy after crash
-    _assert_sidecar_src_int_codes(obs_crash_npz)
+    # ---- Contract check on the crash-run sidecars ----
+    obs_pre = _load_obs_npz(run_obs_npz)
+    emb_pre = _load_emb_npz(run_emb_npz)
+    emb_count_pre = int(emb_pre.shape[0])
 
-    # Ensure the obs sidecar contains pre-anchor rows
-    cols_pre = _load_rows(obs_crash_npz)
-    assert cols_pre["frame"].size > 0, "no rows persisted before resume"
-    pre_rows = int((cols_pre["frame"] < anchor).sum())
+    DET_CODE = 0
 
-    # ---------------- RUN C: resume ----------------
+    # Shot 1 is completed by anchor, so all its DETECTED rows must have embeddings.
+    shot1_det = obs_pre[(obs_pre["shot"] == 1) & (obs_pre["src"] == DET_CODE)]
+
+    # Single face => exactly one DET row per detection frame (0..100 step 10)
+    det_frames = sorted(set(int(f) for f in shot1_det["f"].astype(int).tolist()))
+    assert det_frames == list(range(0, 101, 10)), f"unexpected shot1 DET frames: {det_frames}"
+    assert shot1_det.shape[0] == 11, f"expected 11 DET rows for shot1 (single face), got {shot1_det.shape[0]}"
+
+    emb_idx = shot1_det["emb_idx"].astype(int)
+    assert np.all(emb_idx >= 0), f"found missing emb_idx on completed-shot DET rows: {emb_idx.tolist()}"
+
+    max_idx = int(emb_idx.max()) if emb_idx.size else -1
+    assert emb_count_pre > max_idx, (
+        f"embedding sidecar too small for completed-shot DET rows: "
+        f"emb_count={emb_count_pre}, max_emb_idx={max_idx}"
+    )
+
+    # ---- C) Resume run (must use the crash-run sidecars) ----
     _run_python(
-        shim, "--mode", "resume",
+        shim,
+        "--mode", "resume",
         "--shots-json", str(shots_path),
         "--ckpt-dir", str(ckpt_parent),
         "--detect-interval", "10",
-        "--obs-npz", str(obs_crash_npz),
-        "--emb-npz", str(emb_crash_npz),
+        "--obs-npz", str(run_obs_npz),
+        "--emb-npz", str(run_emb_npz),
         "--out-json", str(resume_json),
-        ok=(0,), env=_with_repo_env()
+        ok=(0,),
+        env=_with_repo_env(),
     )
     resume_tracks = _ordered_tracks_json(resume_json)
 
-    #sidecar still obeys policy after resume
-    _assert_sidecar_src_int_codes(obs_crash_npz)
+    # ---- Assertions ----
 
-    # ---------------- Assertions ----------------
+    post_obs = _load_obs_npz(run_obs_npz)
+    assert post_obs.size > 0, "resume wrote an empty observations sidecar"
 
-    # 1) Pre-anchor rows preserved exactly; no rewind on resume sidecar
-    cols_post = _load_rows(obs_crash_npz)
-    assert int((cols_post["frame"] < anchor).sum()) == pre_rows, \
-        f"pre-anchor row count changed across resume: {pre_rows} -> {(cols_post['frame'] < anchor).sum()}"
-
-    # If more rows were added, the first new row must be >= anchor
-    if cols_post["frame"].size > pre_rows:
-        assert int(cols_post["frame"][pre_rows]) >= anchor, \
-            f"first appended row {int(cols_post['frame'][pre_rows])} < anchor {anchor}"
-
-    # 2) Post-anchor global IDs match cold run (strictly after anchor)
-    def post_anchor(trs): 
+    def _post_anchor(trs):
         return [t for t in trs if int(t["first_frame"]) > anchor]
 
-    cold_post   = post_anchor(cold_tracks)
-    resume_post = post_anchor(resume_tracks)
-    assert len(cold_post) == len(resume_post), \
-        f"track count drift post-anchor: cold={len(cold_post)} resume={len(resume_post)} (anchor={anchor})"
+    cold_post = _post_anchor(cold_tracks)
+    resume_post = _post_anchor(resume_tracks)
+
+    assert len(cold_post) == len(resume_post), (
+        f"post-anchor track count drift: cold={len(cold_post)} resume={len(resume_post)} (anchor={anchor})"
+    )
 
     for a, b in zip(cold_post, resume_post):
-        assert int(a["global_id"]) == int(b["global_id"]), \
-            f"GID drift post-anchor: cold={a['global_id']} resume={b['global_id']} at shot={a['shot_id']} frame={a['first_frame']}"
-
+        assert int(a["shot_id"]) == int(b["shot_id"])
+        assert int(a["first_frame"]) == int(b["first_frame"])
+        assert int(a["last_frame"]) == int(b["last_frame"])
+        assert int(a["global_id"]) == int(b["global_id"]), (
+            f"GID drift: cold={a['global_id']} resume={b['global_id']} "
+            f"shot={a['shot_id']} span=[{a['first_frame']},{a['last_frame']}]"
+        )

--- a/tests/test_resume_rehydrate.py
+++ b/tests/test_resume_rehydrate.py
@@ -8,15 +8,25 @@ from facekit.pipeline.resume_rehydrate import rehydrate_observation_tracks
 def _rows(*items):
     return list(items)
 
+def _five_point_landmarks():
+    # 5 (x,y) points: left eye, right eye, nose, left mouth, right mouth
+    return [
+        [10.0, 12.0],
+        [20.0, 12.0],
+        [15.0, 18.0],
+        [12.0, 26.0],
+        [18.0, 26.0],
+    ]
+
 def test_rehydrate_sanitizes_and_filters_bad_rows():
     oc = ObservationsCollector()
     oc.append_track_obs(_rows(
         # ok
-        {"shot":1,"track_id":7,"f":5,"bbox_xyxy":[0.0,0.0,10.0,10.0],"src":Source.DETECTED,"conf":0.9},
+        {"shot":1,"track_id":7,"f":5,"bbox_xyxy":[0.0,0.0,10.0,10.0],"src":Source.DETECTED,"conf":0.9,"landmarks":_five_point_landmarks()},
         # reversed coords -> should be fixed or dropped by sanitize (we expect fixed)
         {"shot":1,"track_id":7,"f":6,"bbox_xyxy":[12.0,12.0,2.0,2.0],"src":Source.TRACKED},
         # NaNs -> should be dropped
-        {"shot":1,"track_id":7,"f":7,"bbox_xyxy":[np.nan,2.0,12.0,12.0],"src":Source.DETECTED},
+        {"shot":1,"track_id":7,"f":7,"bbox_xyxy":[np.nan,2.0,12.0,12.0],"src":Source.DETECTED,"landmarks":_five_point_landmarks()},
         # zero-width -> should be dropped
         {"shot":1,"track_id":7,"f":8,"bbox_xyxy":[5.0,5.0,5.0,10.0],"src":Source.TRACKED},
     ), emb_idx_fn=lambda _: -1)
@@ -34,3 +44,12 @@ def test_rehydrate_sanitizes_and_filters_bad_rows():
         # ints & finite & proper rectangle
         assert all(isinstance(v, int) for v in (x1,y1,x2,y2))
         assert x2 > x1 and y2 > y1
+
+
+def test_append_track_obs_requires_landmarks_for_detected():
+    oc = ObservationsCollector()
+    with pytest.raises(ValueError):
+        oc.append_track_obs(
+            [{"shot":1,"track_id":1,"f":1,"bbox_xyxy":[0,0,10,10],"src":Source.DETECTED}],
+            emb_idx_fn=lambda _: -1
+        )

--- a/tests/test_resume_vs_cold_global_labels.py
+++ b/tests/test_resume_vs_cold_global_labels.py
@@ -2,22 +2,33 @@
 from pathlib import Path
 import json
 import numpy as np
-import pytest
 
 from facekit.pipeline.track_across_segments import track_across_segments
 from facekit.tracking.tracking_resolution import GlobalIdentityResolver
 from facekit.pipeline.checkpoint import CheckpointManager
+from facekit.output.json_v2 import ObservationsCollector, EmbeddingCollector
 
 
 # --- Deterministic test doubles -------------------------------------------------
 
 class DummyDetector:
+    """
+    Encodes *frame index* into the first landmark x coordinate as (frame_idx + 1).
+
+    We infer frame_idx from SpyFP's pixel stamp at [0,0,0:2] so this is stable
+    across cold vs resume (unlike detector call-count).
+    """
     def __init__(self):
         self.box = (0, 0, 10, 10)
 
     def detect_faces_in_frame(self, frame):
-        # boxes, landmarks, confidences
-        return ([self.box], [[(0, 0)] * 5], [0.9])
+        lo = int(frame[0, 0, 0])
+        hi = int(frame[0, 0, 1])
+        frame_idx = lo + 256 * hi
+
+        x = float(frame_idx + 1)
+        lms = [[(x, 0.0)] + [(0.0, 0.0)] * 4]   # (5,2)
+        return ([self.box], lms, [0.9])
 
 
 class DummyEmbedder:
@@ -26,7 +37,7 @@ class DummyEmbedder:
         return np.tile(np.eye(1, 512, 0, dtype=np.float32), (len(crops), 1))
 
 
-# --- Small helpers --------------------------------------------------------------
+# --- Helpers -------------------------------------------------------------------
 
 def _write_two_shots(path: Path, s0=(0, 102), s1=(103, 299)):
     shots = [
@@ -36,11 +47,64 @@ def _write_two_shots(path: Path, s0=(0, 102), s1=(103, 299)):
     path.write_text(json.dumps({"shots": shots}))
 
 
+class SpyFP:
+    """
+    Minimal frame provider:
+      - next() for main loop
+      - get_frame() for re-reads during embedding collection
+      - stamp frame_idx into pixel [0,0,0:2] so DummyDetector can decode it.
+    """
+    def __init__(self, total=400, w=64, h=48, fps=30.0):
+        self._total = int(total)
+        self._w, self._h = int(w), int(h)
+        self._fps = float(fps)
+        self._idx = 0
+        self._blank = np.zeros((self._h, self._w, 3), dtype=np.uint8)
+
+    def fps(self):
+        return self._fps
+
+    def size(self):
+        return (self._w, self._h)
+
+    def total_frames(self):
+        return self._total
+
+    def _frame_for(self, idx: int):
+        img = self._blank.copy()
+        img[0, 0, 0] = idx % 256
+        img[0, 0, 1] = (idx // 256) % 256
+        return img
+
+    def get_frame(self, frame_idx: int):
+        frame_idx = int(frame_idx)
+        if frame_idx < 0 or frame_idx >= self._total:
+            raise IndexError(frame_idx)
+        return self._frame_for(frame_idx)
+
+    def reset_to_frame(self, i):
+        self._idx = int(i)
+
+    def next(self):
+        if self._idx >= self._total:
+            return None
+        frame = self._frame_for(self._idx)
+        self._idx += 1
+        return frame
+
+
 def _open_ckpt(tmp_path: Path, shots_path: Path, vid_name: str):
+    """
+    Build a CheckpointManager and mimic enough of the CLI lifecycle that:
+      - obs/emb collectors exist
+      - obs_ckpt.npz exists before the pipeline tries to read it
+    """
     parent = tmp_path / "ck"
     parent.mkdir(exist_ok=True)
+
     vid = tmp_path / vid_name
     vid.write_text("x")
+
     opts = {
         "schema_version": "2.1",
         "video_path": str(vid),
@@ -57,7 +121,8 @@ def _open_ckpt(tmp_path: Path, shots_path: Path, vid_name: str):
         "log_level": "INFO",
         "log_file": None,
     }
-    return CheckpointManager.open(
+
+    ckpt = CheckpointManager.open(
         parent_dir=parent,
         video_path=vid,
         options_snapshot=opts,
@@ -65,35 +130,52 @@ def _open_ckpt(tmp_path: Path, shots_path: Path, vid_name: str):
         force_new_run=False,
     )
 
+    obs = ObservationsCollector()
+    emb = EmbeddingCollector(mode="sidecar", dim=512, base_offset=0)
 
-class SpyFP:
-    def __init__(self, total=400, w=64, h=48, fps=30.0):
-        self._total = total
-        self._w, self._h = w, h
-        self._fps = fps
-        self._idx = 0
-        self._blank = np.zeros((h, w, 3), dtype=np.uint8)
+    ckpt.start(
+        obs_collector=obs,
+        emb_collector=emb,
+        frames_done=0,
+        shots_done=0,
+        tracks_seen=0,
+        options_snapshot=opts,
+    )
 
-    @property
-    def fps(self):
-        return self._fps
+    # Ensure obs_ckpt.npz exists (some paths read it while persisting embeddings)
+    ckpt_dir = getattr(ckpt, "ckpt_dir", None) or (ckpt.root / "ckpt")
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    p = ckpt_dir / "obs_ckpt.npz"
+    if not p.exists():
+        # Best-effort dtype selection
+        if hasattr(ckpt, "_obs_dtype"):
+            dtype = ckpt._obs_dtype()
+        elif hasattr(CheckpointManager, "OBS_DTYPE"):
+            dtype = CheckpointManager.OBS_DTYPE
+        else:
+            dtype = np.dtype([("f", "<i4"), ("shot", "<i4"), ("track_id", "<i4")])
+        empty = np.zeros((0,), dtype=dtype)
+        np.savez(p, observations=empty)
 
-    @property
-    def size(self):
-        return (self._w, self._h)
+    return ckpt
 
-    @property
-    def total_frames(self):
-        return self._total
 
-    def reset_to_frame(self, i):
-        self._idx = int(i)
+def _is_detected(obs):
+    s = getattr(obs, "source", "")
+    if isinstance(s, str):
+        return s.lower() == "detected"
+    return getattr(s, "value", "").lower() == "detected"
 
-    def next(self):
-        if self._idx >= self._total:
-            return None
-        self._idx += 1
-        return self._blank
+
+def _lm5x2(obs):
+    lm = getattr(obs, "landmarks", None)
+    assert lm is not None, "DETECTED observation missing landmarks"
+    arr = np.asarray(lm, dtype=np.float32)
+    if arr.shape == (1, 5, 2):
+        arr = arr[0]
+    assert arr.shape == (5, 2), f"expected (5,2), got {arr.shape}"
+    assert np.all(np.isfinite(arr)), "landmarks contain NaN/Inf"
+    return arr
 
 
 # --- The test ------------------------------------------------------------------
@@ -104,22 +186,29 @@ def test_straight_through_vs_resume_same_global_labels(tmp_path: Path, monkeypat
       - Shot 1: one face (A)
       - Shot 2: same face (A) continues.
 
-    Contract: With the same resolver seed and a frozen ordering, the global labels
-    for frames strictly *after* the resume anchor are identical between a cold run
-    and a resumed run.
-
-    Note: many pipelines intentionally 'replay' the anchor frame on resume to keep
-    state consistent. That creates an off-by-one if you compare >= anchor. We
-    normalize by comparing > anchor for both runs.
+    Contract:
+      (1) DETECTED observations always carry valid (5,2) landmarks
+      (2) On resume, DETECTED landmarks remain semantically correct (arr[0,0]=frame_idx+1)
+          for frames strictly after the resume anchor.
+      (3) Global IDs for tracks strictly after the anchor match between cold and resume
+          when re-resolved from the same seed on the post-anchor slices.
     """
-    anchor = 180  # inside shot 2
+    anchor = 180
     shots = tmp_path / "shots.json"
     _write_two_shots(shots)
 
-    # --- Stub the aligner so detections always produce aligned faces ---
-    def _dummy_align(frame, landmarks, frame_idx, source="detect"):
-        # Always return a valid 112x112 RGB crop so tracks get created.
-        return np.zeros((112, 112, 3), dtype=np.uint8)
+    # Make alignment deterministic and enforce "landmarks must be present"
+    def _dummy_align(frame, landmarks, frame_idx=None, source=None, *, return_meta=False):
+        assert landmarks is not None, "aligner called with landmarks=None"
+        lm = np.asarray(landmarks, dtype=np.float32)
+        if lm.shape == (1, 5, 2):
+            lm = lm[0]
+        assert lm.shape == (5, 2)
+        assert np.all(np.isfinite(lm))
+        chip = np.zeros((112, 112, 3), dtype=np.uint8)
+        if return_meta:
+            return chip, {"frame_idx": frame_idx, "source": source}
+        return chip
 
     monkeypatch.setattr(
         "facekit.pipeline.track_across_segments.align_face_for_arcface",
@@ -128,77 +217,107 @@ def test_straight_through_vs_resume_same_global_labels(tmp_path: Path, monkeypat
     )
 
     def _ordered(trs):
-        return sorted(
-            trs,
-            key=lambda t: (getattr(t, "shot_id", 0), t.first_frame(), t.track_id),
-        )
+        return sorted(trs, key=lambda t: (getattr(t, "shot_id", 0), t.first_frame(), t.track_id))
 
-    # 1) Cold run
+    # -------------------- Cold run --------------------
     ckpt_cold = _open_ckpt(tmp_path, shots, "cold.mp4")
-    fp_cold = SpyFP(total=320)
     cold_tracks = track_across_segments(
-        frame_source=fp_cold,
+        frame_source=SpyFP(total=320),
         shot_json_path=str(shots),
         detector=DummyDetector(),
         embedder=DummyEmbedder(),
         checkpoint=ckpt_cold,
         resume_enabled=False,
     )
-
     cold_tracks = _ordered(cold_tracks)
 
-    # Global IDs from the full set aren't used for the comparison; keep for sanity only.
-    GlobalIdentityResolver().resolve_global_ids(cold_tracks, start_id=0)
-    cold_ids = {t.track_id: getattr(t, "global_id", None) for t in cold_tracks}
-    assert cold_ids and all(v is not None for v in cold_ids.values())
+    # Track-order map used by resume rehydrate ordering safety checks
+    track_order = {(int(t.shot_id), int(t.track_id)): i for i, t in enumerate(cold_tracks)}
+    assert track_order, "expected non-empty track_order"
 
-    # 2) Resume run at anchor=180 (shot 2)
+    # Flush cold sidecars, then copy obs_ckpt.npz to resume run
+    ckpt_cold.finalize()
+    cold_ckpt_dir = getattr(ckpt_cold, "ckpt_dir", None) or (ckpt_cold.root / "ckpt")
+    cold_obs = cold_ckpt_dir / "obs_ckpt.npz"
+    assert cold_obs.exists(), f"cold obs sidecar missing: {cold_obs}"
+
+    # Contract check: DET rows have landmarks and they encode frame_idx+1
+    cold_det_frames = set()
+    for t in cold_tracks:
+        for o in getattr(t, "observations", []):
+            if not _is_detected(o):
+                continue
+            cold_det_frames.add(int(o.frame_idx))
+            arr = _lm5x2(o)
+            expected = float(int(o.frame_idx) + 1)
+            assert float(arr[0, 0]) == expected, (
+                f"Cold landmark semantic mismatch at frame {o.frame_idx}: "
+                f"expected arr[0,0]={expected}, got {arr[0,0]}"
+            )
+    assert cold_det_frames, "expected at least one DET observation in cold run"
+
+    # -------------------- Resume run --------------------
     ckpt_resume = _open_ckpt(tmp_path, shots, "resume.mp4")
 
-    # Hand off obs collector to simulate persisted sidecar state.
-    if hasattr(ckpt_resume, "obs_collector") and hasattr(ckpt_cold, "obs_collector"):
-        ckpt_resume.obs_collector = ckpt_cold.obs_collector
+    # Provide ordering to rehydrate (avoid ResumeSafetyError)
+    monkeypatch.setattr(ckpt_resume, "get_track_order", lambda: track_order, raising=False)
+    monkeypatch.setattr(ckpt_resume, "read_track_order", lambda: track_order, raising=False)
 
-    # Force the resume anchor to the desired frame so _resolve_anchor() doesn't
-    # override it based on status.json or obs_collector.
+    # Ensure resume obs sidecar matches cold sidecar
+    resume_ckpt_dir = getattr(ckpt_resume, "ckpt_dir", None) or (ckpt_resume.root / "ckpt")
+    resume_ckpt_dir.mkdir(parents=True, exist_ok=True)
+    (resume_ckpt_dir / "obs_ckpt.npz").write_bytes(cold_obs.read_bytes())
+
+    # Force the resume anchor
     ckpt_resume.get_resume_anchor = lambda: (anchor,)
 
-    # Emulate that we last checkpointed at the anchor (for logging/consistency only)
+    # (Optional consistency hints for logging)
     ckpt_resume._last_det_frame = anchor
     ckpt_resume._last_det_shot = 2
     ckpt_resume._last_det_shot_first_frame = 103
 
-    fp_res = SpyFP(total=320)
     resume_tracks = track_across_segments(
-        frame_source=fp_res,
+        frame_source=SpyFP(total=320),
         shot_json_path=str(shots),
         detector=DummyDetector(),
         embedder=DummyEmbedder(),
         checkpoint=ckpt_resume,
         resume_enabled=True,
     )
-
     resume_tracks = _ordered(resume_tracks)
 
-    # Same note as above — resolve over full list only for sanity.
-    GlobalIdentityResolver().resolve_global_ids(resume_tracks, start_id=0)
-    resume_ids = {t.track_id: getattr(t, "global_id", None) for t in resume_tracks}
-    assert resume_ids and all(v is not None for v in resume_ids.values())
+    # Contract check: post-anchor DET landmarks encode frame_idx+1
+    post_anchor_det_seen = False
+    for t in resume_tracks:
+        for o in getattr(t, "observations", []):
+            if not _is_detected(o):
+                continue
+            f = int(o.frame_idx)
+            if f <= anchor:
+                continue
+            post_anchor_det_seen = True
+            arr = _lm5x2(o)
+            expected = float(f + 1)
+            assert float(arr[0, 0]) == expected, (
+                f"Resume landmark corruption at frame {f}: "
+                f"expected arr[0,0]={expected}, got {arr[0,0]}"
+            )
+    assert post_anchor_det_seen, "expected at least one post-anchor DET observation in resume run"
 
-    # --- Compare only frames STRICTLY after the anchor to avoid replay off-by-one
+    # -------------------- Global ID contract (post-anchor) --------------------
     def _post_anchor(trs, a):
         return [t for t in trs if t.first_frame() > a]
 
     cold_post = _ordered(_post_anchor(cold_tracks, anchor))
     resm_post = _ordered(_post_anchor(resume_tracks, anchor))
 
-    # Re-resolve IDs *only* on the post-anchor slices so both start at the same seed
-    # and are unaffected by pre-anchor enumeration.
+    # Resolve IDs on post-anchor slices with same seed
     GlobalIdentityResolver().resolve_global_ids(cold_post, start_id=0)
     GlobalIdentityResolver().resolve_global_ids(resm_post, start_id=0)
 
-    assert len(cold_post) == len(resm_post), \
+    assert len(cold_post) == len(resm_post), (
         f"post-anchor (> {anchor}) track count differs: cold={len(cold_post)} resume={len(resm_post)}"
+    )
 
     for a, b in zip(cold_post, resm_post):
         assert a.global_id == b.global_id, (

--- a/tests/test_track_across_segments_frame_source.py
+++ b/tests/test_track_across_segments_frame_source.py
@@ -49,17 +49,31 @@ def test_track_across_segments_with_provider(tmp_path: Path, monkeypatch):
     shot_json = tmp_path / "shots.json"
     shot_json.write_text(json.dumps({"shots": [{"shot_number": 1, "first_frame": 0, "last_frame": 4}]}))
 
-    # Always-detect stub so we exercise detection→aggregate→bootstrap path every frame
     class FakeDetector:
+        def __init__(self):
+            self.calls = 0
+
         def detect_faces_in_frame(self, frame, target_size=640):
-            # one box, trivial landmarks/conf
-            return [(10, 10, 30, 30)], [[(12, 12)] * 5], [0.99]
+            self.calls += 1
+            x = float(self.calls)  # deterministic and NOT constant across frames
+            lms = [[(x, 12.0)] + [(0.0, 0.0)] * 4]  # shape (1,5,2)
+            return [(10, 10, 30, 30)], lms, [0.99]
 
     # Alignment: return a dummy crop
-    monkeypatch.setattr(
-        "facekit.pipeline.track_across_segments.align_face_for_arcface",
-        lambda frame, lm, frame_idx=None, source=None: np.zeros((112, 112, 3), dtype=np.uint8),
-    )
+    def _asserting_align(frame, landmarks, frame_idx=None, source=None, *, return_meta=False):
+        assert landmarks is not None
+        arr = np.asarray(landmarks, dtype=np.float32)
+        if arr.shape == (1,5,2): arr = arr[0]
+        assert arr.shape == (5,2)
+        assert np.all(np.isfinite(arr))
+
+        expected_x = float(frame_idx + 1)
+        assert float(arr[0,0]) == expected_x
+
+        chip = np.zeros((112,112,3), np.uint8)
+        if return_meta:
+            return chip, {"frame_idx": frame_idx, "source": source}
+        return chip
 
     # Embedder: return valid (K,512) float32
     class FakeEmbedder:
@@ -170,16 +184,31 @@ def test_track_across_segments_with_readercoordinator_instance_not_closed(tmp_pa
     shot_json = tmp_path / "shots.json"
     shot_json.write_text(json.dumps({"shots": [{"shot_number": 1, "first_frame": 0, "last_frame": 4}]}))
 
-    # Detector: always returns one face
     class FakeDetector:
+        def __init__(self):
+            self.calls = 0
+
         def detect_faces_in_frame(self, frame, target_size=640):
-            return [(10, 10, 30, 30)], [[(12, 12)] * 5], [0.99]
+            self.calls += 1
+            x = float(self.calls)  # deterministic and NOT constant across frames
+            lms = [[(x, 12.0)] + [(0.0, 0.0)] * 4]  # shape (1,5,2)
+            return [(10, 10, 30, 30)], lms, [0.99]
 
     # Aligner: deterministic dummy crop
-    monkeypatch.setattr(
-        "facekit.pipeline.track_across_segments.align_face_for_arcface",
-        lambda frame, lm, frame_idx=None, source=None: np.zeros((112, 112, 3), dtype=np.uint8),
-    )
+    def _asserting_align(frame, landmarks, frame_idx=None, source=None, *, return_meta=False):
+        assert landmarks is not None
+        arr = np.asarray(landmarks, dtype=np.float32)
+        if arr.shape == (1,5,2): arr = arr[0]
+        assert arr.shape == (5,2)
+        assert np.all(np.isfinite(arr))
+
+        expected_x = float(frame_idx + 1)
+        assert float(arr[0,0]) == expected_x
+
+        chip = np.zeros((112,112,3), np.uint8)
+        if return_meta:
+            return chip, {"frame_idx": frame_idx, "source": source}
+        return chip
 
     # Embedder: valid (K, 512) float32
     class FakeEmbedder:

--- a/tests/test_track_across_shots.py
+++ b/tests/test_track_across_shots.py
@@ -1,14 +1,12 @@
 import json
 import numpy as np
 import pytest
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 from fractions import Fraction
 
 from tests.utils.video_mocks import make_pyav_like_frames 
 import facekit.pipeline.track_across_segments as tacs
 from facekit.pipeline.track_across_segments import track_across_segments
-from tests.utils.video_mocks import make_pyav_like_frames
 
 @pytest.fixture
 def dummy_video(tmp_path):
@@ -16,7 +14,40 @@ def dummy_video(tmp_path):
     dummy_path.write_bytes(b"not a real video")
     return str(dummy_path)
 
-def test_track_across_segments_with_mock_av(tmp_path):
+def _install_asserting_aligner(monkeypatch, *, expected_first_x_fn):
+    """
+    Monkeypatch align_face_for_arcface with an assertion-heavy stub.
+
+    expected_first_x_fn(frame_idx) -> float:
+        returns the expected value for landmarks[0][0] for that DET call.
+        (You choose the contract per test: frame-based, call-based, etc.)
+    """
+    import numpy as _np
+
+    def _asserting_align(frame, landmarks, frame_idx=None, source=None, *, return_meta=False):
+        assert frame_idx is not None, "aligner called with frame_idx=None"
+        assert landmarks is not None, "aligner called with landmarks=None"
+        arr = _np.asarray(landmarks, dtype=_np.float32)
+
+        # Accept either (5,2) or (1,5,2) and normalize to (5,2)
+        if arr.shape == (1, 5, 2):
+            arr = arr[0]
+        assert arr.shape == (5, 2), f"expected (5,2) landmarks, got {arr.shape}"
+        assert _np.all(_np.isfinite(arr)), "landmarks contain NaN/Inf"
+
+        # Strong semantic check (not just > 0)
+        exp = float(expected_first_x_fn(frame_idx))
+        got = float(arr[0, 0])
+        assert got == exp, f"landmark corruption: expected arr[0,0]={exp} got {got} (frame_idx={frame_idx})"
+
+        chip = _np.zeros((112, 112, 3), dtype=_np.uint8)
+        if return_meta:
+            return chip, {"frame_idx": frame_idx, "source": source}
+        return chip
+
+    monkeypatch.setattr(tacs, "align_face_for_arcface", _asserting_align, raising=True)
+
+def test_track_across_segments_with_mock_av(tmp_path, monkeypatch):
     dummy_shot_json = tmp_path / "shot_features.json"
     shots = [
         {"shot_number": 1, "first_frame": 0, "last_frame": 2},
@@ -31,15 +62,40 @@ def test_track_across_segments_with_mock_av(tmp_path):
 
         def init_trackers(self, frame, boxes, track_ids=None, *a, **k):
             self.trackers = list(boxes)
-            # Mirror aggregator behavior in this code path: IDs start at 2
-            n = len(self.trackers)
             self.track_ids = list(track_ids) if track_ids is not None else list(range(len(self.trackers)))
 
         def update_trackers(self, frame):
             return {tid: box for tid, box in zip(self.track_ids, self.trackers)}
-        
+
+    class FakeDetector:
+        def __init__(self):
+            self.calls = 0
+
+        def detect_faces_in_frame(self, frame, target_size=640):
+            self.calls += 1
+            boxes = [(10, 10, 50, 50)]
+            # Encode FRAME INDEX (+1) into landmarks[0][0].x (stronger than call count)
+            # NOTE: track_across_segments passes the absolute frame index to aligner as frame_idx.
+            # We don't have frame_idx here, so just encode call count and validate via call count
+            # OR switch to frame_idx encoding by using the aligner meta instead (see below).
+            x = float(self.calls)
+            landmarks = [[(x, 0.0)] + [(0.0, 0.0)] * 4]
+            confidences = [0.99]
+            return boxes, landmarks, confidences
+
+    det = FakeDetector()
+
+    # Expected landmark x equals detector call count *at the time aligner is called*.
+    # Since aligner is invoked on each detection, this should match 1..N in order.
+    align_calls = {"n": 0}
+    def _expected(_frame_idx):
+        align_calls["n"] += 1
+        return float(align_calls["n"])
+
+    _install_asserting_aligner(monkeypatch, expected_first_x_fn=_expected)
+
     with patch("facekit.utils.video_reader.av.open") as mock_av_open, \
-     patch.object(tacs, "FaceTracker", FakeTracker):
+         patch.object(tacs, "FaceTracker", FakeTracker):
         mock_container = MagicMock()
         mock_stream = MagicMock()
         mock_stream.type = "video"
@@ -48,23 +104,15 @@ def test_track_across_segments_with_mock_av(tmp_path):
         mock_container.decode.return_value = make_pyav_like_frames(8)
         mock_av_open.return_value = mock_container
 
-        class FakeDetector:
-            def detect_faces_in_frame(self, frame, target_size=640):
-                boxes = [(10, 10, 50, 50)]
-                landmarks = [[(38, 52), (73, 52), (56, 72), (42, 92), (71, 92)]]
-                confidences = [0.99]
-                return boxes, landmarks, confidences
-
         class FakeEmbedder:
             def get_embedding_batch(self, aligned_faces, batch_size=32):
-                # Shape: (K, 512), float32
                 K = len(aligned_faces)
                 return np.ones((K, 512), dtype=np.float32)
 
         tracks = track_across_segments(
             frame_source="dummy.mp4",
             shot_json_path=str(dummy_shot_json),
-            detector=FakeDetector(),
+            detector=det,
             embedder=FakeEmbedder(),
         )
 
@@ -75,15 +123,26 @@ def test_all_tracks_have_valid_segment_ids(monkeypatch, dummy_video, tmp_path):
     dummy_shot_json = tmp_path / "shot_features.json"
     dummy_shot_json.write_text(json.dumps({"shots": [{"shot_number": 1, "first_frame": 0, "last_frame": 4}]}))
 
+    _calls = {"n": 0}
+
     def fake_detect_faces_in_frame(frame, target_size=640):
+        _calls["n"] += 1
         boxes = [(10, 10, 50, 50)]
-        landmarks = [[(38, 52), (73, 52), (56, 72), (42, 92), (71, 92)]]
+        x = float(_calls["n"])
+        landmarks = [[(x, 0.0)] + [(0.0, 0.0)] * 4]
         confidences = [0.99]
         return boxes, landmarks, confidences
 
     class FakeDetector:
         def detect_faces_in_frame(self, frame, target_size=640):
             return fake_detect_faces_in_frame(frame, target_size)
+        
+    align_calls = {"n": 0}
+    def _expected(_frame_idx):
+        align_calls["n"] += 1
+        return float(align_calls["n"])
+
+    _install_asserting_aligner(monkeypatch, expected_first_x_fn=_expected)
 
     class FakeEmbedder:
         def get_embedding_batch(self, aligned_faces, batch_size=32):
@@ -243,13 +302,31 @@ def test_align_face_returns_none_is_skipped(tmp_path, monkeypatch):
         mock_open.side_effect = lambda *a, **k: make_context()
 
         class FakeDetector:
+            def __init__(self):
+                self.calls = 0
             def detect_faces_in_frame(self, frame, target_size=640):
-                return [(10, 10, 50, 50)], [[(20, 20)] * 5], [0.9]
+                self.calls += 1
+                x = float(self.calls)
+                return [(10, 10, 50, 50)], [[(x, 0.0)] + [(0.0, 0.0)] * 4], [0.9]
 
         # Force align_face_for_arcface to return None on odd calls
         calls = {"n": 0}
-        def fake_align(frame, lm, frame_idx=None, source=None):
+
+        def fake_align(frame, landmarks, frame_idx=None, source=None):
             calls["n"] += 1
+
+            arr = np.asarray(landmarks, dtype=np.float32)
+            if arr.shape == (1, 5, 2):
+                arr = arr[0]
+            assert arr.shape == (5, 2)
+            assert np.all(np.isfinite(arr))
+
+            expected_x = float(calls["n"])
+            actual_x = float(arr[0, 0])
+            assert actual_x == expected_x, (
+                f"expected landmarks[0][0].x={expected_x} but got {actual_x} (align call {calls['n']})"
+            )
+
             return None if calls["n"] % 2 else np.zeros((112, 112, 3), dtype=np.uint8)
 
         monkeypatch.setattr(tacs, "align_face_for_arcface", fake_align)

--- a/tests/test_track_consolidation_and_pruning.py
+++ b/tests/test_track_consolidation_and_pruning.py
@@ -1,0 +1,243 @@
+import pytest
+
+from facekit.common.obs_consts import Source
+from facekit.tracking.face_structures import FaceTrack, FaceObservation
+
+from facekit.tracking.track_consolidation_and_pruning import (
+    apply_track_consolidation_and_pruning,
+)
+
+
+# ----------------------------
+# Test helpers
+# ----------------------------
+
+def obs(frame_idx: int, bbox, *, src=Source.DETECTED) -> FaceObservation:
+    return FaceObservation(
+        frame_idx=int(frame_idx),
+        bbox=tuple(map(int, bbox)),
+        source=src,
+        track_id=None,
+        embedding=None,
+        confidence=None,
+        aligned_face=None,
+        landmarks=None,
+    )
+
+def make_track(
+    *,
+    shot_id: int,
+    track_id: int,
+    global_id: int | None,
+    frames_and_bboxes: list[tuple[int, tuple[int, int, int, int]]],
+) -> FaceTrack:
+    t = FaceTrack(shot_id=int(shot_id), track_id=int(track_id), global_id=global_id)
+    # Ensure open so add_observation works in your implementation
+    if hasattr(t, "mark_open"):
+        t.mark_open()
+    for f, bb in frames_and_bboxes:
+        o = obs(f, bb, src=Source.DETECTED)
+        o.track_id = int(track_id)
+        try:
+            o.shot_id = int(shot_id)
+        except Exception:
+            pass
+        t.add_observation(o)
+    return t
+
+def frames(t: FaceTrack) -> list[int]:
+    return list(map(int, t.get_frame_indices()))
+
+def sources_by_frame(t: FaceTrack) -> dict[int, Source]:
+    return {int(o.frame_idx): o.source for o in (t.observations or [])}
+
+
+# ----------------------------
+# Tests: Phase 1 reassignment
+# ----------------------------
+
+def test_short_track_competition_same_gid_winner_keeps_loser_falls_back():
+    """
+    Two short tracks overlap in time and both want gid=10.
+    The better-fitting one (higher IoU evidence) keeps gid=10.
+    The loser should fall back to gid=11 (its second-best candidate),
+    not be pruned just because it lost.
+    """
+    shot = 1
+
+    # Left caps:
+    # L10 ends at 4; bbox is very close to short1 start bbox -> strong IoU
+    L10 = make_track(
+        shot_id=shot, track_id=100, global_id=10,
+        frames_and_bboxes=[(4, (10, 10, 50, 50))]
+    )
+    # L11 also ends at 4; bbox is closer to short2 start bbox -> good fallback
+    L11 = make_track(
+        shot_id=shot, track_id=101, global_id=11,
+        frames_and_bboxes=[(4, (100, 100, 140, 140))]
+    )
+
+    # Two short tracks that overlap in time:
+    # short1: frames 5-6 near L10 bbox => wants gid=10
+    S1 = make_track(
+        shot_id=shot, track_id=1, global_id=None,
+        frames_and_bboxes=[(5, (11, 11, 51, 51)), (6, (12, 12, 52, 52))]
+    )
+    # short2: frames 6-7 closer to L11 bbox, but still can "see" L10 as a candidate
+    S2 = make_track(
+        shot_id=shot, track_id=2, global_id=None,
+        frames_and_bboxes=[(6, (102, 102, 142, 142)), (7, (103, 103, 143, 143))]
+    )
+
+    tracks = [L10, L11, S1, S2]
+
+    out = apply_track_consolidation_and_pruning(
+        tracks,
+        min_gap_len=10,
+        min_track_len=3,      # S1 and S2 are short (len 2)
+        iou_threshold=0.1,    # permissive
+    )
+
+    # S1 should take gid=10; S2 should take gid=11 (fallback)
+    by_tid = {t.track_id: t for t in out}
+    assert by_tid[1].global_id == 10
+    assert by_tid[2].global_id == 11
+
+    # Both should survive (they now have gids)
+    assert 1 in by_tid and 2 in by_tid
+
+
+def test_short_track_cannot_take_gid_if_it_overlaps_fixed_track_with_that_gid():
+    """
+    If a short track overlaps in time with a fixed (non-short) track that already has gid=10,
+    it must not be reassigned to gid=10 even if IoU would suggest it.
+    It should fall back to gid=11 if available.
+    """
+    shot = 1
+
+    # Fixed (long) track with gid=10 spanning 5..20
+    fixed10 = make_track(
+        shot_id=shot, track_id=200, global_id=10,
+        frames_and_bboxes=[(5, (10, 10, 50, 50)), (20, (10, 10, 50, 50))]
+    )
+    # Left caps for gid=10 and gid=11 end at 9, within min_gap_len of the short track at 10
+    L10 = make_track(
+        shot_id=shot, track_id=201, global_id=10,
+        frames_and_bboxes=[(9, (10, 10, 50, 50))]
+    )
+    L11 = make_track(
+        shot_id=shot, track_id=202, global_id=11,
+        frames_and_bboxes=[(9, (12, 12, 52, 52))]
+    )
+
+    # Short track overlaps fixed10 in time (10..11)
+    S = make_track(
+        shot_id=shot, track_id=3, global_id=None,
+        frames_and_bboxes=[(10, (11, 11, 51, 51)), (11, (12, 12, 52, 52))]
+    )
+
+    tracks = [fixed10, L10, L11, S]
+
+    out = apply_track_consolidation_and_pruning(
+        tracks,
+        min_gap_len=10,
+        min_track_len=3,     # S is short
+        iou_threshold=0.1,
+    )
+
+    by_tid = {t.track_id: t for t in out}
+    assert by_tid[3].global_id == 11, "Should fall back because gid=10 overlaps fixed gid=10 track"
+
+
+# ----------------------------
+# Tests: Phase 3 gap filling + merge
+# ----------------------------
+
+def test_fill_gap_merges_two_tracks_and_injects_interpolated_frames():
+    """
+    Same gid tracks A then B with a short gap should:
+      - inject interpolated observations into A for every gap frame
+      - merge B into A
+      - remove B from output list
+    """
+    if not hasattr(Source, "INTERPOLATED"):
+        pytest.skip("Source.INTERPOLATED not defined yet")
+
+    shot = 1
+
+    A = make_track(
+        shot_id=shot, track_id=10, global_id=1,
+        frames_and_bboxes=[(0, (0, 0, 10, 10)), (2, (0, 0, 10, 10))]
+    )
+    # Gap frames are 3 and 4 (since B starts at 5)
+    B = make_track(
+        shot_id=shot, track_id=11, global_id=1,
+        frames_and_bboxes=[(5, (1, 1, 11, 11)), (6, (1, 1, 11, 11))]
+    )
+
+    tracks = [A, B]
+
+    out = apply_track_consolidation_and_pruning(
+        tracks,
+        min_gap_len=5,       # gap_len=2 => fill
+        min_track_len=1,     # no pruning concerns
+        iou_threshold=0.0,   # ensure boundary passes
+    )
+
+    # Should now be ONE surviving gid=1 track in this shot
+    gid1 = [t for t in out if t.shot_id == shot and t.global_id == 1]
+    assert len(gid1) == 1
+
+    T = gid1[0]
+    fs = frames(T)
+    assert fs == [0, 2, 3, 4, 5, 6] or fs == [0, 2, 3, 4, 5, 6], "Expected merged + gap frames"
+
+    srcs = sources_by_frame(T)
+    assert srcs[3] == Source.INTERPOLATED
+    assert srcs[4] == Source.INTERPOLATED
+    assert srcs[5] == Source.DETECTED
+    assert srcs[6] == Source.DETECTED
+
+
+def test_fill_gap_is_blocked_if_any_gap_frame_is_occupied_by_any_track():
+    """
+    No frame skipping: if any gap frame is occupied by ANY track in the shot,
+    we do not fill and therefore do not merge.
+    """
+    if not hasattr(Source, "INTERPOLATED"):
+        pytest.skip("Source.INTERPOLATED not defined yet")
+
+    shot = 1
+
+    A = make_track(
+        shot_id=shot, track_id=10, global_id=1,
+        frames_and_bboxes=[(0, (0, 0, 10, 10)), (2, (0, 0, 10, 10))]
+    )
+    B = make_track(
+        shot_id=shot, track_id=11, global_id=1,
+        frames_and_bboxes=[(5, (1, 1, 11, 11))]
+    )
+
+    # Occupier has an observation at frame 3 (in the gap 3..4)
+    OCC = make_track(
+        shot_id=shot, track_id=99, global_id=999,
+        frames_and_bboxes=[(3, (200, 200, 210, 210))]
+    )
+
+    tracks = [A, B, OCC]
+
+    out = apply_track_consolidation_and_pruning(
+        tracks,
+        min_gap_len=5,
+        min_track_len=1,
+        iou_threshold=0.0,
+    )
+
+    # Should NOT merge; both gid=1 tracks remain
+    gid1 = sorted([t for t in out if t.shot_id == shot and t.global_id == 1], key=lambda t: t.track_id)
+    assert len(gid1) == 2
+
+    # And no interpolated observations should have been added to A
+    srcsA = sources_by_frame(gid1[0])
+    assert 3 not in srcsA or srcsA[3] != Source.INTERPOLATED
+    assert 4 not in srcsA or srcsA[4] != Source.INTERPOLATED

--- a/tests/test_validation_dispatcher_v21.py
+++ b/tests/test_validation_dispatcher_v21.py
@@ -1,13 +1,23 @@
+import os
 import json
 from pathlib import Path
 import numpy as np
 import pytest
 from facekit.validation import validate_manifest
 from facekit.validation.json.validate_shot_features_json_v2 import validate_shot_features_json_v2
+import facekit
 
-
+@pytest.fixture
+def schema_path() -> Path:
+    pkg_root = Path(facekit.__file__).resolve().parent.parent
+    schema = pkg_root / "schemas" / "shot_features_v2.1.schema.json"
+    assert schema.exists(), f"Schema not found at {schema}"
+    return schema
 
 def _minimal_v21(tmp_path: Path):
+    obs_path = tmp_path / "obs.npz"
+    emb_path = tmp_path / "embs.npz"
+
     data = {
         "schema_version": "2.1",
         "video": {"path":"x.mp4","fps":30.0,"size":[100,100],"total_frames":2},
@@ -21,9 +31,12 @@ def _minimal_v21(tmp_path: Path):
                 "obs_offset":0, "obs_count":2
             }]
         }],
-        "embedding_sidecar": {"path": str(tmp_path/"embs.npz"), "format":"npz","dtype":"float32","dim":512,"count":2},
+        "embedding_sidecar": {
+            "path": str(emb_path), 
+            "format":"npz","dtype":"float32","dim":512,"count":2
+            },
         "observations_sidecar": {
-          "path":"obs.npz",
+          "path": str(obs_path),
           "format":"npz",
           "dtype":"structured",
           "fields": [
@@ -54,3 +67,90 @@ def test_v21_rejects_unknown_minor(tmp_path):
     # using v2 validator directly – expect schema error or business error list
     errs = validate_shot_features_json_v2(p, p)  # bogus schema path ok; validator iterates anyway
     assert errs, "Expected errors for unknown minor"
+
+def test_trackless_shot_is_schema_and_business_valid(tmp_path: Path, schema_path: Path):
+    data = {
+        "schema_version": "2.1",
+        "video": {
+            "path": "dummy.mp4",
+            "fps": 30.0,
+            "size": [1920, 1080],
+            "total_frames": 300,
+        },
+        "generation": {
+            "created_utc": "2025-01-01T00:00:00Z",
+            "commit": "deadbeef",
+            "branch": "main",
+            "params_hash": "abc123",
+            "emb_store": "sidecar",
+        },
+        "observations_sidecar": {
+            "path": "obs_ckpt.npz",
+            "format": "npz",
+            "dtype": "structured",
+            "fields": [
+                {"name": "shot", "type": "int32"},
+                {"name": "f", "type": "int32"},
+            ],
+            "count": 0,
+        },
+        "embedding_sidecar": {
+            "path": "emb_ckpt.npz",
+            "format": "npz",
+            "dtype": "float32",
+            "dim": 512,
+            "count": 0,
+        },
+        "shots": [
+            {
+                "shot_number": 1,
+                "first_frame": 0,
+                "last_frame": 99,
+                "num_tracks": 1,
+                "face_tracks": [
+                    {
+                        "first_frame": 0,
+                        "last_frame": 99,
+                        "face_label": "face1",
+                        "avg_center_x": 50.0,
+                        "avg_center_y": 50.0,
+                        "avg_face_width": 20.0,
+                        "avg_face_height": 30.0,
+                        "is_static": False,
+                        "obs_offset": 0,
+                        "obs_count": 100,
+                    }
+                ],
+            },
+            {
+                # << trackless graphics-only shot >>
+                "shot_number": 2,
+                "first_frame": 100,
+                "last_frame": 199,
+                "num_tracks": 0,
+                "face_tracks": [],
+            },
+            {
+                "shot_number": 3,
+                "first_frame": 200,
+                "last_frame": 299,
+                "num_tracks": 0,
+                "face_tracks": [],
+            },
+        ],
+        "totals": {
+            "num_shots": 3,
+            "num_tracks": 1,
+        },
+    }
+
+    json_path = tmp_path / "trackless.json"
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+
+    errs = validate_shot_features_json_v2(
+        json_path=json_path,
+        schema_path=schema_path,
+        total_frame_count=300,
+    )
+
+    assert errs == []

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -10,23 +10,23 @@ def _solid_frame(h: int = 240, w: int = 320, bgr=(40, 40, 40)) -> np.ndarray:
     img[:] = bgr
     return img
 
+def _paint_box(frame: np.ndarray, box_xywh, bgr) -> np.ndarray:
+    x, y, w, h = [int(round(v)) for v in box_xywh]
+    out = frame.copy()
+    cv2.rectangle(out, (x, y), (x + w, y + h), bgr, thickness=-1)
+    return out
+
 @pytest.fixture
 def frames_gray():
-    """
-    Simple deterministic frames list for validator (no I/O).
-    60 frames, same content by default.
-    """
+    # 60 deterministic frames, identical content
     return [_solid_frame() for _ in range(60)]
 
 @pytest.fixture
 def frames_with_patch():
-    """
-    Frames where we draw a colored patch (so HSV signatures are non-degenerate).
-    """
+    # 60 deterministic frames with a patch whose color varies slightly
     frames = []
     for i in range(60):
         img = _solid_frame()
-        # small patch varies slightly over time (but stays very similar)
         x, y, s = 100, 80, 40
         color = (40 + (i % 5), 180, 220)  # BGR
         cv2.rectangle(img, (x, y), (x + s, y + s), color, thickness=-1)
@@ -38,81 +38,75 @@ BBox = tuple[float, float, float, float]
 def _box(x, y, w, h) -> BBox:
     return (float(x), float(y), float(w), float(h))
 
-
 def test_accepts_consecutive_small_changes(frames_with_patch):
-    first = 10
     p = ValidatorParams(
-        iou_thresh=0.4,           # allow moderate overlap drop
+        iou_thresh=0.4,
         area_delta_max=0.5,
         asp_ratio_delta_max=0.5,
         v_max=0.8,
-        hsv_thresh=0.5
+        hsv_thresh=0.5,
     )
-    v = TrackerValidator(frames_with_patch, first_frame_idx=first, params=p)
+    v = TrackerValidator(params=p)
 
-    # Seed at frame 10
-    f10 = first
+    f10 = 10
     boxes10 = {1: _box(100, 80, 40, 40)}
-    v.set_baseline(boxes10, f10)
+    assert v.validate(boxes10, current_frame=frames_with_patch[f10], frame_idx=f10) is True
 
-    # Small, realistic movement/scale change at frame 11
-    f11 = first + 1
+    f11 = 11
     boxes11 = {1: _box(102, 82, 41, 39)}
-    assert v.validate(boxes11, f11, verbose=True) is True
+    assert v.validate(boxes11, current_frame=frames_with_patch[f11], frame_idx=f11) is True
 
-    # Another tiny change at frame 12
-    f12 = first + 2
+    f12 = 12
     boxes12 = {1: _box(104, 84, 41, 40)}
-    assert v.validate(boxes12, f12) is True
-
+    assert v.validate(boxes12, current_frame=frames_with_patch[f12], frame_idx=f12) is True
 
 def test_rejects_large_motion(frames_gray):
-    first = 0
-    v = TrackerValidator(frames_gray, first_frame_idx=first, params=ValidatorParams())
+    v = TrackerValidator(params=ValidatorParams())
+
     # seed at frame 0
-    boxes0 = {5: _box(50, 50, 40, 40)}
-    v.set_baseline(boxes0, 0)
+    assert v.validate({5: _box(50, 50, 40, 40)}, current_frame=frames_gray[0], frame_idx=0) is True
 
-    # jump far away next frame -> should fail on velocity/IoU
-    boxes1 = {5: _box(200, 160, 40, 40)}
-    assert v.validate(boxes1, 1, verbose=True) is False
-
+    # jump far away next frame -> should fail on velocity and/or IoU
+    assert v.validate({5: _box(200, 160, 40, 40)}, current_frame=frames_gray[1], frame_idx=1) is False
 
 def test_rejects_low_iou(frames_gray):
-    first = 5
-    p = ValidatorParams(iou_thresh=0.7)  # make IoU stricter
-    v = TrackerValidator(frames_gray, first_frame_idx=first, params=p)
-    v.set_baseline({3: _box(100, 80, 40, 40)}, first)
+    p = ValidatorParams(iou_thresh=0.7, hsv_thresh=2.0)  # disable HSV to isolate IoU
+    v = TrackerValidator(params=p)
 
-    # Shift enough to drop IoU below 0.7 (but not too far to trigger velocity alone)
-    assert v.validate({3: _box(130, 80, 40, 40)}, first + 1, verbose=True) is False
+    f = 5
+    assert v.validate({3: _box(100, 80, 40, 40)}, current_frame=frames_gray[f], frame_idx=f) is True
 
+    # Shift enough to drop IoU below 0.7
+    assert v.validate({3: _box(130, 80, 40, 40)}, current_frame=frames_gray[f + 1], frame_idx=f + 1) is False
 
 def test_reseeds_on_non_consecutive(frames_with_patch):
+    v = TrackerValidator(params=ValidatorParams())
+
     first = 20
-    v = TrackerValidator(frames_with_patch, first_frame_idx=first, params=ValidatorParams())
+    assert v.validate({1: _box(100, 80, 40, 40)}, current_frame=frames_with_patch[first], frame_idx=first) is True
 
-    # First call with no baseline -> seeds and returns True
-    assert v.validate({1: _box(100, 80, 40, 40)}, first) is True
+    # skip a frame => non-consecutive => reseed and accept
+    assert v.validate({1: _box(101, 81, 40, 40)}, current_frame=frames_with_patch[first + 2], frame_idx=first + 2) is True
 
-    # Skip a frame (non-consecutive); validator should reseed and accept
-    assert v.validate({1: _box(101, 81, 40, 40)}, first + 2) is True
+def test_hsv_appearance_threshold(frames_gray):
+    """
+    Keep geometry identical, but change the pixels inside the box a lot between frames
+    so failure is driven by HSV (not IoU/velocity).
+    """
+    box = _box(100, 80, 40, 40)
 
+    # frame 0: box painted one color; frame 1: box painted very different color
+    f0 = _paint_box(frames_gray[0], box, bgr=(0, 0, 255))     # red
+    f1 = _paint_box(frames_gray[1], box, bgr=(0, 255, 255))   # yellow/cyan-ish
 
-def test_hsv_appearance_threshold(frames_with_patch):
-    first = 0
-    # Tighten hsv_thresh so appearance difference triggers failure
-    p = ValidatorParams(hsv_thresh=0.05, iou_thresh=0.4)  # lenient geom, strict appearance
-    v = TrackerValidator(frames_with_patch, first_frame_idx=first, params=p)
+    p = ValidatorParams(
+        iou_thresh=0.4,
+        area_delta_max=0.8,
+        asp_ratio_delta_max=0.8,
+        v_max=2.0,         # generous, so geom can’t fail
+        hsv_thresh=0.05,   # strict appearance
+    )
+    v = TrackerValidator(params=p)
 
-    # Seed at 0
-    v.set_baseline({9: _box(100, 80, 40, 40)}, 0)
-
-    # Make a "different appearance" by shifting the box outside the colored patch
-    # BUT keep geometry okay to ensure failure is from appearance, not IoU/velocity.
-    # At frame 1, the patch is still near (100,80). Move to a region without patch.
-    new_box = _box(10, 10, 40, 40)
-    ok = v.validate({9: new_box}, 1, verbose=True)
-
-    # Expect failure due to appearance mismatch (HSV distance > hsv_thresh)
-    assert ok is False
+    assert v.validate({9: box}, current_frame=f0, frame_idx=0) is True
+    assert v.validate({9: box}, current_frame=f1, frame_idx=1) is False

--- a/tests/utils/probe_sidecars.py
+++ b/tests/utils/probe_sidecars.py
@@ -9,21 +9,30 @@ What it does:
   - Loads obs sidecar: <run-root>/ckpt/obs_ckpt.npz  (key 'observations')
   - Loads emb sidecar: <run-root>/ckpt/emb_ckpt.npz  (key usually 'embeddings' or 'vecs')
   - Treats the given `anchor` as the resume anchor frame.
-  - Enforces **new resume semantics**:
+  - Enforces **current resume semantics** (no crops):
 
     Let `anchor_shot` be the shot that contains DET rows at frame == anchor.
 
     * For all pre-anchor DET rows (f <= anchor-1) in **completed shots** (shot < anchor_shot):
-        - Require that each row has a valid embedding index: 0 <= emb_idx < num_embeddings.
-        - Also require that a crop is present (has_crop == 1 or crop_ref non-empty).
+        - Require that each row has a valid embedding index:
+              0 <= emb_idx < num_embeddings
+        - Require that each row has valid landmarks:
+              * landmarks present
+              * numeric
+              * finite (no NaN/Inf)
+              * shape either (10,) flat or (5,2)
 
     * For pre-anchor DET rows in the **anchor shot** (shot == anchor_shot):
-        - Require that a crop is present.
-        - Do **NOT** require emb_idx; it's allowed to be -1, since embeddings
-          will be recomputed from crops on resume.
+        - Require valid landmarks (same rules as above).
+        - Do **NOT** require emb_idx; it's allowed to be -1 because embeddings may be
+          computed/batched at end-of-shot and the anchor shot may be incomplete at crash time.
 
   - Exits 0 if all invariants hold.
   - Exits 1 otherwise, printing a summary of the violations.
+
+Notes:
+  - This script intentionally does not check anything about crops. Crops are not persisted
+    under the current contract; landmarks are the persisted alignment primitive.
 """
 
 import argparse
@@ -31,6 +40,8 @@ import sys
 from pathlib import Path
 import numpy as np
 
+
+# ---- Loading helpers ---------------------------------------------------------
 
 def _load_obs(run_root: Path):
     obs_npz = run_root / "ckpt" / "obs_ckpt.npz"
@@ -56,6 +67,128 @@ def _load_emb(run_root: Path):
     return None
 
 
+# ---- Landmarks helpers -------------------------------------------------------
+
+def _select_landmarks_field(fields: tuple[str, ...]) -> str | None:
+    """
+    Return the preferred landmarks field name present in `fields`, else None.
+
+    We explicitly avoid the abbreviation 'lm'. If legacy schemas used it, we can
+    choose to support it, but we won't print or refer to it as 'lm'.
+    """
+    # Current canonical (based on your printed dtype): 'landmarks_flat10'
+    preferred = (
+        "landmarks_flat10",   # flat [x1,y1,...,x5,y5]
+        "landmarks",          # generic
+        "landmarks_5pt",      # explicit
+        "landmarks5",         # alternative legacy-ish
+        "five_point_landmarks",
+        # If you *must* support older data, add exact legacy field names here.
+        # Avoid "lm" in new code; only include if you really have old files:
+        # "lm",
+        # "lms",
+    )
+    for name in preferred:
+        if name in fields:
+            return name
+    return None
+
+
+def _landmarks_missing_or_invalid_mask(
+    obs: np.ndarray,
+    det_mask: np.ndarray,
+) -> tuple[np.ndarray, str | None]:
+    """
+    Return (bad_mask, landmarks_field_name).
+
+    bad_mask is True for DET rows (per det_mask) that are missing landmarks OR have invalid landmarks.
+
+    Valid landmarks:
+      - present in sidecar under a supported field name
+      - numeric array
+      - finite (no NaN/Inf)
+      - shape either:
+          * (10,)   flat
+          * (5, 2)  5 points x/y
+    """
+    fields = obs.dtype.names or ()
+    landmarks_field = _select_landmarks_field(fields)
+    if landmarks_field is None:
+        # If we cannot find any landmarks field at all, all DET rows are invalid.
+        return det_mask.copy(), None
+
+    # If a has_landmarks flag exists, honor it. Otherwise infer "should have landmarks"
+    # for DET rows (conservative: DET rows must have landmarks under the current contract).
+    if "has_landmarks" in fields:
+        should_have = det_mask & (obs["has_landmarks"].astype(int) == 1)
+    else:
+        should_have = det_mask.copy()
+
+    # Pull landmarks array; expected numeric dtype (float32)
+    landmarks = obs[landmarks_field]
+
+    bad = np.zeros(det_mask.shape[0], dtype=bool)
+
+    # Shape handling:
+    # - If landmarks is (N, 10): each row flat10
+    # - If landmarks is (N, 5, 2): each row 5x2
+    # - If landmarks is object/structured, we'll attempt per-row conversion (slower but robust)
+    try:
+        arr = np.asarray(landmarks)
+        # Fast-path numeric
+        if arr.dtype != object:
+            # Per-row validation depending on dimensionality
+            if arr.ndim == 2 and arr.shape[1] == 10:
+                # Check finiteness for required rows
+                finite = np.all(np.isfinite(arr), axis=1)
+                bad |= should_have & ~finite
+            elif arr.ndim == 3 and arr.shape[1:] == (5, 2):
+                finite = np.all(np.isfinite(arr.reshape(arr.shape[0], -1)), axis=1)
+                bad |= should_have & ~finite
+            else:
+                # Unexpected shape: mark required rows bad
+                bad |= should_have
+        else:
+            # Object array: validate row-by-row
+            idx = np.nonzero(should_have)[0]
+            for i in idx:
+                try:
+                    one = np.asarray(landmarks[i], dtype=np.float32)
+                    if one.shape == (10,):
+                        ok_shape = True
+                        flat = one
+                    elif one.shape == (5, 2):
+                        ok_shape = True
+                        flat = one.reshape(-1)
+                    else:
+                        ok_shape = False
+                        flat = None
+                    if (not ok_shape) or (flat is None) or (not np.all(np.isfinite(flat))):
+                        bad[i] = True
+                except Exception:
+                    bad[i] = True
+    except Exception:
+        # If anything goes wrong at array level, mark required rows bad.
+        bad |= should_have
+
+    # Also treat "all zeros" as suspicious? (Optional)
+    # Under your pipeline, zeros are unlikely; but if you want to enforce nonzero:
+    # (keeping it OFF by default because it can false-positive on edge cases)
+    #
+    # if landmarks_field is not None:
+    #     try:
+    #         arr = np.asarray(obs[landmarks_field], dtype=np.float32)
+    #         if arr.ndim == 2 and arr.shape[1] == 10:
+    #             nonzero = np.any(arr != 0, axis=1)
+    #             bad |= should_have & ~nonzero
+    #     except Exception:
+    #         pass
+
+    return bad, landmarks_field
+
+
+# ---- Main --------------------------------------------------------------------
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--run-root", required=True, type=Path)
@@ -70,7 +203,7 @@ def main(argv=None) -> int:
     obs = _load_obs(run_root)
     emb = _load_emb(run_root)
 
-    fields = obs.dtype.names
+    fields = obs.dtype.names or ()
     print("OBS fields:", fields)
 
     n_emb = int(emb.shape[0]) if emb is not None else 0
@@ -82,16 +215,8 @@ def main(argv=None) -> int:
     src = obs["src"].astype(int)
     emb_idx = obs["emb_idx"].astype(int) if "emb_idx" in fields else np.full_like(f, -1, dtype=int)
 
-    # has_crop: prefer explicit field; else infer from crop_ref
-    if "has_crop" in fields:
-        has_crop_arr = (obs["has_crop"] == 1)
-    elif "crop_ref" in fields:
-        has_crop_arr = (obs["crop_ref"] != b"") & (obs["crop_ref"] != "")
-    else:
-        has_crop_arr = np.zeros_like(f, dtype=bool)
-
     # Pre-anchor DET rows: f <= anchor-1
-    pre_anchor_mask = (src == det_code) & (f <= anchor - 1)
+    pre_anchor_det_mask = (src == det_code) & (f <= anchor - 1)
 
     # Determine anchor_shot from DET rows at exactly anchor, if any.
     anchor_det_mask = (src == det_code) & (f == anchor)
@@ -99,39 +224,39 @@ def main(argv=None) -> int:
     if anchor_shots.size == 1:
         anchor_shot = int(anchor_shots[0])
     else:
-        # Fallback: take the max shot index seen among pre-anchor rows (conservative).
-        pre_shots = np.unique(shot[pre_anchor_mask]) if pre_anchor_mask.any() else np.array([], dtype=int)
+        # Fallback: take the max shot index seen among pre-anchor DET rows (conservative).
+        pre_shots = np.unique(shot[pre_anchor_det_mask]) if pre_anchor_det_mask.any() else np.array([], dtype=int)
         anchor_shot = int(pre_shots.max()) if pre_shots.size > 0 else None
 
     print(f"Anchor: {anchor} (checked frames <= {anchor-1})")
     print(f"Anchor shot inferred as: {anchor_shot!r}")
 
-    if not pre_anchor_mask.any():
+    if not pre_anchor_det_mask.any():
         print("No pre-anchor DET rows found; nothing to check.")
         return 0
 
-    # --- Crop invariant: ALL pre-anchor DET rows must have crops ---
-    missing_crop_mask = pre_anchor_mask & ~has_crop_arr
-    missing_crop_count = int(missing_crop_mask.sum())
+    # --- Landmarks invariant: all pre-anchor DET rows must have valid landmarks ---
+    bad_landmarks_mask, landmarks_field_name = _landmarks_missing_or_invalid_mask(obs, pre_anchor_det_mask)
+    bad_landmarks_count = int(bad_landmarks_mask.sum())
 
     # --- Embedding invariant: completed shots only (shot < anchor_shot) ---
-    completed_shot_mask = np.zeros_like(pre_anchor_mask, dtype=bool)
     if anchor_shot is not None:
-        completed_shot_mask = pre_anchor_mask & (shot < anchor_shot)
+        completed_shot_mask = pre_anchor_det_mask & (shot < anchor_shot)
     else:
-        # If we couldn't infer anchor_shot, treat all as completed (old strict behavior).
-        completed_shot_mask = pre_anchor_mask.copy()
+        # If we couldn't infer anchor_shot, treat all as completed (strict fallback).
+        completed_shot_mask = pre_anchor_det_mask.copy()
 
     bad_emb_mask = completed_shot_mask & ((emb_idx < 0) | (emb_idx >= n_emb))
     missing_emb_count = int(bad_emb_mask.sum())
 
     # For debugging, report totals
-    det_rows_total = int(pre_anchor_mask.sum())
-    print("\n=== DET→EMB parity (completed shots only) ===")
+    det_rows_total = int(pre_anchor_det_mask.sum())
+    print("\n=== DET→LANDMARKS and DET→EMB checks (pre-anchor) ===")
     print(f"Total DET rows considered (pre-anchor, all shots): {det_rows_total}")
     print(f"Completed-shot DET rows (shot < anchor_shot): {int(completed_shot_mask.sum())}")
     print(f"Embedding rows in sidecar: {n_emb}")
-    print(f"Missing crops in pre-anchor DET rows: {missing_crop_count}")
+    print(f"Landmarks field used: {landmarks_field_name!r}")
+    print(f"Pre-anchor DET rows missing/invalid landmarks: {bad_landmarks_count}")
     print(f"Missing embeddings in completed shots: {missing_emb_count}")
 
     # Show small samples when there are issues
@@ -142,32 +267,42 @@ def main(argv=None) -> int:
         print(f"\n=== Samples for {label} (up to {limit}) ===")
         for i in idx[:limit]:
             row = {name: obs[name][i] for name in fields}
-            # make it a bit shorter
+            # make it a bit shorter / consistent
             row["f"] = int(row.get("f", -1))
             row["shot"] = int(row.get("shot", -1))
             row["src"] = int(row.get("src", -1))
-            row["emb_idx"] = int(row.get("emb_idx", -1)) if "emb_idx" in row else -1
-            row["has_crop"] = int(row.get("has_crop", 0)) if "has_crop" in row else int(bool(row.get("crop_ref")))
+            if "emb_idx" in row:
+                row["emb_idx"] = int(row["emb_idx"])
+            if "has_landmarks" in row:
+                row["has_landmarks"] = int(row["has_landmarks"])
+            # Optional: truncate very long landmarks prints
+            if landmarks_field_name and landmarks_field_name in row:
+                try:
+                    lm_arr = np.asarray(row[landmarks_field_name], dtype=np.float32).reshape(-1)
+                    if lm_arr.size > 10:
+                        row[landmarks_field_name] = lm_arr[:10]
+                except Exception:
+                    pass
             print(row)
 
-    if missing_crop_count:
-        _sample(missing_crop_mask, "pre-anchor DET rows missing crops")
+    if bad_landmarks_count:
+        _sample(bad_landmarks_mask, "pre-anchor DET rows missing/invalid landmarks")
 
     if missing_emb_count:
         _sample(bad_emb_mask, "completed-shot DET rows with invalid emb_idx")
 
     # Decide exit code:
-    #  - Any missing crop in pre-anchor DET rows is a hard error.
+    #  - Any missing/invalid landmarks in pre-anchor DET rows is a hard error.
     #  - Any missing embedding in completed shots is a hard error.
-    if missing_crop_count or missing_emb_count:
+    if bad_landmarks_count or missing_emb_count:
         print("\n=== Summary ===")
         print(f"Pre-anchor DET rows: {det_rows_total}")
-        print(f"Missing crops (all pre-anchor DET): {missing_crop_count}")
+        print(f"Missing/invalid landmarks (all pre-anchor DET): {bad_landmarks_count}")
         print(f"Missing embeddings (completed shots only): {missing_emb_count}")
         return 1
 
     print("\n=== Summary ===")
-    print("OK: all pre-anchor DET rows have crops; completed shots have DET↔EMB parity.")
+    print("OK: all pre-anchor DET rows have valid landmarks; completed shots have DET↔EMB parity.")
     return 0
 
 


### PR DESCRIPTION
Improve efficiency, persist landmarks for end-of-shot embedding calculations vs. cropped faces and tighten resume embedding linkage

- remove memory leak shot_frames identified by Jamie Roberts from track_across_segments.py
- validator constructor and validator.validate() no longer relies on shot_frames, but instead just current frame is passed to validate()
- fix limitations on hsv_thresh to be between 0,2 instead of -1,1
- set_baseline() now requires hsv_signature_dict as a  parameter
- Replace crop-based DETECTED bookkeeping with persisted ArcFace landmarks (landmarks_flat10).
- Enforce DETECTED landmarks at checkpoint + collector boundaries; tighten embedding linkage to exact frame.
- Update resume rehydrate to rebuild landmarks and stabilize segment ordering.