### PR TITLE
Multi-embedding-per-track identity handling across tracking

### DIFF
--- a/facekit/cli/resolve_face_ids_v2_cli.py
+++ b/facekit/cli/resolve_face_ids_v2_cli.py
@@ -271,6 +271,7 @@ def run_pipeline(args):
             detector=detector,
             embedder=embedder,
             detect_interval=int(args.detect_interval),
+            track_sample_interval=args.track_sample_interval,
             embedding_batch_size_max=int(args.embedding_batch_size_max),
             embedding_queue_max_pending=embedding_queue_max_pending,
             checkpoint=ckpt,
@@ -496,8 +497,6 @@ def main() -> None:
                         help="Path to YOLOv5 model weights",)
     parser.add_argument("--embedding-model", default="models/embedding/glintr100_dynamic.onnx",
                         help="Path to ArcFace ONNX model",)
-    parser.add_argument("--embedding-queue-max-pending", type=int, default=1024,
-                        help=("Flush trigger for the embedding queue: flush occurs only when pending >= max_pending. "))
     parser.add_argument("--config", default="models/detector/yolov5n.yaml",
                         help="Path to YOLOv5 model config",)
     parser.add_argument("--min-face", type=positive_int, default=10,
@@ -517,12 +516,20 @@ def main() -> None:
                         help=("Render video with global + segment IDs. "
                                 "If used with no value, writes '<video>_global_faceIDs.avi'. "
                                 "If a path is provided, writes there."))
-    parser.add_argument("--detect-interval", type=int, default=30,
-                        help="frame count between forced face detection frame")
-    parser.add_argument("--embedding-batch-size-max", type=int, default=32)
     parser.add_argument("--device",  choices=["auto", "cuda", "cpu"], default="auto",
                         help="Compute device for detector/embedder (default: auto)")
     
+    # control detection interval, embedding sampling interval, queue depth and batch size
+    parser.add_argument("--detect-interval", type=int, default=30,
+                        help="frame count between forced face detection frame")
+    parser.add_argument("--embedding-queue-max-pending", type=int, default=1024,
+                        help=("Flush trigger for the embedding queue: flush occurs only when pending >= max_pending. "))
+    parser.add_argument("--embedding-batch-size-max", type=int, default=32)
+    parser.add_argument("--track-sample-interval", type=int, default=4,
+                        help=("Subsampling interval for selecting frames to generate embeddings from non-detection frames. "
+                                "Lower values increase embedding density and identity stability at the cost "
+                                "of additional compute. A value of 1 uses every eligible frame."),)
+
     # Post processing
     parser.add_argument("--post-min-gap-len", type=int, default=210,
                         help=("Minimum gap length (in frames) that will NOT be filled during post-processing. "

--- a/facekit/embedding/embedding_sampling.py
+++ b/facekit/embedding/embedding_sampling.py
@@ -1,0 +1,23 @@
+"""Helpers for deciding when to capture embedding samples for a track."""
+
+
+def should_sample_track_observation(
+    *,
+    track_local_index: int,
+    is_detection_frame: bool,
+    track_sample_interval: int,
+) -> bool:
+    """Return True when a track observation should be sampled for embedding.
+
+    Rules:
+    - detection frames are always sampled
+    - otherwise, sample every N track-local frames
+    - non-detection frames are never sampled when interval <= 0
+    """
+    if is_detection_frame:
+        return True
+
+    if track_sample_interval <= 0:
+        return False
+
+    return track_local_index % track_sample_interval == 0

--- a/facekit/embedding/embedding_selection.py
+++ b/facekit/embedding/embedding_selection.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class TrackEmbeddingSample:
+    frame_idx: int
+    track_local_index: int
+    source: str
+    embedding: np.ndarray | None
+    quality_score: float | None = None
+    aligned_face: np.ndarray | None = None
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b))
+
+def _connected_components(adj: list[list[int]]) -> list[list[int]]:
+    n = len(adj)
+    seen = [False] * n
+    components: list[list[int]] = []
+
+    for start in range(n):
+        if seen[start]:
+            continue
+
+        stack = [start]
+        seen[start] = True
+        comp: list[int] = []
+
+        while stack:
+            node = stack.pop()
+            comp.append(node)
+            for nbr in adj[node]:
+                if not seen[nbr]:
+                    seen[nbr] = True
+                    stack.append(nbr)
+
+        components.append(sorted(comp))
+
+    return components
+
+def _average_internal_similarity(
+    comp: list[int],
+    sim: np.ndarray,
+) -> float:
+    if len(comp) <= 1:
+        return 1.0
+
+    vals = []
+    for i in range(len(comp)):
+        for j in range(i + 1, len(comp)):
+            vals.append(float(sim[comp[i], comp[j]]))
+    return float(sum(vals) / len(vals))
+
+def select_consistent_embedding_subset(
+    samples: list[TrackEmbeddingSample],
+    similarity_threshold: float = 0.95,
+) -> list[TrackEmbeddingSample]:
+    """
+    Return the most self-consistent subset of valid embedding samples.
+
+    Rules:
+    - Ignore samples whose embedding is None.
+    - If there are 3 or fewer valid samples, return all of them.
+    - If there are 4 or more valid samples, return the largest/best mutually
+      similar subset of size at least 3 and discard the rest.
+    - Return results in ascending frame order.
+    """
+    valid_samples = [s for s in samples if s.embedding is not None]
+
+    if len(valid_samples) <= 3:
+        return sorted(valid_samples, key=lambda s: s.frame_idx)
+
+    n = len(valid_samples)
+    embs = [np.asarray(s.embedding, dtype=np.float32) for s in valid_samples]
+
+    sim = np.eye(n, dtype=np.float32)
+    adj: list[list[int]] = [[] for _ in range(n)]
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            sij = _cosine_similarity(embs[i], embs[j])
+            sim[i, j] = sim[j, i] = sij
+            if sij >= similarity_threshold:
+                adj[i].append(j)
+                adj[j].append(i)
+
+    comps = _connected_components(adj)
+
+    eligible = [c for c in comps if len(c) >= 3]
+
+    if not eligible:
+        # Fallback: choose the 3 samples with highest mean similarity to others
+        mean_scores = []
+        for i in range(n):
+            mean_scores.append((float(np.mean(sim[i])), i))
+        chosen_idx = sorted(i for _, i in sorted(mean_scores, reverse=True)[:3])
+        return [valid_samples[i] for i in chosen_idx]
+
+    eligible.sort(
+        key=lambda comp: (len(comp), _average_internal_similarity(comp, sim)),
+        reverse=True,
+    )
+    best = sorted(eligible[0])
+
+    chosen = [valid_samples[i] for i in best]
+    return sorted(chosen, key=lambda s: s.frame_idx)

--- a/facekit/embedding/track_embedding_queueing.py
+++ b/facekit/embedding/track_embedding_queueing.py
@@ -1,0 +1,31 @@
+from facekit.common.obs_consts import Source
+from facekit.embedding.embedding_sampling import should_sample_track_observation
+
+
+def maybe_enqueue_track_observation_for_embedding(
+    *,
+    observation,
+    track_local_index: int,
+    track_sample_interval: int,
+    frame,
+    align_face_fn,
+    embedding_queue,
+) -> bool:
+    if not should_sample_track_observation(
+        track_local_index=track_local_index,
+        is_detection_frame=(observation.source == Source.DETECTED),
+        track_sample_interval=track_sample_interval,
+    ):
+        return False
+
+    landmarks = getattr(observation, "landmarks", None)
+    if landmarks is None:
+        return False
+
+    aligned_face = align_face_fn(frame, landmarks)
+    if aligned_face is None:
+        return False
+
+    observation.aligned_face = aligned_face
+    embedding_queue.enqueue(observation)
+    return True

--- a/facekit/pipeline/checkpoint.py
+++ b/facekit/pipeline/checkpoint.py
@@ -822,7 +822,8 @@ class CheckpointManager(TrackingCheckpoint):
 
         - This call represents embeddings for exactly ONE frame (frame_idx_last).
         - `embs` must be shape (1, D).
-        - Link by exact frame equality to exactly one DETECTED, emb_idx=-1 observation row.
+        - Link by exact frame equality to exactly one eligible, emb_idx=-1 observation row.
+        - Eligible sources are currently DETECTED or TRACKED.
         """
         # If checkpoint output is disabled, checkpoint collectors must be inert.
         if self._writes_disabled():
@@ -871,16 +872,21 @@ class CheckpointManager(TrackingCheckpoint):
             raise ResumeSafetyError("[ckpt] ObservationsCollector needs find_rows/update_emb_idx/frame_at_pos.")
 
         det_code = int(SRC_TO_CODE[Source.DETECTED])
+        tracked_code = int(SRC_TO_CODE[Source.TRACKED])
 
-        candidates = find_rows(
-            shot=int(shot_number),
-            track_id=int(track_id),
-            frame_last=int(frame_idx_last),
-            only_unassigned=True,
-            only_with_landmarks=False,
-            source=det_code,
-            count=None,
-        )
+        candidates = []
+        for src_code in (det_code, tracked_code):
+            candidates.extend(
+                find_rows(
+                    shot=int(shot_number),
+                    track_id=int(track_id),
+                    frame_last=int(frame_idx_last),
+                    only_unassigned=True,
+                    only_with_landmarks=False,
+                    source=src_code,
+                    count=None,
+                )
+            )
 
         # normalize candidate positions to (block,row) tuples
         norm: list[tuple[int, int]] = []
@@ -902,15 +908,15 @@ class CheckpointManager(TrackingCheckpoint):
 
         if len(exact) == 0:
             raise ResumeSafetyError(
-                f"[ckpt] cannot link embedding: no DETECTED+landmarks+unassigned obs row at exact frame "
+                f"[ckpt] cannot link embedding: no eligible unassigned obs row at exact frame "
                 f"(shot={shot_number} track={track_id} frame={frame_idx_last}). "
-                f"Candidates_upto_frame={len(norm)}"
+                f"Eligible sources=(DETECTED, TRACKED) candidates_upto_frame={len(norm)}"
             )
 
         if len(exact) > 1:
             # For bulletproof linking, ambiguity should be fatal.
             raise ResumeSafetyError(
-                f"[ckpt] ambiguous link: multiple candidate obs rows at the same frame "
+                f"[ckpt] ambiguous link: multiple eligible obs rows at the same frame "
                 f"(shot={shot_number} track={track_id} frame={frame_idx_last}) count={len(exact)}"
             )
 
@@ -1295,6 +1301,60 @@ class CheckpointManager(TrackingCheckpoint):
         )
         if frame_max is not None:
             mask &= (arr["f"] <= int(frame_max))
+
+        frames = [int(f) for f in np.asarray(arr["f"][mask]).tolist()]
+        frames.sort()
+        return frames
+    
+    def get_obs_frames_for_track(
+        self,
+        shot: int,
+        track_id: int,
+        frame_max: int | None = None,
+        *,
+        sources: list[Source] | tuple[Source, ...] | None = None,
+    ) -> list[int]:
+        """
+        Return frame indices for observation rows on a given track.
+
+        Parameters
+        ----------
+        shot, track_id
+            Track identity within the checkpoint sidecar.
+        frame_max
+            Optional inclusive upper bound on frame index.
+        sources
+            Optional whitelist of allowed observation sources. If omitted, all
+            sources are included.
+
+        Notes
+        -----
+        - Prefers the live in-memory collector when available.
+        - Returns sorted frame indices (ascending).
+        """
+        # Prefer live in-memory collector if present
+        arr = None
+        if getattr(self, "_obs", None) is not None and hasattr(self._obs, "to_array"):
+            try:
+                arr = self._obs.to_array()
+            except Exception:
+                arr = None
+
+        # Fallback: disk NPZ
+        if arr is None:
+            arr = self._obs_np()
+
+        mask = (
+            (arr["shot"] == int(shot)) &
+            (arr["track_id"] == int(track_id))
+        )
+
+        if frame_max is not None:
+            mask &= (arr["f"] <= int(frame_max))
+
+        if sources is not None:
+            source_codes = np.array([int(SRC_TO_CODE[s]) for s in sources], dtype=np.int32)
+            mask &= np.isin(arr["src"], source_codes)
 
         frames = [int(f) for f in np.asarray(arr["f"][mask]).tolist()]
         frames.sort()

--- a/facekit/pipeline/checkpoint_io.py
+++ b/facekit/pipeline/checkpoint_io.py
@@ -356,20 +356,6 @@ def _persist_embeddings_for_track(
     # ------------------------------------------------------------------
 
     # Contract: We only require that a DETECTED obs exists
-    # for the frame(s) being embedded.
-    #
-    det_frames = set(
-        int(f) for f in checkpoint.get_det_frames_for_track(shot_i, tid_i, frame_max=max_f)
-    )
-
-    bad_missing_det = [int(f) for f in frames_for_embed if int(f) not in det_frames]
-
-    if bad_missing_det:
-        raise ValueError(
-            "[ckpt] refusing to persist embeddings for frames without a DETECTED obs: "
-            f"shot={shot_i} track={tid_i} bad_frames={bad_missing_det} "
-            f"detected_up_to_{max_f}={sorted(det_frames)}"
-        )
 
     # Persist and link one frame at a time. If any call fails, DO NOT advance
     # the embedding-safe anchor.

--- a/facekit/pipeline/resume_rehydrate.py
+++ b/facekit/pipeline/resume_rehydrate.py
@@ -9,6 +9,7 @@ from facekit.tracking.face_structures import FaceTrack, FaceObservation
 from facekit.common.obs_consts import Source, code_to_src, SRC_TO_CODE
 from facekit.errors import ResumeSafetyError
 from facekit.pipeline.checkpoint import TrackingCheckpoint
+from facekit.embedding.embedding_selection import TrackEmbeddingSample
 
 def _emb_head(track: FaceTrack, n: int = 5):
     try:
@@ -45,7 +46,9 @@ def _log_tracks_emb_brief(label: str, tracks: List[FaceTrack] | None) -> None:
     except Exception:
         logging.exception("failed to log embedding summaries for %s", label)
 
-def _prepare_tracks_for_resume_runtime(
+# ---------- Runtime warm-start helpers for the first resumed frame ----------
+
+def _prepare_runtime_state_for_resume(
     tracks: List[FaceTrack],
     *,
     resume_frame: int,
@@ -166,7 +169,7 @@ def bootstrap_runtime_trackers_for_resume_frame(
     ]
     if not open_tracks:
         logging.info(
-            "resume-bootstrap: shot=%d frame=%d no open anchor tracks to seed "
+            "bootstrap_runtime_trackers_for_resume_frame: shot=%d frame=%d no open anchor tracks to seed "
             "(aggregator_open=%s, allowed_open=%s)",
             int(shot_number),
             int(frame_idx),
@@ -200,7 +203,7 @@ def bootstrap_runtime_trackers_for_resume_frame(
 
     if not track_ids:
         logging.warning(
-            "resume-bootstrap: shot=%d frame=%d no valid open-track boxes; skipped=%s",
+            "bootstrap_runtime_trackers_for_resume_frame: shot=%d frame=%d no valid open-track boxes; skipped=%s",
             int(shot_number),
             int(frame_idx),
             skipped,
@@ -216,7 +219,7 @@ def bootstrap_runtime_trackers_for_resume_frame(
     live = getattr(face_tracker, "trackers", None) or []
 
     logging.info(
-        "resume-bootstrap: shot=%d frame=%d seeded %d/%d live trackers tids=%s skipped=%s",
+        "bootstrap_runtime_trackers_for_resume_frame: shot=%d frame=%d seeded %d/%d live trackers tids=%s skipped=%s",
         int(shot_number),
         int(frame_idx),
         len(live),
@@ -273,17 +276,17 @@ def _normalize_src(raw_src) -> Source:
             try:
                 return Source(s.lower())
             except Exception as e:
-                raise ResumeSafetyError(f"rehydrate: unknown string src={raw_src!r}") from e
+                raise ResumeSafetyError(f"_normalize_src: unknown string src={raw_src!r}") from e
 
     # Numpy scalar string or other scalar-like
     if hasattr(raw_src, "item"):
         try:
             return _normalize_src(raw_src.item())
         except Exception as e:
-            raise ResumeSafetyError(f"rehydrate: unsupported src scalar {raw_src!r}") from e
+            raise ResumeSafetyError(f"_normalize_src: unsupported src scalar {raw_src!r}") from e
 
     raise ResumeSafetyError(
-        f"rehydrate: unsupported src type {type(raw_src)!r} value={raw_src!r}"
+        f"_normalize_src: unsupported src type {type(raw_src)!r} value={raw_src!r}"
     )
 
 def _landmarks_from_flat10(has_landmarks, flat10) -> np.ndarray | None:
@@ -299,21 +302,21 @@ def _landmarks_from_flat10(has_landmarks, flat10) -> np.ndarray | None:
         return None
 
     if flat10 is None:
-        raise ResumeSafetyError("rehydrate: has_landmarks=1 but landmarks_flat10 is None")
+        raise ResumeSafetyError("_landmarks_from_flat10: has_landmarks=1 but landmarks_flat10 is None")
 
     try:
         arr = np.asarray(flat10, dtype=np.float32)
     except Exception as e:
-        raise ResumeSafetyError(f"rehydrate: invalid landmarks_flat10: {e}")
+        raise ResumeSafetyError(f"_landmarks_from_flat10: invalid landmarks_flat10: {e}")
 
     if arr.shape != (10,):
         raise ResumeSafetyError(
-            f"rehydrate: landmarks_flat10 must have shape (10,), got {arr.shape}"
+            f"_landmarks_from_flat10: landmarks_flat10 must have shape (10,), got {arr.shape}"
         )
 
     if not np.all(np.isfinite(arr)):
         raise ResumeSafetyError(
-            "rehydrate: landmarks_flat10 contains NaN/Inf but has_landmarks=1"
+            "_landmarks_from_flat10: landmarks_flat10 contains NaN/Inf but has_landmarks=1"
         )
 
     return arr.reshape((5, 2))
@@ -368,7 +371,7 @@ def _row_to_faceobs(row: dict, *, shot_id: int, track_id: int) -> FaceObservatio
     # Debug logging (optional, safe)
     try:
         logging.info(
-            "rehydrate DEBUG obs row: shot=%r tid=%r f=%r src=%r has_landmarks=%r flat10_len=%r",
+            "_row_to_faceobs DEBUG obs row: shot=%r tid=%r f=%r src=%r has_landmarks=%r flat10_len=%r",
             int(shot_id),
             track_id,
             row.get("f"),
@@ -404,13 +407,13 @@ def make_emb_lookup_from_sidecars(
     """
     if emb_array is None or getattr(emb_array, "ndim", 0) != 2:
         raise ResumeSafetyError(
-            f"rehydrate: emb_array has invalid shape {getattr(emb_array, 'shape', None)}; expected (N, 512)"
+            f"make_emb_lookup_from_sidecars: emb_array has invalid shape {getattr(emb_array, 'shape', None)}; expected (N, 512)"
         )
 
     try:
         arr = obs_collector.to_array()
     except Exception as e:
-        raise ResumeSafetyError(f"rehydrate: obs_collector.to_array() failed: {e}") from e
+        raise ResumeSafetyError(f"make_emb_lookup_from_sidecars: obs_collector.to_array() failed: {e}") from e
 
     if getattr(arr, "size", 0) == 0:
         # no observations at all → no embeddings to attach.
@@ -423,7 +426,7 @@ def make_emb_lookup_from_sidecars(
     missing = required - set(names)
     if missing:
         raise ResumeSafetyError(
-            f"rehydrate: obs sidecar missing required fields {sorted(missing)}; "
+            f"make_emb_lookup_from_sidecars: obs sidecar missing required fields {sorted(missing)}; "
             f"present={list(names)}"
         )
 
@@ -436,7 +439,7 @@ def make_emb_lookup_from_sidecars(
             row_src = _normalize_src(row["src"])
         except ResumeSafetyError as e:
             raise ResumeSafetyError(
-                f"rehydrate: invalid src={row['src']!r} in obs sidecar row idx={idx}"
+                f"make_emb_lookup_from_sidecars: invalid src={row['src']!r} in obs sidecar row idx={idx}"
             ) from e
 
         if row_src != det_src:
@@ -465,7 +468,7 @@ def make_emb_lookup_from_sidecars(
         for f, ei in rows_sorted:
             if ei < 0 or ei >= n_rows:
                 raise ResumeSafetyError(
-                    f"rehydrate: emb_idx {ei} out of bounds for embeddings array of size {n_rows}"
+                    f"make_emb_lookup_from_sidecars: emb_idx {ei} out of bounds for embeddings array of size {n_rows}"
                 )
             frames.append(int(f))
             vecs.append(np.asarray(emb_array[ei], dtype=np.float32, order="C"))
@@ -477,8 +480,8 @@ def make_emb_lookup_from_sidecars(
 
     return _lookup
 
-# ---------- Phase 1: observations-only rehydration ----------
-def rehydrate_observation_tracks(
+# ---------- Track reconstruction from persisted observation rows ----------
+def reconstruct_tracks_from_observations(
     collector,
     *,
     frame_max: Optional[int],
@@ -490,7 +493,7 @@ def rehydrate_observation_tracks(
     """
     groups = list(collector.iter_tracks(frame_max=frame_max))
     if not groups:
-        logging.info("rehydrate_observation_tracks: no groups from collector (frame_max=%r)", frame_max)
+        logging.info("reconstruct_tracks_from_observations: no groups from collector (frame_max=%r)", frame_max)
         return []
 
     def _debug_track_order_lookup(track_order: dict[tuple[int, int], int], shot: int, track_id: int) -> None:
@@ -568,12 +571,12 @@ def rehydrate_observation_tracks(
         tracks.append(t)
 
     logging.info(
-        "rehydrate_observation_tracks: built %d tracks, %d observations; span first=%s last=%s",
+        "reconstruct_tracks_from_observations: built %d tracks, %d observations; span first=%s last=%s",
         len(tracks), obs_count, first_span, last_span
     )
     return tracks
 
-# ---------- Phase 2: embeddings attachment ----------
+# ---------- Embedding reattachment for reconstructed tracks ----------
 # Flexible lookups: supply whichever your checkpoint/collector supports.
 EmbLookup = Callable[[int, int], Optional[Tuple[Iterable[int], np.ndarray]]]       # -> (frame_indices, embs)
 EmbArrayLookup = Callable[[int, int], Optional[np.ndarray]]                        # -> embs only
@@ -704,8 +707,75 @@ def attach_embeddings_to_tracks(
         "%s: DET obs=%d, with_embeddings=%d (%.1f%%)", log_prefix, tot_det, tot_attached, pct
     )
 
-# ---------- Phase 3: one-call rehydration (observations + embeddings) ----------
-def rehydrate_tracks(
+def _finalize_track_identity_state(
+    tracks: List[FaceTrack],
+    *,
+    log_prefix: str,
+) -> None:
+    """
+    Rebuild track-level identity state after embeddings have been attached.
+
+    Resume rehydration restores DET observation embeddings and track.embeddings,
+    but FaceTrack.finalize_embedding_representation() derives the stable
+    representative embedding from track.embedding_samples. We therefore rebuild
+    embedding_samples from the attached observation embeddings before invoking
+    the canonical FaceTrack finalization path.
+    """
+    for track in tracks:
+        observations = getattr(track, "observations", None) or []
+
+        rebuilt_samples: list[TrackEmbeddingSample] = []
+        for track_local_index, observation in enumerate(observations):
+            embedding = getattr(observation, "embedding", None)
+            if embedding is None:
+                continue
+
+            embedding_array = np.asarray(embedding, dtype=np.float32)
+            if embedding_array.ndim != 1 or not np.isfinite(embedding_array).all():
+                continue
+
+            source = getattr(observation, "source", None)
+            source_name = getattr(source, "value", None)
+            if source_name is None:
+                source_name = str(source)
+
+            rebuilt_samples.append(
+                TrackEmbeddingSample(
+                    frame_idx=int(observation.frame_idx),
+                    track_local_index=int(track_local_index),
+                    source=str(source_name),
+                    embedding=embedding_array,
+                )
+            )
+
+        track.embedding_samples = rebuilt_samples
+
+        finalize = getattr(track, "finalize_embedding_representation", None)
+        if finalize is None or not callable(finalize):
+            raise ResumeSafetyError(
+                f"{log_prefix}: FaceTrack is missing finalize_embedding_representation(); "
+                "cannot rebuild deterministic track-level identity state during resume"
+            )
+
+        finalize()
+
+        has_embeddings = bool(getattr(track, "embeddings", None) or [])
+        if has_embeddings:
+            if not bool(getattr(track, "embedding_stable", False)):
+                raise ResumeSafetyError(
+                    f"{log_prefix}: finalize_embedding_representation() did not produce "
+                    f"stable track identity state for "
+                    f"(shot={int(getattr(track, 'shot_id', -1))}, tid={int(getattr(track, 'track_id', -1))})"
+                )
+            if getattr(track, "representative_embedding", None) is None:
+                raise ResumeSafetyError(
+                    f"{log_prefix}: finalize_embedding_representation() did not produce "
+                    f"a representative_embedding for "
+                    f"(shot={int(getattr(track, 'shot_id', -1))}, tid={int(getattr(track, 'track_id', -1))})"
+                )
+
+# ---------- Historical track finalization for resume ----------
+def prepare_tracks_for_resume(
     collector,
     *,
     frame_max: Optional[int],
@@ -725,7 +795,7 @@ def rehydrate_tracks(
     anchor_tracks: list[FaceTrack] = []
     future_tracks: list[FaceTrack] = []
 
-    tracks = rehydrate_observation_tracks(
+    tracks = reconstruct_tracks_from_observations(
         collector,
         frame_max=frame_max,
         track_order=track_order,
@@ -755,8 +825,11 @@ def rehydrate_tracks(
             strict=bool(strict),
             log_prefix="rehydrate-completed",
         )
-
-        _log_tracks_emb_brief("rehydrate-completed after attach", completed_tracks)
+        _finalize_track_identity_state(
+            completed_tracks,
+            log_prefix="rehydrate-completed",
+        )
+        _log_tracks_emb_brief("rehydrate-completed after finalize", completed_tracks)
 
     # 2) Resume-shot tracks: these observations are all strictly before the
     # resume frame (frame_max = anchor_frame - 1), so under the current
@@ -771,7 +844,11 @@ def rehydrate_tracks(
             strict=bool(strict),
             log_prefix="rehydrate-anchor",
         )
-        _log_tracks_emb_brief("rehydrate-anchor after attach", anchor_tracks)
+        _finalize_track_identity_state(
+            anchor_tracks,
+            log_prefix="rehydrate-anchor",
+        )
+        _log_tracks_emb_brief("rehydrate-anchor after finalize", anchor_tracks)
 
     # 3) Stitch back together in the original order
     return completed_tracks + anchor_tracks
@@ -856,7 +933,7 @@ def _resolve_anchor(
         0 means cold start / no anchor.
     """
     if not (resume_enabled and checkpoint):
-        logging.info("resume: disabled or no checkpoint -> start=0")
+        logging.info("_resolve_anchor: disabled or no checkpoint -> start=0")
         return 0
 
     # Resume starts at anchor+1.
@@ -866,11 +943,11 @@ def _resolve_anchor(
         anchors = None
 
     if anchors is None or len(anchors) < 1:
-        logging.info("resume: no embedding-safe anchor -> start=0")
+        logging.info("_resolve_anchor: no embedding-safe anchor -> start=0")
         return 0
 
     safe_f = int(anchors[0])
-    logging.info("resume: embedding-safe anchor=%d", safe_f)
+    logging.info("_resolve_anchor: embedding-safe anchor=%d", safe_f)
     return safe_f
 
 def _shot_idx_by_abs_frame(shots, abs_frame_idx: int) -> int:
@@ -978,9 +1055,9 @@ def _build_resume_plan(
     try:
         if checkpoint and hasattr(checkpoint, "obs_collector"):
             rows_before = int(checkpoint.obs_collector.count())
-            logging.info("resume: obs_collector rows BEFORE processing=%d", rows_before)
+            logging.info("_build_resume_plan: obs_collector rows BEFORE processing=%d", rows_before)
     except Exception:
-        logging.exception("resume: failed to read obs_collector.count() before")
+        logging.exception("_build_resume_plan: failed to read obs_collector.count() before")
 
     # Identify anchor-containing shot BEFORE any trimming (used for logging)
     anchor_shot_idx = _shot_idx_by_abs_frame(shots, resume_abs_frame) if resume_abs_frame > 0 else None
@@ -1012,7 +1089,7 @@ def _build_resume_plan(
             checkpoint,
             anchor_frame=resume_abs_frame,
         )
-        prior_tracks = rehydrate_tracks(
+        prior_tracks = prepare_tracks_for_resume(
             obs_for_rehydrate,
             frame_max=resume_abs_frame - 1,
             track_order=(checkpoint.get_track_order() or {}) if checkpoint else {},
@@ -1022,10 +1099,10 @@ def _build_resume_plan(
             strict=False,
         )
     elif obs_for_rehydrate is not None:
-        logging.info("resume: anchor=0 -> cold start; skipping pre-anchor rehydration")
+        logging.info("_build_resume_plan: anchor=0 -> cold start; skipping pre-anchor rehydration")
         prior_tracks = []
     else:
-        logging.info("resume: no obs_collector on checkpoint; skipping pre-anchor rehydration")
+        logging.info("_build_resume_plan: no obs_collector on checkpoint; skipping pre-anchor rehydration")
         prior_tracks = []
 
     # Split rehydrated tracks into fully completed vs anchor shot
@@ -1043,7 +1120,7 @@ def _build_resume_plan(
     # Completed shots become outputs immediately
     if prior_tracks_completed:
         logging.info(
-            "resume: adding %d completed pre-anchor tracks to outputs",
+            "_build_resume_plan: adding %d completed pre-anchor tracks to outputs",
             len(prior_tracks_completed),
         )
         all_tracks.extend(prior_tracks_completed)
@@ -1054,17 +1131,17 @@ def _build_resume_plan(
         for track in prior_tracks:
             shot = int(getattr(track, "shot_id", -1))
             by_shot_counts[shot] = by_shot_counts.get(shot, 0) + 1
-        logging.info("resume: rehydrated counts by shot: %r", by_shot_counts)
+        logging.info("_build_resume_plan: rehydrated counts by shot: %r", by_shot_counts)
         logging.info(
-            "resume: segment_id_seed_by_shot: %r",
+            "_build_resume_plan: segment_id_seed_by_shot: %r",
             {int(k): int(v) for k, v in (segment_id_seed_by_shot or {}).items()},
         )
         logging.info(
-            "resume: trackid_seed_by_shot: %r",
+            "_build_resume_plan: trackid_seed_by_shot: %r",
             {int(k): int(v) for k, v in (trackid_seed_by_shot or {}).items()},
         )
     except Exception:
-        logging.exception("resume: failed summarizing seeds")
+        logging.exception("_build_resume_plan: failed summarizing seeds")
 
     # Compute per-shot track_id seeds from all rehydrated tracks.
     # segment_id assignment is deferred until after we partition anchor-shot
@@ -1099,14 +1176,14 @@ def _build_resume_plan(
                 last_tid_by_shot[shot] = tid
 
         logging.info(
-            "resume: computed track_id seeds from %d rehydrated tracks; seeds=%s",
+            "_build_resume_plan: computed track_id seeds from %d rehydrated tracks; seeds=%s",
             len(prior_tracks),
             {int(k): int(v) for k, v in trackid_seed_by_shot.items()},
         )
 
     except Exception:
         logging.exception(
-            "resume: failed to compute track_id seeds from rehydrated tracks; continuing with empty seeds"
+            "_build_resume_plan: failed to compute track_id seeds from rehydrated tracks; continuing with empty seeds"
         )
         segment_id_seed_by_shot = {}
         trackid_seed_by_shot = {}
@@ -1116,7 +1193,7 @@ def _build_resume_plan(
         checkpoint._validate_resume_embeddings(anchor_shot=anchor_shot_num)
 
     logging.info(
-        "resume: prior_tracks strictness OK (anchor_shot=%s); rehydrated=%d (completed=%d, anchor-shot=%d)",
+        "_build_resume_plan: prior_tracks strictness OK (anchor_shot=%s); rehydrated=%d (completed=%d, anchor-shot=%d)",
         anchor_shot_num,
         len(prior_tracks or []),
         len(prior_tracks_completed),
@@ -1170,7 +1247,7 @@ def _build_resume_plan(
 
     if closed_anchor_tracks:
         logging.info(
-            "resume: anchor-shot closed-by-anchor tracks moved directly to outputs: %s",
+            "_build_resume_plan: anchor-shot closed-by-anchor tracks moved directly to outputs: %s",
             sorted(
                 (int(getattr(t, "shot_id", -1)), int(t.first_frame()), int(t.last_frame()), int(getattr(t, "track_id", -1)))
                 for t in closed_anchor_tracks
@@ -1187,13 +1264,13 @@ def _build_resume_plan(
             durable_prior_tracks, track_order_map or {}
         )
         logging.info(
-            "resume: assigned segment_ids to %d durable rehydrated tracks; seeds=%s",
+            "_build_resume_plan: assigned segment_ids to %d durable rehydrated tracks; seeds=%s",
             len(durable_prior_tracks),
             {k: int(v) for k, v in segment_id_seed_by_shot.items()},
         )
     except Exception:
         logging.exception(
-            "resume: failed to assign segment_ids to durable rehydrated tracks; continuing with empty seeds"
+            "_build_resume_plan: failed to assign segment_ids to durable rehydrated tracks; continuing with empty seeds"
         )
         segment_id_seed_by_shot = {}
 
@@ -1204,9 +1281,9 @@ def _build_resume_plan(
     # Only tracks that were actually OPEN at the embedding-safe boundary should
     # be normalized for warm-start runtime tracking.
     if prior_tracks_anchor and resume_abs_frame > 0:
-        _prepare_tracks_for_resume_runtime(prior_tracks_anchor, resume_frame=resume_abs_frame)
+        _prepare_runtime_state_for_resume(prior_tracks_anchor, resume_frame=resume_abs_frame)
         logging.info(
-            "resume: anchor-shot live tracks kept for runtime seeding: %s",
+            "_build_resume_plan: anchor-shot live tracks kept for runtime seeding: %s",
             sorted(
                 (int(getattr(t, "shot_id", -1)), int(t.first_frame()), int(t.last_frame()), int(getattr(t, "track_id", -1)))
                 for t in prior_tracks_anchor
@@ -1219,7 +1296,7 @@ def _build_resume_plan(
             reuse_tid_for_first_shot = last_tid_by_shot.get(int(first_processed_shot_number))
             if reuse_tid_for_first_shot is not None:
                 logging.info(
-                    "resume: will reuse tid=%d for first detection in shot=%d",
+                    "_build_resume_plan: will reuse tid=%d for first detection in shot=%d",
                     int(reuse_tid_for_first_shot),
                     int(first_processed_shot_number),
                 )
@@ -1227,7 +1304,7 @@ def _build_resume_plan(
             reuse_tid_for_first_shot = None
 
         logging.info(
-            "resume: anchor=%d anchor_shot_num=%s first_processed_shot_number=%s reuse_tid_for_first_shot=%s",
+            "_build_resume_plan: anchor=%d anchor_shot_num=%s first_processed_shot_number=%s reuse_tid_for_first_shot=%s",
             resume_abs_frame,
             anchor_shot_num,
             first_processed_shot_number,
@@ -1269,14 +1346,14 @@ def _read_open_track_ids_for_shot(
             if int(row.get("shot", -1)) == int(shot_number)
         }
         logging.info(
-            "resume: open_track_ids for shot=%s -> %s",
+            "_read_open_track_ids_for_shot: open_track_ids for shot=%s -> %s",
             shot_number,
             sorted(tids),
         )
         return frozenset(tids)
     except Exception:
         logging.exception(
-            "resume: failed reading open_tracks from status.json for shot=%s",
+            "_read_open_track_ids_for_shot: failed reading open_tracks from status.json for shot=%s",
             shot_number,
         )
         return frozenset()
@@ -1289,7 +1366,7 @@ def _audit_preanchor_embedding_parity(checkpoint, *, shots: list, anchor_frame: 
     landmarks are present (when available).
     """
     if not checkpoint or not hasattr(checkpoint, "obs_collector"):
-        logging.info("RESUME-AUDIT: no checkpoint/collector; skipping.")
+        logging.info("_audit_preanchor_embedding_parity: no checkpoint/collector; skipping.")
         return
 
     oc = checkpoint.obs_collector
@@ -1297,7 +1374,7 @@ def _audit_preanchor_embedding_parity(checkpoint, *, shots: list, anchor_frame: 
     has_iter_track_frames = hasattr(oc, "iter_track_frames") and callable(getattr(oc, "iter_track_frames"))
 
     if not has_rows_for_frame and not has_iter_track_frames:
-        logging.info("RESUME-AUDIT: collector lacks rows_for_frame/iter_track_frames; skipping.")
+        logging.info("_audit_preanchor_embedding_parity: collector lacks rows_for_frame/iter_track_frames; skipping.")
         return
 
     # Helper: record a missing embedding at (shot, tid, frame) with landmarks presence if we can see it.
@@ -1333,7 +1410,7 @@ def _audit_preanchor_embedding_parity(checkpoint, *, shots: list, anchor_frame: 
                 try:
                     rows = list(oc.rows_for_frame(shot_num, f))  # iterable of dict-ish
                 except Exception:
-                    logging.exception("RESUME-AUDIT: rows_for_frame failed at shot=%d frame=%d", shot_num, f)
+                    logging.exception("_audit_preanchor_embedding_parity: rows_for_frame failed at shot=%d frame=%d", shot_num, f)
                     continue
                 for r in rows:
                     try:
@@ -1393,25 +1470,25 @@ def _audit_preanchor_embedding_parity(checkpoint, *, shots: list, anchor_frame: 
                     except Exception:
                         continue
             if not seen_any:
-                logging.debug("RESUME-AUDIT: no tracks observed via iter_track_frames for shot=%d", shot_num)
+                logging.debug("_audit_preanchor_embedding_parity: no tracks observed via iter_track_frames for shot=%d", shot_num)
 
     # Summarize
     if not det_by_key:
-        logging.info("RESUME-AUDIT: no pre-anchor DET rows to audit (or none missing).")
+        logging.info("_audit_preanchor_embedding_parity: no pre-anchor DET rows to audit (or none missing).")
         return
 
     for (shot, tid), misses in sorted(det_by_key.items()):
         misses.sort(key=lambda r: int(r["f"]))
         frames_str = ",".join(f'{m["f"]}({m["has_landmarks"]})' for m in misses)
         logging.error(
-            "RESUME-AUDIT shot=%d tid=%d missing_preanchor=%d frames=[%s]  (paren=has_landmarks)",
+            "_audit_preanchor_embedding_parityAUDIT shot=%d tid=%d missing_preanchor=%d frames=[%s]  (paren=has_landmarks)",
             shot, tid, len(misses), frames_str
         )
 
     if total_missing == 0:
-        logging.info("RESUME-AUDIT OK: all pre-anchor DET rows have embeddings.")
+        logging.info("_audit_preanchor_embedding_parity OK: all pre-anchor DET rows have embeddings.")
     else:
-        logging.error("RESUME-AUDIT FAIL: total missing pre-anchor DET embeddings=%d", total_missing)
+        logging.error("_audit_preanchor_embedding_parity FAIL: total missing pre-anchor DET embeddings=%d", total_missing)
 
 def _build_emb_lookups_for_checkpoint(
     checkpoint: TrackingCheckpoint | None,
@@ -1419,7 +1496,7 @@ def _build_emb_lookups_for_checkpoint(
     anchor_frame: int,
 ):
     """
-    Build emb_lookup/emb_array_lookup callables for resume_rehydrate.rehydrate_tracks.
+    Build emb_lookup/emb_array_lookup callables for resume_rehydrate.prepare_tracks_for_resume.
 
     emb_lookup(shot, tid) returns (frames, embs) for DET observations strictly
     before the anchor frame, using the checkpoint's sidecar accessors:

--- a/facekit/pipeline/track_across_segments.py
+++ b/facekit/pipeline/track_across_segments.py
@@ -18,7 +18,6 @@ from facekit.io.frame_provider import FrameProvider, ReaderCoordinator
 from facekit.pipeline.checkpoint import TrackingCheckpoint
 from facekit.common.obs_consts import Source
 from facekit.utils.geometry import compute_iou 
-
 from facekit.pipeline.resume_rehydrate import (
     ResumePlan,
     _build_resume_plan,
@@ -27,12 +26,14 @@ from facekit.pipeline.resume_rehydrate import (
 )
 from facekit.pipeline.checkpoint_io import (
     _checkpoint_root_dir,
-    do_checkpoint, 
     _checkpoint_observations_and_snapshot,
     _persist_embeddings_for_track,
     _finalize_checkpoint_run
 )
 from facekit.errors import ResumeSafetyError
+from facekit.tracking.landmark_propagation import propagate_landmarks_by_bbox_transform
+from facekit.embedding.track_embedding_queueing import maybe_enqueue_track_observation_for_embedding
+from facekit.embedding.embedding_selection import TrackEmbeddingSample
 
 logger = logging.getLogger(__name__)
 
@@ -499,6 +500,13 @@ def extend_prev_track_for_overlapping_detection(
 
     return matched
 
+def _normalize_embedding_for_sample(embedding: np.ndarray) -> np.ndarray:
+    arr = np.asarray(embedding, dtype=np.float32)
+    norm = float(np.linalg.norm(arr))
+    if norm == 0.0:
+        return arr
+    return arr / norm
+
 def _attach_and_persist_embedded_obs(
     *,
     embedded_obs: list[FaceObservation],
@@ -547,25 +555,58 @@ def _attach_and_persist_embedded_obs(
 
         aggregator.attach_embeddings(int(tid), embs)
 
-        # Persist per track (if checkpoint enabled)
-        if checkpoint is not None:
-            # Find the actual FaceTrack object for this tid (needed by _persist_embeddings_for_track)
-            track = next((t for t in aggregator.tracks if int(getattr(t, "track_id", -1)) == int(tid)), None)
-            if track is not None:
-                _persist_embeddings_for_track(
-                    checkpoint,
-                    shot_number=shot_number,
-                    track=track,
-                    frames_for_embed=frames_for_embed,
-                    embs=embs,
+        # Find the actual FaceTrack object for this tid.
+        track = next(
+            (t for t in aggregator.tracks if int(getattr(t, "track_id", -1)) == int(tid)),
+            None,
+        )
+
+        # Register per-sample embedding metadata on the track.
+        if track is not None and hasattr(track, "add_embedding_sample"):
+            for ob in obs_list:
+                try:
+                    track_local_index = next(
+                        i
+                        for i, candidate in enumerate(track.observations)
+                        if candidate is ob
+                    )
+                except StopIteration:
+                    logging.warning(
+                        "track-embed: embedded observation missing from track history "
+                        "shot=%d track_id=%d frame=%d source=%s",
+                        int(shot_number),
+                        int(tid),
+                        int(getattr(ob, "frame_idx", -1)),
+                        str(getattr(ob, "source", None)),
+                    )
+                    continue
+
+                track.add_embedding_sample(
+                    TrackEmbeddingSample(
+                        frame_idx=int(ob.frame_idx),
+                        track_local_index=int(track_local_index),
+                        source=getattr(ob, "source", None),
+                        embedding=_normalize_embedding_for_sample(ob.embedding),
+                        quality_score=None,
+                    )
                 )
 
-                # Track the newest frame whose embeddings were persisted in this batch.
-                if frames_for_embed:
-                    last_f = int(frames_for_embed[-1])
-                    if max_persisted_frame is None or last_f > max_persisted_frame:
-                        max_persisted_frame = last_f
+        # Persist per track (if checkpoint enabled)
+        if checkpoint is not None and track is not None:
+            _persist_embeddings_for_track(
+                checkpoint,
+                shot_number=shot_number,
+                track=track,
+                frames_for_embed=frames_for_embed,
+                embs=embs,
+            )
 
+            # Track the newest frame whose embeddings were persisted in this batch.
+            if frames_for_embed:
+                last_f = int(frames_for_embed[-1])
+                if max_persisted_frame is None or last_f > max_persisted_frame:
+                    max_persisted_frame = last_f
+                    
     # Advance the embedding-safe resume anchor once per batch (after successful persistence).
     # Prefer the explicit boundary-completion frame when provided; otherwise use the newest
     # payload frame that contributed embeddings.
@@ -588,6 +629,156 @@ def _attach_and_persist_embedded_obs(
             # Non-fatal: embeddings were already persisted; this only affects resume metadata.
             logging.exception("track: failed to mark embedding-safe (non-fatal)")
 
+def _maybe_enqueue_track_embedding_observations_for_frame(
+    *,
+    aggregator,
+    frame_idx: int,
+    frame,
+    track_sample_interval: int,
+    embedding_queue,
+) -> None:
+    """
+    For the current frame's authoritative observations (after track assignment),
+    decide which observations should be sampled for embedding, attempt alignment
+    online, and enqueue the observation itself when alignment succeeds.
+
+    Notes:
+    - DETECTED observations are always eligible by policy.
+    - TRACKED observations are eligible only when they land on the track-local
+      sampling interval.
+    - Observations without landmarks are skipped.
+    - This helper mutates observation.aligned_face only for items that are
+      actually enqueued.
+    """
+    obs_for_frame = aggregator.observations_at(
+        frame_idx,
+        require_track_id=True,
+    )
+
+    for obs in obs_for_frame:
+        tid = getattr(obs, "track_id", None)
+        if tid is None:
+            continue
+
+        track = next(
+            (
+                t
+                for t in aggregator.tracks
+                if int(getattr(t, "track_id", -1)) == int(tid)
+            ),
+            None,
+        )
+        if track is None:
+            continue
+
+        # update_tracks_with_frame(...) has already appended this frame's observation
+        # to the authoritative track history, so the track-local index for this obs
+        # is its current position in the per-track observation list.
+        try:
+            track_local_index = next(
+                i
+                for i, candidate in enumerate(track.observations)
+                if candidate is obs
+            )
+        except StopIteration:
+            continue
+
+        if getattr(obs, "aligned_face", None) is not None:
+            continue
+
+        try:
+            maybe_enqueue_track_observation_for_embedding(
+                observation=obs,
+                track_local_index=track_local_index,
+                track_sample_interval=track_sample_interval,
+                frame=frame,
+                align_face_fn=align_face_for_arcface,
+                embedding_queue=embedding_queue,
+            )
+        except Exception:
+            logging.exception(
+                "track-embed: failed enqueue attempt shot=%d frame=%d track_id=%s source=%s",
+                int(getattr(track, "shot_id", -1)),
+                int(frame_idx),
+                str(tid),
+                str(getattr(obs, "source", None)),
+            )
+
+def append_detection_observation(observations,
+                                shot_number, 
+                                frame_idx, 
+                                frame, 
+                                detected_box, 
+                                landmarks, 
+                                confidence):
+    bbox = tuple(int(v) for v in detected_box[:4])
+
+    aligned_face = None
+    try:
+        aligned_face = align_face_for_arcface(frame, landmarks)
+    except Exception:
+        logging.exception(
+            "align: failed to compute aligned_face shot=%d frame=%d bbox=%s",
+            int(shot_number),
+            int(frame_idx),
+            str(bbox),
+        )
+
+    observations.append(FaceObservation(
+                frame_idx=frame_idx,
+                bbox=bbox,
+                track_id=None,  # aggregator will set
+                embedding=None,
+                confidence=float(confidence) if confidence is not None else None,
+                aligned_face=aligned_face,
+                landmarks=landmarks,
+                source=Source.DETECTED,
+            )
+        )
+
+def append_tracking_observation(
+    observations,
+    frame_idx,
+    track_id,
+    tracked_box,
+    aggregator,
+):
+    x, y, w, h = tracked_box
+    bbox = (int(x), int(y), int(x + w), int(y + h))
+
+    previous_observation = None
+    track = next(
+        (t for t in aggregator.tracks if int(getattr(t, "track_id", -1)) == int(track_id)),
+        None,
+    )
+    if track is not None and getattr(track, "observations", None):
+        if track.observations:
+            previous_observation = track.observations[-1]
+
+    landmarks = None
+    if previous_observation is not None:
+        prev_landmarks = getattr(previous_observation, "landmarks", None)
+        prev_bbox = getattr(previous_observation, "bbox", None)
+        if prev_landmarks is not None and prev_bbox is not None:
+            landmarks = propagate_landmarks_by_bbox_transform(
+                prev_landmarks=prev_landmarks,
+                prev_bbox=prev_bbox,
+                curr_bbox=bbox,
+            )
+
+    observations.append(
+        FaceObservation(
+            frame_idx=frame_idx,
+            track_id=track_id,
+            bbox=bbox,
+            embedding=None,
+            confidence=None,
+            aligned_face=None,
+            landmarks=landmarks,
+            source=Source.TRACKED,
+        )
+    )
+
 def track_across_segments(
     frame_source: Union[str, Path, FrameProvider],
     shot_json_path: str,
@@ -599,6 +790,7 @@ def track_across_segments(
     embedding_batch_size_max: int = 32,
     *,
     embedding_queue_max_pending: int = 1024,
+    track_sample_interval: int = 10,
     checkpoint: TrackingCheckpoint | None = None,
     resume_enabled: bool = True,
 ) -> List[FaceTrack]:
@@ -818,23 +1010,17 @@ def track_across_segments(
                         basic_fail = (not tracked_boxes) or any(b is None for b in tracked_boxes.values())
 
                         if (not basic_fail) and validator.validate(tracked_boxes, frame, frame_idx):
-                            for track_id, tb in tracked_boxes.items():
-                                if tb is None:
+                            for track_id, tracked_box in tracked_boxes.items():
+                                if tracked_box is None:
                                     continue
-                                x, y, w, h = tb
-                                bbox = (int(x), int(y), int(x + w), int(y + h))
-                                observations.append(
-                                    FaceObservation(
-                                        frame_idx=frame_idx,
-                                        track_id=track_id,
-                                        bbox=bbox,
-                                        embedding=None,
-                                        confidence=None,
-                                        aligned_face=None,
-                                        source=Source.TRACKED,
-                                    )
-                                )
 
+                                append_tracking_observation(
+                                    observations,
+                                    frame_idx,
+                                    track_id,
+                                    tracked_box,
+                                    aggregator=aggregator,
+                                )
                         else:
                             aggregator.finalize_tracks()
                             tracker_active = False
@@ -867,32 +1053,14 @@ def track_across_segments(
                             if landmarks is None:
                                 continue  # treat as "not a detected face"
 
-                            bbox = tuple(int(v) for v in box[:4])
-
-                            aligned_face = None
-                            try:
-                                aligned_face = align_face_for_arcface(frame, landmarks)
-                            except Exception:
-                                logging.exception(
-                                    "align: failed to compute aligned_face shot=%d frame=%d bbox=%s",
-                                    int(shot_number),
-                                    int(frame_idx),
-                                    str(bbox),
-                                )
-
-                            observations.append(
-                                FaceObservation(
-                                    frame_idx=frame_idx,
-                                    bbox=bbox,
-                                    track_id=None,  # aggregator will set
-                                    embedding=None,
-                                    confidence=float(confidence) if confidence is not None else None,
-                                    aligned_face=aligned_face,
-                                    landmarks=landmarks,
-                                    source=Source.DETECTED,
-                                )
-                            )
-
+                            append_detection_observation(observations,
+                                                        shot_number, 
+                                                        frame_idx, 
+                                                        frame, 
+                                                        box, 
+                                                        landmarks, 
+                                                        confidence)
+                            
                         # print(f"Detection frame number: {frame_idx}, num faces: {len(observations)}")
                     
                     if not detections or not observations:
@@ -919,6 +1087,14 @@ def track_across_segments(
                             )
       
                 _ = aggregator.update_tracks_with_frame(frame_idx, observations)
+
+                _maybe_enqueue_track_embedding_observations_for_frame(
+                    aggregator=aggregator,
+                    frame_idx=frame_idx,
+                    frame=frame,
+                    track_sample_interval=track_sample_interval,
+                    embedding_queue=embed_q,
+                )
 
                 # Persist observations for EVERY processed frame.
                 #
@@ -1055,4 +1231,3 @@ def track_across_segments(
         logger.info("Done processing video")
 
         return all_tracks
-

--- a/facekit/tracking/aggregator.py
+++ b/facekit/tracking/aggregator.py
@@ -502,9 +502,14 @@ class ShotFaceTrackAggregator:
         def embedding_similarity(e1, e2):
             if e1 is None or e2 is None:
                 raise RuntimeError("Embedding missing for similarity computation")
-            e1 = e1 / np.linalg.norm(e1)
-            e2 = e2 / np.linalg.norm(e2)
-            return float(np.dot(e1, e2))
+
+            n1 = np.linalg.norm(e1)
+            n2 = np.linalg.norm(e2)
+
+            if n1 == 0.0 or n2 == 0.0:
+                return float("-inf")
+
+            return float(np.dot(e1, e2) / (n1 * n2))
         
         # Identify and summarize tracks missing embeddings
         missing_tracks = [
@@ -637,12 +642,14 @@ class ShotFaceTrackAggregator:
 
     def finalize_tracks(self) -> List[FaceTrack]:
         """
-        Close all remaining open tracks and return them.
+        Close all remaining open tracks, finalize embeddings and return them.
         """
 
-        for t in self.tracks:
-            if not t.is_closed():
-                t.mark_closed()
+        for track in self.tracks:
+            if not track.is_closed():
+                track.mark_closed()
+            track.finalize_embedding_representation()
+
         return self.tracks
 
     def _to_src_code(x):

--- a/facekit/tracking/face_structures.py
+++ b/facekit/tracking/face_structures.py
@@ -4,6 +4,10 @@ import numpy as np
 import logging
 import traceback
 from facekit.common.obs_consts import Source, code_to_src, src_to_code
+from facekit.embedding.embedding_selection import (
+    TrackEmbeddingSample,
+    select_consistent_embedding_subset,
+)
 
 @dataclass
 class FaceObservation:
@@ -83,6 +87,10 @@ class FaceTrack:
     is_active: bool = False       # Frame-level: assigned in current frame
     is_open: bool = True          # Track lifecycle
     embeddings: List[np.ndarray] = field(default_factory=list)
+    embedding_samples: List[TrackEmbeddingSample] = field(default_factory=list)
+    selected_embedding_samples: List[TrackEmbeddingSample] = field(default_factory=list)
+    representative_embedding: Optional[np.ndarray] = None
+    embedding_stable: bool = False
 
     last_landmarks: Optional[np.ndarray] = None     # shape (5,2), float32
     last_bbox: Optional[Tuple[int,int,int,int]] = None
@@ -295,3 +303,62 @@ class FaceTrack:
                 x1,y1,x2,y2 = map(int, o.bbox[:4])
                 return (x1,y1,x2,y2)
         return None
+    
+    def add_embedding_sample(self, sample: TrackEmbeddingSample) -> None:
+        """
+        Register a per-frame embedding sample for later representative-selection.
+        """
+        if not isinstance(sample, TrackEmbeddingSample):
+            raise TypeError(
+                f"sample must be TrackEmbeddingSample, got {type(sample).__name__}: {sample!r}"
+            )
+
+        if not hasattr(self, "embedding_samples"):
+            self.embedding_samples = []
+
+        self.embedding_samples.append(sample)
+
+    def finalize_embedding_representation(self) -> None:
+        """
+        Select a consistent subset of per-track embedding samples and compute a
+        representative embedding for the track.
+
+        Contract:
+        - If no valid embeddings are available, do not crash.
+        - Preserve the selected sample metadata.
+        - Mark the track unstable when no representative embedding can be formed.
+        - Treat duplicate samples at the same logical observation identity as one sample.
+        """
+        deduped_samples: list[TrackEmbeddingSample] = []
+        seen: set[tuple[int, int, Source]] = set()
+
+        for sample in self.embedding_samples:
+            key = (
+                int(sample.frame_idx),
+                int(sample.track_local_index),
+                sample.source,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped_samples.append(sample)
+
+        chosen = select_consistent_embedding_subset(deduped_samples)
+        self.selected_embedding_samples = list(chosen)
+
+        valid_embeddings = [
+            np.asarray(s.embedding, dtype=np.float32)
+            for s in self.selected_embedding_samples
+            if s.embedding is not None
+        ]
+
+        if not valid_embeddings:
+            self.representative_embedding = None
+            self.embedding_stable = False
+            return
+
+        self.representative_embedding = np.mean(
+            np.stack(valid_embeddings, axis=0),
+            axis=0,
+        )
+        self.embedding_stable = True

--- a/facekit/tracking/landmark_propagation.py
+++ b/facekit/tracking/landmark_propagation.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def propagate_landmarks_by_bbox_transform(
+    *,
+    prev_landmarks,
+    prev_bbox,
+    curr_bbox,
+):
+    if prev_landmarks is None:
+        return None
+
+    prev_landmarks = np.asarray(prev_landmarks, dtype=np.float32)
+    if prev_landmarks.shape != (5, 2):
+        return None
+
+    if prev_bbox is None or curr_bbox is None:
+        return None
+
+    px1, py1, px2, py2 = prev_bbox
+    cx1, cy1, cx2, cy2 = curr_bbox
+
+    prev_w = float(px2 - px1)
+    prev_h = float(py2 - py1)
+    curr_w = float(cx2 - cx1)
+    curr_h = float(cy2 - cy1)
+
+    if prev_w <= 0.0 or prev_h <= 0.0:
+        return None
+    if curr_w <= 0.0 or curr_h <= 0.0:
+        return None
+
+    x_norm = (prev_landmarks[:, 0] - float(px1)) / prev_w
+    y_norm = (prev_landmarks[:, 1] - float(py1)) / prev_h
+
+    out = np.empty((5, 2), dtype=np.float32)
+    out[:, 0] = float(cx1) + x_norm * curr_w
+    out[:, 1] = float(cy1) + y_norm * curr_h
+    return out

--- a/facekit/tracking/tracking_resolution.py
+++ b/facekit/tracking/tracking_resolution.py
@@ -1,11 +1,11 @@
-import numpy as np
-from typing import Optional, List
-from dataclasses import dataclass
-from typing import Tuple, Dict, Any
+import logging
 import math
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
 import torch
 import torch.nn.functional as F
-import logging
 
 from facekit.tracking.face_structures import FaceTrack
 
@@ -13,15 +13,24 @@ def _first_abs_frame(track) -> int:
     # Track may expose helpers; else infer from observations.
     if hasattr(track, "first_frame") and callable(getattr(track, "first_frame")):
         return int(track.first_frame())
-    obs = getattr(track, "observations", None) or []
-    if not obs:
+    observations = getattr(track, "observations", None) or []
+    if not observations:
         return 1 << 30
-    return int(getattr(obs[0], "frame_idx", 1 << 30))
+    return int(getattr(observations[0], "frame_idx", 1 << 30))
 
 @dataclass
 class _Comp:
     tracks: list
     earliest: int
+
+@dataclass
+class _TrackGroup:
+    members: List[FaceTrack]
+    member_keys: List[Tuple[int, int, int, int, int, int, int, int]]
+    group_embeddings: List[np.ndarray]
+    shot_id: Optional[int]
+    span_start: Optional[int]
+    span_end: Optional[int]
 
 class GlobalIdentityResolver:
     def __init__(self, embedding_threshold: float = 0.7, device: str = "auto"):
@@ -31,7 +40,7 @@ class GlobalIdentityResolver:
 
         Args:
             embedding_threshold (float): Cosine similarity threshold for linking tracks.
-            device (str): "auto", "cpu", or "cuda". 
+            device (str): "auto", "cpu", or "cuda".
                 - "auto": Use GPU if available, else CPU.
                 - "cpu": Force CPU.
                 - "cuda": Require GPU (raise error if not available).
@@ -39,7 +48,6 @@ class GlobalIdentityResolver:
         self.embedding_threshold = embedding_threshold
         self._threshold_tol = 1e-6
 
-        # Device selection logic
         if device == "auto":
             self.device = "cuda" if torch.cuda.is_available() else "cpu"
         elif device == "cuda" and not torch.cuda.is_available():
@@ -49,14 +57,16 @@ class GlobalIdentityResolver:
 
         # self._audit = bool(int(os.environ.get("FACEKIT_GI_AUDIT", "0")))
         self._audit = 1
-        logging.info(f"[INFO] GlobalIdentityResolver initialized on {self.device} (audit={self._audit})")
+        logging.info(
+            f"[INFO] GlobalIdentityResolver initialized on {self.device} (audit={self._audit})"
+        )
 
     def resolve_global_ids(self, tracks: List[FaceTrack], start_id: int = 0) -> int:
         """
-        Assign global_ids by clustering group representatives based on embedding similarity, 
-        groups consisting of tracks with same segment_id within a shot.  A must-not-link 
-        constraint  forbids merging tracks which overlap in time within the same shot. 
-        Uses a deterministic, best-first union-find so results are invariant to input order 
+        Assign global_ids by clustering group representatives based on embedding similarity,
+        groups consisting of tracks with same segment_id within a shot. A must-not-link
+        constraint forbids merging tracks which overlap in time within the same shot.
+        Uses a deterministic, best-first union-find so results are invariant to input order
         and cannot be 'bridged' across the constraint.
 
         Args:
@@ -67,8 +77,11 @@ class GlobalIdentityResolver:
             int: The next available global_id after assignment.
         """
 
-        # ---------- helpers ----------
-        def track_key(t: FaceTrack) -> Tuple[int, int, int, int, int]:
+        # ------------------------------
+        # Helpers
+        # ------------------------------
+
+        def track_key(track: FaceTrack) -> Tuple[int, int, int, int, int, int, int, int]:
             """
             Stable key for determinism across cold/resume.
             Avoid using list indices and track_id.
@@ -78,380 +91,590 @@ class GlobalIdentityResolver:
               - first_frame, last_frame
               - first bbox (rounded to int pixels) as an additional stable tie-break
             """
-            shot = int(getattr(t, "shot_id", -1))
-            seg  = getattr(t, "segment_id", None)
-            segk = int(seg) if seg is not None else (1 << 30)
-            try:
-                f0 = int(t.first_frame())
-            except Exception:
-                obs = getattr(t, "observations", None) or []
-                f0 = int(getattr(obs[0], "frame_idx", 1 << 30)) if obs else (1 << 30)
-            try:
-                f1 = int(t.last_frame())
-            except Exception:
-                obs = getattr(t, "observations", None) or []
-                f1 = int(getattr(obs[-1], "frame_idx", -1)) if obs else -1
+            shot_id = int(getattr(track, "shot_id", -1))
+            segment_id = getattr(track, "segment_id", None)
+            segment_key = int(segment_id) if segment_id is not None else (1 << 30)
 
-            # geometry tie-break: first bbox (int pixels), if available
+            try:
+                first = int(track.first_frame())
+            except Exception:
+                observations = getattr(track, "observations", None) or []
+                first = (
+                    int(getattr(observations[0], "frame_idx", 1 << 30))
+                    if observations
+                    else (1 << 30)
+                )
+
+            try:
+                last = int(track.last_frame())
+            except Exception:
+                observations = getattr(track, "observations", None) or []
+                last = int(getattr(observations[-1], "frame_idx", -1)) if observations else -1
+
             x1 = y1 = x2 = y2 = (1 << 30)
-            obs = getattr(t, "observations", None) or []
-            if obs:
-                bb = getattr(obs[0], "bbox", None)
-                if bb is not None and len(bb) == 4:
+            observations = getattr(track, "observations", None) or []
+            if observations:
+                bbox = getattr(observations[0], "bbox", None)
+                if bbox is not None and len(bbox) == 4:
                     try:
-                        x1, y1, x2, y2 = (int(round(float(bb[0]))),
-                                          int(round(float(bb[1]))),
-                                          int(round(float(bb[2]))),
-                                          int(round(float(bb[3]))))
+                        x1, y1, x2, y2 = (
+                            int(round(float(bbox[0]))),
+                            int(round(float(bbox[1]))),
+                            int(round(float(bbox[2]))),
+                            int(round(float(bbox[3]))),
+                        )
                     except Exception:
                         pass
 
-            return (shot, segk, f0, f1, x1, y1, x2, y2)
+            return (shot_id, segment_key, first, last, x1, y1, x2, y2)
 
-        def robust_center(emb_list: List[np.ndarray], cutoff: float = 0.30) -> Optional[np.ndarray]:
-            E = np.stack(emb_list).astype(np.float32)
-            # row-normalize to unit length
-            norms = np.linalg.norm(E, axis=1, keepdims=True)
+        def robust_center(
+            embedding_list: List[np.ndarray], cutoff: float = 0.30
+        ) -> Optional[np.ndarray]:
+            embedding_matrix = np.stack(embedding_list).astype(np.float32)
+
+            norms = np.linalg.norm(embedding_matrix, axis=1, keepdims=True)
             norms[norms == 0] = 1.0
-            E = E / norms
-            c = E.mean(axis=0)
-            cn = np.linalg.norm(c)
-            if not np.isfinite(cn) or cn == 0.0:
-                return None
-            # trim outliers by cosine distance to the provisional center
-            c_hat = c / cn
-            d = 1.0 - (E @ c_hat)
-            keep = d <= cutoff
-            c2 = (E[keep].mean(axis=0) if keep.any() else c_hat)
-            cn2 = np.linalg.norm(c2)
-            if not np.isfinite(cn2) or cn2 == 0.0:
-                return None
-            return (c2 / cn2)
+            embedding_matrix = embedding_matrix / norms
 
-        def first_frame(t: FaceTrack) -> int:
-            return t.first_frame()
+            center = embedding_matrix.mean(axis=0)
+            center_norm = np.linalg.norm(center)
+            if not np.isfinite(center_norm) or center_norm == 0.0:
+                return None
 
-        def last_frame(t: FaceTrack) -> int:
-            return t.last_frame()
-        
-        # ----------- audit helpers -------------
-        def _obs_mix(t: FaceTrack):
+            center_hat = center / center_norm
+            cosine_distance = 1.0 - (embedding_matrix @ center_hat)
+            keep_mask = cosine_distance <= cutoff
+
+            trimmed_center = embedding_matrix[keep_mask].mean(axis=0) if keep_mask.any() else center_hat
+            trimmed_center_norm = np.linalg.norm(trimmed_center)
+            if not np.isfinite(trimmed_center_norm) or trimmed_center_norm == 0.0:
+                return None
+
+            return trimmed_center / trimmed_center_norm
+
+        def first_frame(track: FaceTrack) -> int:
+            return track.first_frame()
+
+        def last_frame(track: FaceTrack) -> int:
+            return track.last_frame()
+
+        def _identity_embeddings_for_track(track: FaceTrack) -> List[np.ndarray]:
+            """
+            Return the embedding evidence this track should contribute to
+            identity resolution.
+
+            Contract:
+            - If a stable representative_embedding exists, use that as the
+              canonical identity signal for the track.
+            - Otherwise fall back to the track's per-observation embeddings.
+            """
+            representative_embedding = getattr(track, "representative_embedding", None)
+            is_stable = bool(getattr(track, "embedding_stable", False))
+
+            if is_stable and representative_embedding is not None:
+                representative_array = np.asarray(representative_embedding, dtype=np.float32)
+                if representative_array.ndim == 1 and np.isfinite(representative_array).all():
+                    return [representative_array]
+
+            identity_embeddings: List[np.ndarray] = []
+            for embedding in (getattr(track, "embeddings", None) or []):
+                if embedding is None:
+                    continue
+                embedding_array = np.asarray(embedding, dtype=np.float32)
+                if embedding_array.ndim == 1 and np.isfinite(embedding_array).all():
+                    identity_embeddings.append(embedding_array)
+
+            return identity_embeddings
+
+        # ------------------------------
+        # Audit helpers
+        # ------------------------------
+
+        def _obs_mix(track: FaceTrack):
             from facekit.common.obs_consts import Source
-            n_det = n_trk = 0
-            for o in getattr(t, "observations", []) or []:
-                src = getattr(o, "source", None)
-                if src == Source.DETECTED: n_det += 1
-                elif src == Source.TRACKED: n_trk += 1
-            return n_det, n_trk
 
-        def _emb_stats(t: FaceTrack):
-            embs = getattr(t, "embeddings", None) or []
-            n = len(embs)
-            if n == 0:
+            detected_count = 0
+            tracked_count = 0
+            for observation in getattr(track, "observations", []) or []:
+                source = getattr(observation, "source", None)
+                if source == Source.DETECTED:
+                    detected_count += 1
+                elif source == Source.TRACKED:
+                    tracked_count += 1
+            return detected_count, tracked_count
+
+        def _emb_stats(track: FaceTrack):
+            embeddings = getattr(track, "embeddings", None) or []
+            embedding_count = len(embeddings)
+            if embedding_count == 0:
                 return 0, 0, "0.000"
-            nan_cnt = sum(0 if (e is not None and np.isfinite(e).all()) else 1 for e in embs)
+
+            nan_count = sum(
+                0 if (embedding is not None and np.isfinite(embedding).all()) else 1
+                for embedding in embeddings
+            )
+
             norms = []
-            for e in embs:
-                if e is None: continue
-                v = float(np.linalg.norm(np.asarray(e, dtype=np.float32)))
-                if math.isfinite(v): norms.append(v)
-            avg_norm = (sum(norms)/len(norms) if norms else 0.0)
-            return n, nan_cnt, f"{avg_norm:.3f}"
+            for embedding in embeddings:
+                if embedding is None:
+                    continue
+                norm_value = float(np.linalg.norm(np.asarray(embedding, dtype=np.float32)))
+                if math.isfinite(norm_value):
+                    norms.append(norm_value)
 
-        def _tspan(t: FaceTrack):
+            average_norm = (sum(norms) / len(norms)) if norms else 0.0
+            return embedding_count, nan_count, f"{average_norm:.3f}"
+
+        def _tspan(track: FaceTrack):
             try:
-                return int(t.first_frame()), int(t.last_frame())
+                return int(track.first_frame()), int(track.last_frame())
             except Exception:
-                obs = getattr(t, "observations", None) or []
-                if not obs: return (1<<30, -1)
-                return int(obs[0].frame_idx), int(obs[-1].frame_idx)
+                observations = getattr(track, "observations", None) or []
+                if not observations:
+                    return (1 << 30, -1)
+                return int(observations[0].frame_idx), int(observations[-1].frame_idx)
 
-        # --- Preconditions: every track must have >= 1 observation ---
-        # Treat falsy (None or []) as invalid. Raise ValueError (as tests expect).
-        missing = [getattr(t, "track_id", None) for t in tracks
-                if not getattr(t, "observations", None)]
-        if missing:
+        # ------------------------------
+        # Preconditions
+        # ------------------------------
+
+        missing_track_ids = [
+            getattr(track, "track_id", None)
+            for track in tracks
+            if not getattr(track, "observations", None)
+        ]
+        if missing_track_ids:
             raise ValueError(
                 "Track(s) have no observations; resolver requires >=1 observation per track. "
-                f"Offenders track_id={missing}"
+                f"Offenders track_id={missing_track_ids}"
             )
-        
+
         if self._audit:
             logging.info("GI-AUDIT INPUT: count=%d", len(tracks))
-            # Deterministic order for diffs
-            for t in sorted(tracks, key=track_key):
-                s  = int(getattr(t, "shot_id", -1))
-                sg = getattr(t, "segment_id", None)
-                tid= int(getattr(t, "track_id", -1))
-                f0,f1 = _tspan(t)
-                n_obs = len(getattr(t, "observations", []) or [])
-                n_det,n_trk = _obs_mix(t)
-                n_emb, n_nan, avg_norm = _emb_stats(t)
-                logging.info("GI-IN: shot=%d seg=%s tid=%d span=[%d..%d] n_obs=%d det=%d trk=%d emb=%d nan=%d avg_norm=%s",
-                             s, (str(int(sg)) if sg is not None else "-"), tid, f0, f1,
-                             n_obs, n_det, n_trk, n_emb, n_nan, avg_norm)
+            for track in sorted(tracks, key=track_key):
+                shot_id = int(getattr(track, "shot_id", -1))
+                segment_id = getattr(track, "segment_id", None)
+                track_id = int(getattr(track, "track_id", -1))
+                span_start, span_end = _tspan(track)
+                observation_count = len(getattr(track, "observations", []) or [])
+                detected_count, tracked_count = _obs_mix(track)
+                embedding_count, nan_count, average_norm = _emb_stats(track)
 
-        # Step 0: Group tracks by (shot_id, segment_id)
-        # Fall back to per-track grouping when no segment_id present
-        groups: Dict[Any, dict] = {}  # key -> dict with: members (tracks), member_keys, all_embs, shot_id, span_start, span_end
-        for t in tracks:
-            shot_id = getattr(t, "shot_id", None)
-            shot_face_id = getattr(t, "segment_id", None)
+                logging.info(
+                    "GI-IN: shot=%d seg=%s tid=%d span=[%d..%d] n_obs=%d det=%d trk=%d emb=%d nan=%d avg_norm=%s",
+                    shot_id,
+                    (str(int(segment_id)) if segment_id is not None else "-"),
+                    track_id,
+                    span_start,
+                    span_end,
+                    observation_count,
+                    detected_count,
+                    tracked_count,
+                    embedding_count,
+                    nan_count,
+                    average_norm,
+                )
 
-            if shot_face_id is None:
-                # fallback to per-track behavior - use stable key so it is deterministic
-                key = ("__per_track__", track_key(t))
+        # ------------------------------
+        # Step 0: Build track groups
+        # ------------------------------
+
+        group_by_key: Dict[Any, _TrackGroup] = {}
+
+        for track in tracks:
+            shot_id = getattr(track, "shot_id", None)
+            segment_id = getattr(track, "segment_id", None)
+
+            if segment_id is None:
+                group_key = ("__per_track__", track_key(track))
             else:
-                key = (shot_id, shot_face_id)
+                group_key = (shot_id, segment_id)
 
-            g = groups.setdefault(key, {
-                "members": [], "member_keys": [], "all_embs": [], "shot_id": shot_id,
-                "span_start": None, "span_end": None
-            })
-            g["members"].append(t)
-            g["member_keys"].append(track_key(t))
+            if group_key not in group_by_key:
+                group_by_key[group_key] = _TrackGroup(
+                    members=[],
+                    member_keys=[],
+                    group_embeddings=[],
+                    shot_id=shot_id,
+                    span_start=None,
+                    span_end=None,
+                )
 
-            embs = getattr(t, "embeddings", None)
-            if embs:
-                # extend all embeddings for robust averaging
-                for e in embs:
-                    if e is None:
-                        continue
-                    arr = np.asarray(e, dtype=np.float32)
-                    if arr.ndim != 1:
-                        continue
-                    if not np.isfinite(arr).all():
-                        continue
-                    g["all_embs"].append(arr)
+            group = group_by_key[group_key]
+            group.members.append(track)
+            group.member_keys.append(track_key(track))
 
-            # accumulate span
-            s0 = first_frame(t); s1 = last_frame(t)
-            if s0 is not None and s1 is not None:
-                g["span_start"] = s0 if g["span_start"] is None else min(g["span_start"], s0)
-                g["span_end"]   = s1 if g["span_end"]   is None else max(g["span_end"],   s1)
-            
+            for embedding in _identity_embeddings_for_track(track):
+                group.group_embeddings.append(embedding)
+
+            track_start = first_frame(track)
+            track_end = last_frame(track)
+            if track_start is not None and track_end is not None:
+                group.span_start = (
+                    track_start
+                    if group.span_start is None
+                    else min(group.span_start, track_start)
+                )
+                group.span_end = (
+                    track_end
+                    if group.span_end is None
+                    else max(group.span_end, track_end)
+                )
+
         if self._audit:
+
             def _group_sort_key(item):
-                key, g = item
-                if key[0] == "__per_track__":
-                    # put per-track groups after real (shot, seg) groups; stable by the embedded track_key tuple
-                    return (1, key[1])
-                shot_id, seg_id = key
+                group_key, group = item
+                if group_key[0] == "__per_track__":
+                    return (1, group_key[1])
+
+                shot_id, segment_id = group_key
                 shot_sort = int(shot_id) if shot_id is not None else -1
-                seg_sort  = int(seg_id)  if seg_id  is not None else (1 << 30)
-                return (0, shot_sort, seg_sort)
+                segment_sort = int(segment_id) if segment_id is not None else (1 << 30)
+                return (0, shot_sort, segment_sort)
 
-            for key, g in sorted(groups.items(), key=_group_sort_key):
-                if key[0] == "__per_track__":
-                    logging.info("GI-GROUP: per_track key=%s members=%s", key[1], g["members"])
+            for group_key, group in sorted(group_by_key.items(), key=_group_sort_key):
+                if group_key[0] == "__per_track__":
+                    logging.info(
+                        "GI-GROUP: per_track key=%s members=%s",
+                        group_key[1],
+                        group.members,
+                    )
                 else:
-                    logging.info("GI-GROUP: shot=%d seg=%s members=%s span=[%s..%s] embs=%d",
-                                 int(g["shot_id"]) if g["shot_id"] is not None else -1,
-                                 (str(int(key[1])) if key[1] is not None else "-"),
-                                 g["members"], str(g["span_start"]), str(g["span_end"]), len(g["all_embs"]))
+                    logging.info(
+                        "GI-GROUP: shot=%d seg=%s members=%s span=[%s..%s] embs=%d",
+                        int(group.shot_id) if group.shot_id is not None else -1,
+                        (str(int(group_key[1])) if group_key[1] is not None else "-"),
+                        group.members,
+                        str(group.span_start),
+                        str(group.span_end),
+                        len(group.group_embeddings),
+                    )
 
-
+        # ------------------------------
         # Step 1: Build group representatives
-        group_keys = []
-        reps = []
-        shots = []
-        starts = []
-        ends = []
+        # ------------------------------
+
+        representative_group_keys = []
+        representative_embeddings = []
+        representative_shots = []
+        representative_starts = []
+        representative_ends = []
 
         def _rep_group_sort_key(item):
-            key, g = item
-            if key[0] == "__per_track__":
-                # key[1] is already a stable track_key tuple
-                return (1, key[1])
-            shot_id, seg_id = key
-            shot_sort = int(shot_id) if shot_id is not None else -1
-            seg_sort  = int(seg_id)  if seg_id  is not None else (1 << 30)
-            # add min member key for extra determinism if you ever get duplicate (shot, seg) keys by mistake
-            min_member = min(g["member_keys"]) if g["member_keys"] else (1<<30,)*5
-            return (0, shot_sort, seg_sort, min_member)
+            group_key, group = item
+            if group_key[0] == "__per_track__":
+                return (1, group_key[1])
 
-        for key, g in sorted(groups.items(), key=_rep_group_sort_key):
-            if g["all_embs"]:
-                rep = robust_center(g["all_embs"])
-                if rep is None:
-                    # Pathological embeddings: skip this group (falls back to leftover assignment)
+            shot_id, segment_id = group_key
+            shot_sort = int(shot_id) if shot_id is not None else -1
+            segment_sort = int(segment_id) if segment_id is not None else (1 << 30)
+            min_member_key = min(group.member_keys) if group.member_keys else (1 << 30,) * 8
+            return (0, shot_sort, segment_sort, min_member_key)
+
+        for group_key, group in sorted(group_by_key.items(), key=_rep_group_sort_key):
+            if group.group_embeddings:
+                representative_embedding = robust_center(group.group_embeddings)
+                if representative_embedding is None:
                     continue
-                group_keys.append(key)
-                reps.append(rep)
-                # Default unknown shot to -1 so must-not-link only triggers on real matches
-                shots.append(int(g["shot_id"]) if g["shot_id"] is not None else -1)
-                starts.append(g["span_start"] if g["span_start"] is not None else -10**9)
-                ends.append(g["span_end"]   if g["span_end"]   is not None else  10**9)
-        
-        # Edge case: no representatives calculated (no embeddings at all) -> assign unique IDs
-        if not reps:
-           for t in tracks:
-                t.global_id = start_id
+
+                representative_group_keys.append(group_key)
+                representative_embeddings.append(representative_embedding)
+                representative_shots.append(
+                    int(group.shot_id) if group.shot_id is not None else -1
+                )
+                representative_starts.append(
+                    group.span_start if group.span_start is not None else -10**9
+                )
+                representative_ends.append(
+                    group.span_end if group.span_end is not None else 10**9
+                )
+
+        if not representative_embeddings:
+            for track in tracks:
+                track.global_id = start_id
                 start_id += 1
                 if self._audit:
-                    logging.info("GI-AUDIT: no reps -> assigned unique global_ids up to %d", start_id-1)
+                    logging.info(
+                        "GI-AUDIT: no reps -> assigned unique global_ids up to %d",
+                        start_id - 1,
+                    )
+            return start_id
 
-           return start_id
-        
-        # Map: group index -> member track indices
-        group_members = [groups[k]["members"] for k in group_keys]          # List[List[FaceTrack]]
-        group_member_keys = [groups[k]["member_keys"] for k in group_keys]  # List[List[track_key]]
+        group_members = [
+            group_by_key[group_key].members for group_key in representative_group_keys
+        ]
+        group_member_keys = [
+            group_by_key[group_key].member_keys for group_key in representative_group_keys
+        ]
 
-        # Step 2: Compute similarities among group reps
-        emb_tensor = torch.tensor(np.stack(reps), dtype=torch.float32, device=self.device)
-        emb_tensor = F.normalize(emb_tensor, p=2, dim=1)               # (n, d)
-        sim_matrix = torch.mm(emb_tensor, emb_tensor.T)                # cosine similarity matrix, (n, n)
-        sim_matrix_np = sim_matrix.detach().cpu().numpy()              # Pull to CPU numpy once to avoid many device hops
+        # ------------------------------
+        # Step 2: Compute similarities among group representatives
+        # ------------------------------
 
-        emb_threshold = float(self.embedding_threshold)
-        tol = float(getattr(self, "_threshold_tol", 1e-6))
-        m = len(group_keys)
+        embedding_tensor = torch.tensor(
+            np.stack(representative_embeddings),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        embedding_tensor = F.normalize(embedding_tensor, p=2, dim=1)
+        similarity_matrix = torch.mm(embedding_tensor, embedding_tensor.T)
+        similarity_matrix_np = similarity_matrix.detach().cpu().numpy()
 
-        edges = []
-        for i in range(m):
-            # Diagonal ignored; only i < j
-            row = sim_matrix_np[i]
-            for j in range(i + 1, m):
-                s = row[j]
-                if s + tol >= emb_threshold:
-                    # stable ordering by smallest stable track_key in each group
-                    lo = min(group_member_keys[i]) if group_member_keys[i] else (1<<30,)*8
-                    hi = min(group_member_keys[j]) if group_member_keys[j] else (1<<30,)*8
-                    if lo > hi: lo, hi = hi, lo
-                    edges.append((s, i, j, lo, hi))
+        embedding_threshold = float(self.embedding_threshold)
+        threshold_tolerance = float(getattr(self, "_threshold_tol", 1e-6))
+        group_count = len(representative_group_keys)
 
-        edges.sort(key=lambda x: (-float(x[0]), x[3], x[4]))  # similarity desc, then stable tiebreak
+        candidate_edges = []
+        for left_group_idx in range(group_count):
+            similarity_row = similarity_matrix_np[left_group_idx]
+            for right_group_idx in range(left_group_idx + 1, group_count):
+                similarity = similarity_row[right_group_idx]
+                if similarity + threshold_tolerance >= embedding_threshold:
+                    left_tiebreak = (
+                        min(group_member_keys[left_group_idx])
+                        if group_member_keys[left_group_idx]
+                        else (1 << 30,) * 8
+                    )
+                    right_tiebreak = (
+                        min(group_member_keys[right_group_idx])
+                        if group_member_keys[right_group_idx]
+                        else (1 << 30,) * 8
+                    )
+                    if left_tiebreak > right_tiebreak:
+                        left_tiebreak, right_tiebreak = right_tiebreak, left_tiebreak
+
+                    candidate_edges.append(
+                        (
+                            similarity,
+                            left_group_idx,
+                            right_group_idx,
+                            left_tiebreak,
+                            right_tiebreak,
+                        )
+                    )
+
+        candidate_edges.sort(key=lambda edge: (-float(edge[0]), edge[3], edge[4]))
+
         if self._audit:
-            logging.info("GI-EDGES: threshold=%.3f candidates=%d", emb_threshold, len(edges))
-            for s, i, j, lo, hi in edges:
-                logging.info("GI-EDGE: sim=%.4f i=%d j=%d tiebreak=(%s,%s)", float(s), i, j, lo, hi)
+            logging.info(
+                "GI-EDGES: threshold=%.3f candidates=%d",
+                embedding_threshold,
+                len(candidate_edges),
+            )
+            for similarity, left_group_idx, right_group_idx, left_tiebreak, right_tiebreak in candidate_edges:
+                logging.info(
+                    "GI-EDGE: sim=%.4f i=%d j=%d tiebreak=(%s,%s)",
+                    float(similarity),
+                    left_group_idx,
+                    right_group_idx,
+                    left_tiebreak,
+                    right_tiebreak,
+                )
 
-        # Step 3: Union-Find (Disjoint Set) with must-not-link constraint
-        parent = list(range(m))
-        rank = [0] * m
+        # ------------------------------
+        # Step 3: Union-Find with must-not-link constraint
+        # ------------------------------
 
-        # For each component we keep a map: shot_id -> list of (start,end) intervals
-        comp_spans = [{shots[i]: [(starts[i], ends[i])]} for i in range(m)]
+        parent = list(range(group_count))
+        rank = [0] * group_count
 
-        def find(x: int) -> int:
-            while parent[x] != x:
-                parent[x] = parent[parent[x]]
-                x = parent[x]
-            return x
+        component_spans = [
+            {representative_shots[group_idx]: [(representative_starts[group_idx], representative_ends[group_idx])]}
+            for group_idx in range(group_count)
+        ]
 
-        def union(a: int, b: int) -> bool:
-            """ Union with union-by-rank. Returns True if merged, False otherwise. """
-            ra, rb = find(a), find(b)
-            if ra == rb:
+        def find(group_idx: int) -> int:
+            while parent[group_idx] != group_idx:
+                parent[group_idx] = parent[parent[group_idx]]
+                group_idx = parent[group_idx]
+            return group_idx
+
+        def union(left_group_idx: int, right_group_idx: int) -> bool:
+            """
+            Union with union-by-rank.
+            Returns True if merged, False otherwise.
+            """
+            left_root = find(left_group_idx)
+            right_root = find(right_group_idx)
+            if left_root == right_root:
                 return False
 
-            # ---- must-not-link: forbid merging if any same-shot intervals overlap ----
-            spans_a = comp_spans[ra]
-            spans_b = comp_spans[rb]
-            shared_shots = (set(spans_a.keys()) & set(spans_b.keys())) - {-1}
+            left_spans = component_spans[left_root]
+            right_spans = component_spans[right_root]
+            shared_shots = (set(left_spans.keys()) & set(right_spans.keys())) - {-1}
 
             if shared_shots:
 
-                def overlaps(a0, a1, b0, b1):
-                    # inclusive overlap
-                    return not (a1 < b0 or b1 < a0)
+                def overlaps(
+                    left_start: int,
+                    left_end: int,
+                    right_start: int,
+                    right_end: int,
+                ) -> bool:
+                    return not (left_end < right_start or right_end < left_start)
 
-                for sh in shared_shots:
-                    la = spans_a.get(sh, [])
-                    lb = spans_b.get(sh, [])
-                    # If any interval pair overlaps, merging is forbidden
-                    for (sa0, sa1) in la:
-                        for (sb0, sb1) in lb:
-                            if overlaps(sa0, sa1, sb0, sb1):
+                for shot_id in shared_shots:
+                    left_intervals = left_spans.get(shot_id, [])
+                    right_intervals = right_spans.get(shot_id, [])
+
+                    for left_start, left_end in left_intervals:
+                        for right_start, right_end in right_intervals:
+                            if overlaps(left_start, left_end, right_start, right_end):
                                 if self._audit:
-                                    logging.info("GI-BLOCK: shot=%d A=[%d..%d] B=[%d..%d]", int(sh), int(sa0), int(sa1), int(sb0), int(sb1))
-                                return False  # must-not-link violation
+                                    logging.info(
+                                        "GI-BLOCK: shot=%d A=[%d..%d] B=[%d..%d]",
+                                        int(shot_id),
+                                        int(left_start),
+                                        int(left_end),
+                                        int(right_start),
+                                        int(right_end),
+                                    )
+                                return False
 
-            # If constraint passes, merge by rank and merge span maps
-            if rank[ra] < rank[rb]:
-                ra, rb = rb, ra  # ensure ra is the new root
-            parent[rb] = ra
-            if rank[ra] == rank[rb]:
-                rank[ra] += 1
+            if rank[left_root] < rank[right_root]:
+                left_root, right_root = right_root, left_root
 
-            # Merge span maps: concatenate interval lists per shot
-            merged = dict(spans_a)
-            for sh, lst in spans_b.items():
-                merged.setdefault(sh, []).extend(lst)
-            comp_spans[ra] = merged
-            comp_spans[rb] = {}  # not used anymore
+            parent[right_root] = left_root
+            if rank[left_root] == rank[right_root]:
+                rank[left_root] += 1
+
+            merged_spans = dict(left_spans)
+            for shot_id, interval_list in right_spans.items():
+                merged_spans.setdefault(shot_id, []).extend(interval_list)
+
+            component_spans[left_root] = merged_spans
+            component_spans[right_root] = {}
+
             if self._audit:
-                logging.info("GI-UNION: a=%d b=%d -> root=%d", int(a), int(b), int(ra))
+                logging.info(
+                    "GI-UNION: a=%d b=%d -> root=%d",
+                    int(left_group_idx),
+                    int(right_group_idx),
+                    int(left_root),
+                )
+
             return True
 
-        merges = 0
-        for s, i, j, _, _ in edges:
-            if union(i, j):
-                merges += 1
-        if self._audit:
-            logging.info("GI-UNION-SUMMARY: merged=%d / candidates=%d / groups=%d", merges, len(edges), m)
+        merge_count = 0
+        for similarity, left_group_idx, right_group_idx, _, _ in candidate_edges:
+            if union(left_group_idx, right_group_idx):
+                merge_count += 1
 
+        if self._audit:
+            logging.info(
+                "GI-UNION-SUMMARY: merged=%d / candidates=%d / groups=%d",
+                merge_count,
+                len(candidate_edges),
+                group_count,
+            )
+
+        # ------------------------------
         # Step 4: Gather components and assign global IDs
-        root_to_nodes = {}
-        for i in range(m):
-            r = find(i)
-            root_to_nodes.setdefault(r, []).append(i)
+        # ------------------------------
 
-        # Deterministic component order: by earliest absolute frame among a component's members
-        def comp_earliest_frame(nodes: List[int]) -> int:
-            earliest = 10**9
-            for gi in nodes:
-                # each group idx -> its span_start in `starts`
-                earliest = min(earliest, starts[gi] if starts[gi] is not None else 10**9)
-            return earliest
+        root_to_group_indices: Dict[int, List[int]] = {}
+        for group_idx in range(group_count):
+            root_idx = find(group_idx)
+            root_to_group_indices.setdefault(root_idx, []).append(group_idx)
 
-        # Stable ordering: earliest frame, then smallest member track index in the component
-        def comp_tiebreak(nodes: List[int]) -> Tuple[int, int, int, int, int]:
-            # choose the smallest stable key present in this component
-            # (now independent of transient track_id)
-            return min(min(group_member_keys[gi]) for gi in nodes if group_member_keys[gi])
+        def component_earliest_frame(group_indices: List[int]) -> int:
+            earliest_frame = 10**9
+            for group_idx in group_indices:
+                earliest_frame = min(
+                    earliest_frame,
+                    representative_starts[group_idx]
+                    if representative_starts[group_idx] is not None
+                    else 10**9,
+                )
+            return earliest_frame
+
+        def component_tiebreak(group_indices: List[int]) -> Tuple[int, int, int, int, int, int, int, int]:
+            return min(
+                min(group_member_keys[group_idx])
+                for group_idx in group_indices
+                if group_member_keys[group_idx]
+            )
+
         components = sorted(
-            root_to_nodes.values(),
-            key=lambda nodes: (comp_earliest_frame(nodes), comp_tiebreak(nodes))
+            root_to_group_indices.values(),
+            key=lambda group_indices: (
+                component_earliest_frame(group_indices),
+                component_tiebreak(group_indices),
+            ),
         )
- 
-        gid_assignments = []  # for audit dump
-        for comp in components:
-            for local_idx in comp:
-                for tr in group_members[local_idx]:
-                    tr.global_id = start_id
-                    gid_assignments.append((start_id,
-                        int(getattr(tr, "shot_id", -1)),
-                        int(getattr(tr, "segment_id", -1) if getattr(tr, "segment_id", None) is not None else -1),
-                        int(getattr(tr, "track_id", -1)),
-                        _tspan(tr)[0],
-                        _tspan(tr)[1],
-                    ))
+
+        gid_assignments = []
+        for component_group_indices in components:
+            for group_idx in component_group_indices:
+                for track in group_members[group_idx]:
+                    track.global_id = start_id
+                    gid_assignments.append(
+                        (
+                            start_id,
+                            int(getattr(track, "shot_id", -1)),
+                            int(
+                                getattr(track, "segment_id", -1)
+                                if getattr(track, "segment_id", None) is not None
+                                else -1
+                            ),
+                            int(getattr(track, "track_id", -1)),
+                            _tspan(track)[0],
+                            _tspan(track)[1],
+                        )
+                    )
             start_id += 1
+
         if self._audit:
-            for gid, shot, seg, tid, f0, f1 in sorted(gid_assignments, key=lambda r: (r[0], r[1], r[4])):
-                logging.info("GI-ASSIGN: gid=%d shot=%d seg=%s tid=%d span=[%d..%d]",
-                             gid, shot, ("-" if seg < 0 else str(seg)), tid, f0, f1)
+            for gid, shot_id, segment_id, track_id, span_start, span_end in sorted(
+                gid_assignments, key=lambda row: (row[0], row[1], row[4])
+            ):
+                logging.info(
+                    "GI-ASSIGN: gid=%d shot=%d seg=%s tid=%d span=[%d..%d]",
+                    gid,
+                    shot_id,
+                    ("-" if segment_id < 0 else str(segment_id)),
+                    track_id,
+                    span_start,
+                    span_end,
+                )
 
-
+        # ------------------------------
         # Step 5: Assign unique IDs to tracks without embeddings
-        # (Rare: groups existed but had zero embs; or tracks with no embs at all)
-        assigned = {id(t) for members in group_members for t in members}
-        # Assign leftovers (tracks without any group rep / embeddings) AFTER components, by earliest frame
-        leftovers = [t for t in tracks if id(t) not in assigned]
-        def _leftover_sort_key(t: FaceTrack):
+        # ------------------------------
+
+        assigned_track_ids = {
+            id(track)
+            for member_list in group_members
+            for track in member_list
+        }
+
+        leftovers = [track for track in tracks if id(track) not in assigned_track_ids]
+
+        def _leftover_sort_key(track: FaceTrack):
             try:
-                f0 = int(t.first_frame())
+                first = int(track.first_frame())
             except Exception:
-                obs = getattr(t, "observations", None) or []
-                f0 = int(getattr(obs[0], "frame_idx", 1 << 30)) if obs else (1 << 30)
-            return (f0, track_key(t))
+                observations = getattr(track, "observations", None) or []
+                first = (
+                    int(getattr(observations[0], "frame_idx", 1 << 30))
+                    if observations
+                    else (1 << 30)
+                )
+            return (first, track_key(track))
+
         leftovers.sort(key=_leftover_sort_key)
-        for t in leftovers:
-            t.global_id = start_id
+
+        for track in leftovers:
+            track.global_id = start_id
             start_id += 1
 
         if self._audit and leftovers:
-            logging.info("GI-LEFTOVERS: assigned %d unique ids up to %d", len(leftovers), start_id-1)
+            logging.info(
+                "GI-LEFTOVERS: assigned %d unique ids up to %d",
+                len(leftovers),
+                start_id - 1,
+            )
 
         return start_id

--- a/tests/integration/test_resume_anchor_shot_continuity.py
+++ b/tests/integration/test_resume_anchor_shot_continuity.py
@@ -1,5 +1,3 @@
-# tests/integration/test_resume_anchor_shot_continuity.py
-
 from __future__ import annotations
 
 import atexit
@@ -10,16 +8,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
+from facekit.common.obs_consts import Source, src_to_code
 
-# ---- helpers ---------------------------------------------------------------
 
 _LOG_DIRS_TO_ZIP: list[Path] = []
 
 
 def _repo_root() -> Path:
-    # This file lives at tests/integration/test_resume_anchor_shot_continuity.py
     return Path(__file__).resolve().parents[2]
 
 
@@ -29,6 +27,56 @@ def _env_with_repo() -> dict[str, str]:
     old = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = repo if not old else f"{repo}{os.pathsep}{old}"
     return env
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _load_single_array_from_npz(path: Path) -> np.ndarray:
+    with np.load(path, allow_pickle=False) as data:
+        if len(data.files) != 1:
+            raise AssertionError(f"expected exactly one array in {path}, found {data.files}")
+        return data[data.files[0]]
+
+
+def _ordered_tracks(js: dict) -> list[dict]:
+    tracks: list[dict] = []
+    shots = js.get("shots")
+    if shots is None:
+        raise KeyError("No 'shots' key in manifest")
+
+    for shot in shots:
+        shot_no = int(shot.get("shot_number", 0))
+        for track in shot.get("face_tracks", []):
+            row = dict(track)
+            row.setdefault("shot_id", shot_no)
+            tracks.append(row)
+
+    tracks.sort(
+        key=lambda t: (
+            int(t["shot_id"]),
+            int(t["first_frame"]),
+            int(t.get("last_frame", -1)),
+            str(t.get("face_label") or ""),
+        )
+    )
+    return tracks
+
+
+def _latest_ckpt_dir(parent: Path) -> Path:
+    runs = [d for d in parent.iterdir() if d.is_dir() and d.name.startswith("run-")]
+    assert runs, f"No run-* directory under {parent}"
+
+    def _score(path: Path) -> tuple[bool, float, float]:
+        status = path / "status.json"
+        return (
+            status.exists(),
+            status.stat().st_mtime if status.exists() else 0.0,
+            path.stat().st_mtime,
+        )
+
+    return max(runs, key=_score)
 
 
 class RunResult:
@@ -84,56 +132,57 @@ def _zip_logs() -> None:
         pass
 
 
+def _resolve_obs_sidecar_path(latest_ckpt_dir: Path, requested_path: Path) -> Path:
+    if requested_path.exists():
+        return requested_path
+
+    status_json = latest_ckpt_dir / "status.json"
+    if status_json.exists():
+        status = _load_json(status_json)
+        for key in (
+            "obs_sidecar_path",
+            "observations_sidecar_path",
+            "obs_npz_path",
+        ):
+            value = status.get(key)
+            if value:
+                candidate = Path(value)
+                if candidate.exists():
+                    return candidate
+
+    candidates = sorted(latest_ckpt_dir.rglob("*.npz"))
+    obs_like = [p for p in candidates if "obs" in p.name.lower()]
+    if len(obs_like) == 1:
+        return obs_like[0]
+
+    raise AssertionError(
+        "Could not locate observation sidecar.\n"
+        f"requested_path={requested_path}\n"
+        f"latest_ckpt_dir={latest_ckpt_dir}\n"
+        f"npz_candidates={[str(p) for p in candidates]}"
+    )
+
 atexit.register(_zip_logs)
 
-
-def _load_json(path: Path) -> dict:
-    return json.loads(path.read_text())
-
-def _ordered_tracks(js: dict) -> list[dict]:
-    """
-    Return a flattened, consistently-sorted list of track dicts.
-    Matches the helper used by the original integration test.
-    """
-    tracks = []
-    if "shots" in js:
-        # v2.0 / v2.1: flatten shots[*].face_tracks and carry shot_number for sort
-        for shot in js.get("shots", []):
-            shot_no = int(shot.get("shot_number", 0))
-            for t in shot.get("face_tracks", []):
-                t = dict(t)  # shallow copy
-                t.setdefault("shot_id", shot_no)
-                tracks.append(t)
-    else:
-        raise KeyError("No 'shots' key in manifest")
-
-    tracks.sort(key=lambda t: (
-        int(t["shot_id"]),
-        int(t["first_frame"]),
-        int(t.get("last_frame", -1)),
-        str(t.get("face_label") or ""),
-    ))
-    return tracks
-
-# ---- test ------------------------------------------------------------------
 
 @pytest.mark.integration
 def test_resume_anchor_shot_continuity(tmp_path: Path):
     """
     Narrower/faster diagnostic than the full cold-vs-crash-vs-resume equivalence test.
 
-    This test does only:
-      1) crash a run at frame 183
-      2) verify the persisted embedding-safe anchor is 152
-      3) resume from that checkpoint
-      4) inspect only shot-2 track continuity in the resumed output
+    This test:
+      1) crashes a run at frame 183
+      2) verifies the persisted embedding-safe anchor under the current
+         sampled-embedding pipeline configuration
+      3) verifies that TRACKED observations with embeddings were persisted
+      4) resumes from that checkpoint
+      5) inspects only shot-2 continuity in the resumed output
 
-    It is intentionally aimed at the known bad shape where live anchor-shot tracks
-    get split into:
-      - pre-anchor fragments ending near 151/152
-      - fresh tracks beginning at 153
+    With tracked-frame sampling enabled, later sampled TRACKED observations can
+    be embedded and persisted before the crash, advancing the durable boundary
+    deeper into shot 2.
     """
-    video = Path(_repo_root(), "tests", "assets", "videos", "OGsTest_10sec_snippet.mp4")
+    video = _repo_root() / "tests" / "assets" / "videos" / "OGsTest_10sec_snippet.mp4"
     assert video.exists(), "missing test video"
 
     ckpt_parent = tmp_path / "ckpt_parent"
@@ -210,7 +259,7 @@ if __name__ == "__main__":
     ]
 
     print("Running CRASH ----------------------")
-    _ = _run(
+    _run(
         crash_cmd,
         env={**env, "CRASH_AT_FRAME": "183"},
         ok=(0, 1, 2),
@@ -218,27 +267,39 @@ if __name__ == "__main__":
     )
     print("-----------------------------------")
 
-    def _latest_ckpt_dir(parent: Path) -> Path:
-        runs = [d for d in parent.iterdir() if d.is_dir() and d.name.startswith("run-")]
-        assert runs, f"No run-* directory under {parent}"
-
-        def _score(p: Path):
-            s = p / "status.json"
-            return (s.exists(), s.stat().st_mtime if s.exists() else 0, p.stat().st_mtime)
-
-        return max(runs, key=_score)
-
     latest_ckpt_dir = _latest_ckpt_dir(ckpt_parent)
     status_json = latest_ckpt_dir / "status.json"
     assert status_json.exists(), f"Missing {status_json}"
 
     status = _load_json(status_json)
-    assert int(status["last_embedding_safe_frame"]) == 152, (
-        f"status.json embedding-safe-frame drift: expected 152, "
-        f"got {status.get('last_embedding_safe_frame')}"
-    )
-    assert status.get("open_tracks"), f"expected open_tracks at crash anchor, got {status.get('open_tracks')!r}"
+    anchor_frame = int(status["last_embedding_safe_frame"])
 
+    assert anchor_frame == 176, (
+        f"status.json embedding-safe-frame drift: expected 176, got {status.get('last_embedding_safe_frame')}"
+    )
+    assert status.get("open_tracks"), (
+        f"expected open_tracks at crash anchor, got {status.get('open_tracks')!r}"
+    )
+
+    obs_sidecar_path = _resolve_obs_sidecar_path(latest_ckpt_dir, obs_npz)
+    obs_arr = _load_single_array_from_npz(obs_sidecar_path)
+    tracked_code = int(src_to_code(Source.TRACKED.value))
+
+    tracked_embedded_rows = obs_arr[
+        (obs_arr["shot"] == 2)
+        & (obs_arr["src"] == tracked_code)
+        & (obs_arr["emb_idx"].astype(int) >= 0)
+    ]
+    tracked_embedded_frames = sorted(
+        set(int(f) for f in tracked_embedded_rows["f"].astype(int).tolist())
+    )
+
+    assert tracked_embedded_frames, (
+        "Expected at least one persisted TRACKED observation with an embedding in shot 2.\n"
+        f"obs_sidecar_path={obs_sidecar_path}\n"
+        f"tracked_embedded_frames={tracked_embedded_frames}\n"
+        f"anchor_frame={anchor_frame}\n"
+    )
 
     resume_cmd = [
         sys.executable, "-m", "facekit.cli.resolve_face_ids_v2_cli",
@@ -257,7 +318,7 @@ if __name__ == "__main__":
     ]
 
     print("Running RESUME ---------------------")
-    _ = _run(resume_cmd, env=env, log_prefix="diag_resume")
+    _run(resume_cmd, env=env, log_prefix="diag_resume")
     print("-----------------------------------")
 
     resume_js = _load_json(out_resume)
@@ -279,15 +340,31 @@ if __name__ == "__main__":
         (232, 299),
     ]
 
-    fresh_153 = [r for r in shot2 if r[0] == 153]
-    truncated_pre_anchor = [r for r in shot2 if r[1] in (151, 152)]
+    first_resumed_frame = anchor_frame + 1
+    fresh_at_resume_boundary = [r for r in shot2 if r[0] == first_resumed_frame]
+    truncated_at_anchor = [r for r in shot2 if r[1] in (anchor_frame - 1, anchor_frame)]
+
+    assert fresh_at_resume_boundary == [], (
+        "Unexpected fresh shot-2 tracks starting exactly at the first resumed frame.\n"
+        f"anchor_frame={anchor_frame}\n"
+        f"first_resumed_frame={first_resumed_frame}\n"
+        f"fresh_at_resume_boundary={fresh_at_resume_boundary}\n"
+        f"shot2={shot2}\n"
+    )
+
+    assert truncated_at_anchor == [], (
+        "Unexpected shot-2 tracks truncated at the embedding-safe anchor boundary.\n"
+        f"anchor_frame={anchor_frame}\n"
+        f"truncated_at_anchor={truncated_at_anchor}\n"
+        f"shot2={shot2}\n"
+    )
 
     assert shot2 == expected_shot2, (
         "Resumed shot-2 tracks do not match the expected continuity shape.\n"
         f"Expected shot-2 ranges: {expected_shot2}\n"
         f"Actual shot-2 ranges:   {shot2}\n"
-        f"Fresh 153-start ranges: {fresh_153}\n"
-        f"Pre-anchor truncations: {truncated_pre_anchor}\n"
+        f"Fresh at resume-boundary: {fresh_at_resume_boundary}\n"
+        f"Truncated at anchor: {truncated_at_anchor}\n"
         f"Open tracks at crash anchor: {status.get('open_tracks')}\n"
-        f"Resume status anchor: {status.get('last_embedding_safe_frame')}\n"
+        f"Resume status anchor: {anchor_frame}\n"
     )

--- a/tests/integration/test_resume_drawable_bbox_contract.py
+++ b/tests/integration/test_resume_drawable_bbox_contract.py
@@ -1,6 +1,6 @@
 import numpy as np
 from facekit.output.json_v2 import ObservationsCollector
-from facekit.pipeline.resume_rehydrate import rehydrate_observation_tracks
+from facekit.pipeline.resume_rehydrate import reconstruct_tracks_from_observations
 
 
 def test_pre_anchor_tracks_produce_drawable_rects():
@@ -25,7 +25,7 @@ def test_pre_anchor_tracks_produce_drawable_rects():
         emb_idx_fn=lambda _: -1,
     )
 
-    tracks = rehydrate_observation_tracks(
+    tracks = reconstruct_tracks_from_observations(
         oc, frame_max=10, track_order={(1, 2): 0}
     )
     assert tracks

--- a/tests/integration/test_resume_realVideo.py
+++ b/tests/integration/test_resume_realVideo.py
@@ -1,4 +1,3 @@
-# tests/test_resume_equivalence_e2e.py
 import json
 import os
 import re
@@ -132,6 +131,12 @@ def _zip_logs():
             if path.exists():
                 zf.write(path, arcname=path.name)
     print(f"\n[LOG] logs.zip written to: {zip_path}\n")
+
+def _load_single_array_from_npz(path: Path) -> np.ndarray:
+    with np.load(path, allow_pickle=False) as data:
+        if len(data.files) != 1:
+            raise AssertionError(f"expected exactly one array in {path}, found {data.files}")
+        return data[data.files[0]]
 
 # register exit hook
 atexit.register(_zip_logs)
@@ -276,18 +281,36 @@ if __name__ == "__main__":
     assert isinstance(to_list, list) and len(to_list) > 0, "track_order missing/empty in status.json"
 
     status = _load_json(status_json)
-    assert int(status["last_embedding_safe_frame"]) == 152, (
-       f"status.json embedding-safe-frame drift: expected 152, got {status.get('last_embedding_safe_frame')}"
+    anchor_frame = int(status["last_embedding_safe_frame"])
+    assert anchor_frame == 176, (
+        f"status.json embedding-safe-frame drift: expected 176, got {status.get('last_embedding_safe_frame')}"
     )
 
-    # Crash run detections 
-    arr = np.load(obs_npz_path, allow_pickle=False)["observations"]
+    # Crash-run observations sidecar
+    obs_array = _load_single_array_from_npz(obs_npz_path)
+
+    tracked_code = SRC_TO_CODE[Source.TRACKED]
+    tracked_embedded_rows = obs_array[
+        (obs_array["shot"] == 2)
+        & (obs_array["src"] == tracked_code)
+        & (obs_array["emb_idx"].astype(int) >= 0)
+    ]
+    tracked_embedded_frames = sorted(
+        set(int(f) for f in tracked_embedded_rows["f"].astype(int).tolist())
+    )
+    assert tracked_embedded_frames, (
+        "Expected at least one persisted TRACKED observation with an embedding in shot 2.\n"
+        f"tracked_embedded_frames={tracked_embedded_frames}\n"
+        f"anchor_frame={anchor_frame}\n"
+    )
+
+    # Crash run detections
     shot = 1
     det_code = SRC_TO_CODE[Source.DETECTED]
-    is_shot = arr["shot"] == shot
-    is_det  = arr["src"]  == det_code
+    is_shot = obs_array["shot"] == shot
+    is_det  = obs_array["src"]  == det_code
 
-    names = set(arr.dtype.names or [])
+    names = set(obs_array.dtype.names or [])
 
     # Under the current contract, no landmarks are persisted in the obs sidecar.
     forbidden = ("landmarks", "lms", "lm", "landmarks_5pt", "landmarks_flat10")
@@ -303,7 +326,7 @@ if __name__ == "__main__":
     probe_cmd = [
         sys.executable, str(probe),
         "--run-root", str(latest_ckpt_dir),
-        "--anchor", "152",
+        "--anchor", str(anchor_frame),
         "--det-code", str(det_code_int),
     ]
     _ = _run(probe_cmd, env=_env_with_repo(), log_prefix="probe")
@@ -337,7 +360,7 @@ if __name__ == "__main__":
 
     # safe_frame = _extract_anchor_from_logs(resume_log.stdout + "\n" + resume_log.stderr)
     # print(f"Embedding-safe frame for resume run is {safe_frame}")
-    # assert safe_frame == 152, f"unexpected embedding-safe frame parsed: {safe_frame}"
+    # assert safe_frame == 176, f"unexpected embedding-safe frame parsed: {safe_frame}"
 
     # ---- Compare outputs ----
     cold_js   = _load_json(out_cold)
@@ -387,10 +410,6 @@ if __name__ == "__main__":
 
     assert not missing_cold, f"cold: face_metadata missing labels: {sorted(missing_cold)}"
     assert not missing_resume, f"resume: face_metadata missing labels: {sorted(missing_resume)}"
-
-    # Compare track-by-track by identity key (shot, first, last)
-    def _track_identity_key(t: dict) -> tuple[int, int, int]:
-        return (int(t["shot_id"]), int(t["first_frame"]), int(t["last_frame"]))
 
     cold_by_key = {_track_identity_key(t): t for t in cold_tracks}
     resume_by_key = {_track_identity_key(t): t for t in resume_tracks}

--- a/tests/integration/test_resume_rehydrate_integration.py
+++ b/tests/integration/test_resume_rehydrate_integration.py
@@ -129,7 +129,7 @@ def test_resume_invokes_rehydrate_once_with_anchor_minus_one(tmp_path, monkeypat
         emb_idx_fn=lambda _: -1,
     )
 
-    # ---- spy on rehydrate_tracks ----
+    # ---- spy on prepare_tracks_for_resume ----
     called = {"count": 0, "args": None}
 
     def fake_rehydrate(collector, frame_max, **kwargs):
@@ -137,7 +137,7 @@ def test_resume_invokes_rehydrate_once_with_anchor_minus_one(tmp_path, monkeypat
         called["args"] = (collector, int(frame_max), kwargs.get("track_order"))
         return []
 
-    monkeypatch.setattr(resume_rehydrate, "rehydrate_tracks", fake_rehydrate)
+    monkeypatch.setattr(resume_rehydrate, "prepare_tracks_for_resume", fake_rehydrate)
 
     # non-empty track_order required
     monkeypatch.setattr(ckpt, "get_track_order", lambda: {(1, 1): 0})

--- a/tests/integration/test_track_embedding_sampling_real_video.py
+++ b/tests/integration/test_track_embedding_sampling_real_video.py
@@ -1,0 +1,234 @@
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from facekit.common.obs_consts import Source
+from facekit.detection.face_detector import FaceDetector
+from facekit.detection.yolo5face_model import load_yolo5face_model
+from facekit.pipeline.track_across_segments import track_across_segments
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _require_file(path: Path, label: str) -> Path:
+    if not path.exists():
+        pytest.skip(f"Missing {label}: {path}")
+    return path
+
+
+def _write_single_shot_json(video_path: Path, shot_json_path: Path) -> None:
+    import cv2
+
+    cap = cv2.VideoCapture(str(video_path))
+    try:
+        nframes = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    finally:
+        cap.release()
+
+    if nframes <= 0:
+        pytest.skip(f"Could not read frame count from {video_path}")
+
+    payload = {
+        "shots": [
+            {
+                "shot_number": 1,
+                "first_frame": 0,
+                "last_frame": nframes - 1,
+            }
+        ]
+    }
+    shot_json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class RecordingEmbedder:
+    def __init__(self):
+        self.calls = []
+
+    def get_embedding_batch(self, aligned_faces, batch_size=32):
+        self.calls.append(len(aligned_faces))
+        n = len(aligned_faces)
+        return np.zeros((n, 512), dtype=np.float32)
+
+
+@pytest.mark.integration
+def test_tracked_frame_embedding_counts_on_real_video(tmp_path, monkeypatch):
+    """
+    Phase 3 pinned integration test on a real clip.
+
+    With sparse detection cadence and track_sample_interval=2:
+    - DETECTED observations are embedded on every detection frame
+    - TRACKED observations receive propagated landmarks
+    - sampled TRACKED observations are aligned and embedded
+    """
+    repo = _repo_root()
+
+    video = _require_file(
+        repo / "tests" / "assets" / "videos" / "OGsTest_10sec_snippet.mp4",
+        "test video",
+    )
+    detector_weights = _require_file(
+        repo / "models" / "detector" / "yolov5n_state_dict.pt",
+        "detector weights",
+    )
+    detector_cfg = _require_file(
+        repo / "models" / "detector" / "yolov5n.yaml",
+        "detector config",
+    )
+
+    shot_json = tmp_path / "single_shot.json"
+    _write_single_shot_json(video, shot_json)
+
+    device = os.getenv("FACEKIT_DEVICE", "cpu")
+
+    model = load_yolo5face_model(
+        str(detector_weights),
+        str(detector_cfg),
+        device=device,
+    )
+    detector = FaceDetector(model)
+    embedder = RecordingEmbedder()
+
+    import facekit.pipeline.track_across_segments as tas
+
+    align_call_count = {"n": 0}
+
+    def fake_align_face_for_arcface(frame, landmarks, *args, **kwargs):
+        align_call_count["n"] += 1
+        return np.zeros((112, 112, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face_for_arcface)
+
+    tracks = track_across_segments(
+        video,
+        str(shot_json),
+        detector=detector,
+        embedder=embedder,
+        detect_interval=8,
+        track_sample_interval=2,
+        checkpoint=None,
+        resume_enabled=False,
+    )
+
+    detected_total = 0
+    tracked_total = 0
+    detected_with_embedding = 0
+    tracked_with_landmarks = 0
+    tracked_with_embedding = 0
+
+    per_track_summary = []
+
+    for track in tracks:
+        track_detected = 0
+        track_tracked = 0
+        track_tracked_with_landmarks = 0
+        track_tracked_with_embedding = 0
+        track_detected_with_embedding = 0
+
+        for obs in getattr(track, "observations", []) or []:
+            if obs.source == Source.DETECTED:
+                detected_total += 1
+                track_detected += 1
+                if getattr(obs, "embedding", None) is not None:
+                    detected_with_embedding += 1
+                    track_detected_with_embedding += 1
+            elif obs.source == Source.TRACKED:
+                tracked_total += 1
+                track_tracked += 1
+                if getattr(obs, "landmarks", None) is not None:
+                    tracked_with_landmarks += 1
+                    track_tracked_with_landmarks += 1
+                if getattr(obs, "embedding", None) is not None:
+                    tracked_with_embedding += 1
+                    track_tracked_with_embedding += 1
+
+        per_track_summary.append(
+            {
+                "track_id": getattr(track, "track_id", None),
+                "detected": track_detected,
+                "tracked": track_tracked,
+                "tracked_with_landmarks": track_tracked_with_landmarks,
+                "tracked_with_embedding": track_tracked_with_embedding,
+                "detected_with_embedding": track_detected_with_embedding,
+            }
+        )
+
+    assert len(tracks) == 8
+    assert detected_total == 86
+    assert tracked_total == 568
+    assert detected_with_embedding == 86
+    assert tracked_with_landmarks == 568
+    assert tracked_with_embedding == 284
+    assert align_call_count["n"] == 370
+    assert embedder.calls == [370]
+
+    assert per_track_summary == [
+        {
+            "track_id": 0,
+            "detected": 13,
+            "tracked": 90,
+            "tracked_with_landmarks": 90,
+            "tracked_with_embedding": 39,
+            "detected_with_embedding": 13,
+        },
+        {
+            "track_id": 1,
+            "detected": 2,
+            "tracked": 7,
+            "tracked_with_landmarks": 7,
+            "tracked_with_embedding": 4,
+            "detected_with_embedding": 2,
+        },
+        {
+            "track_id": 2,
+            "detected": 26,
+            "tracked": 171,
+            "tracked_with_landmarks": 171,
+            "tracked_with_embedding": 98,
+            "detected_with_embedding": 26,
+        },
+        {
+            "track_id": 3,
+            "detected": 16,
+            "tracked": 105,
+            "tracked_with_landmarks": 105,
+            "tracked_with_embedding": 60,
+            "detected_with_embedding": 16,
+        },
+        {
+            "track_id": 4,
+            "detected": 9,
+            "tracked": 63,
+            "tracked_with_landmarks": 63,
+            "tracked_with_embedding": 27,
+            "detected_with_embedding": 9,
+        },
+        {
+            "track_id": 5,
+            "detected": 1,
+            "tracked": 7,
+            "tracked_with_landmarks": 7,
+            "tracked_with_embedding": 3,
+            "detected_with_embedding": 1,
+        },
+        {
+            "track_id": 6,
+            "detected": 10,
+            "tracked": 66,
+            "tracked_with_landmarks": 66,
+            "tracked_with_embedding": 28,
+            "detected_with_embedding": 10,
+        },
+        {
+            "track_id": 7,
+            "detected": 9,
+            "tracked": 59,
+            "tracked_with_landmarks": 59,
+            "tracked_with_embedding": 25,
+            "detected_with_embedding": 9,
+        },
+    ]

--- a/tests/integration/test_tracking_landmarks_real_video.py
+++ b/tests/integration/test_tracking_landmarks_real_video.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+import cv2
+import pytest
+
+from facekit.common.obs_consts import Source
+from facekit.detection.face_detector import FaceDetector
+from facekit.detection.yolo5face_model import load_yolo5face_model
+from facekit.pipeline.track_across_segments import track_across_segments
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _require_file(path: Path, label: str) -> Path:
+    if not path.exists():
+        pytest.skip(f"Missing {label}: {path}")
+    return path
+
+
+def _write_single_short_shot_json(
+    *,
+    video_path: Path,
+    shot_json_path: Path,
+    max_frames: int = 48,
+) -> None:
+    cap = cv2.VideoCapture(str(video_path))
+    try:
+        nframes = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    finally:
+        cap.release()
+
+    if nframes <= 0:
+        pytest.skip(f"Could not read frame count from {video_path}")
+
+    last_frame = min(nframes, max_frames) - 1
+    if last_frame < 1:
+        pytest.skip(f"Video too short for test: {video_path}")
+
+    payload = {
+        "shots": [
+            {
+                "shot_number": 1,
+                "first_frame": 0,
+                "last_frame": last_frame,
+            }
+        ]
+    }
+    shot_json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class DummyEmbedder:
+    def get_embedding_batch(self, aligned_faces, batch_size=32):
+        import numpy as np
+
+        return np.zeros((len(aligned_faces), 512), dtype=np.float32)
+
+
+@pytest.mark.integration
+def test_tracked_observations_gain_landmarks_on_real_video(tmp_path):
+    """
+    Lean Phase 3 integration test:
+
+    On a real clip with sparse detection cadence, tracking should produce at least
+    one TRACKED observation with propagated landmarks.
+
+    This test is intentionally narrower and faster than the full characterization test.
+    """
+    repo = _repo_root()
+
+    video = _require_file(
+        repo / "tests" / "assets" / "videos" / "OGsTest_10sec_snippet.mp4",
+        "test video",
+    )
+    detector_weights = _require_file(
+        repo / "models" / "detector" / "yolov5n_state_dict.pt",
+        "detector weights",
+    )
+    detector_cfg = _require_file(
+        repo / "models" / "detector" / "yolov5n.yaml",
+        "detector config",
+    )
+
+    shot_json = tmp_path / "short_single_shot.json"
+    _write_single_short_shot_json(
+        video_path=video,
+        shot_json_path=shot_json,
+        max_frames=48,
+    )
+
+    model = load_yolo5face_model(
+        str(detector_weights),
+        str(detector_cfg),
+        device="cpu",
+    )
+    detector = FaceDetector(model)
+    embedder = DummyEmbedder()
+
+    tracks = track_across_segments(
+        video,
+        str(shot_json),
+        detector=detector,
+        embedder=embedder,
+        detect_interval=8,
+        track_sample_interval=2,
+        checkpoint=None,
+        resume_enabled=False,
+    )
+
+    detected_total = 0
+    tracked_total = 0
+    tracked_with_landmarks = 0
+
+    for track in tracks:
+        for obs in getattr(track, "observations", []) or []:
+            if obs.source == Source.DETECTED:
+                detected_total += 1
+            elif obs.source == Source.TRACKED:
+                tracked_total += 1
+                if getattr(obs, "landmarks", None) is not None:
+                    tracked_with_landmarks += 1
+
+    assert detected_total > 0, "Expected at least one DETECTED observation"
+    assert tracked_total > 0, "Expected at least one TRACKED observation"
+    assert tracked_with_landmarks > 0, (
+        "Expected at least one TRACKED observation with propagated landmarks"
+    )

--- a/tests/special/test_cli_e2e_realVideo.py
+++ b/tests/special/test_cli_e2e_realVideo.py
@@ -168,9 +168,9 @@ def test_cli_e2e_realVideo(tmp_path: Path):
     results_dir.mkdir(parents=True, exist_ok=True)
 
     # video_name = "53-man-roster-decisions"
-    # video_name = "hot-to-go"
+    video_name = "hot-to-go"
     # video_name = "OGsTest_10sec_snippet"
-    video_name = "3fiUUxKMiBGn6kF4Puczvi"
+    # video_name = "3fiUUxKMiBGn6kF4Puczvi"
 
     print(f"Video: {video_name}")
 
@@ -201,6 +201,8 @@ def test_cli_e2e_realVideo(tmp_path: Path):
         "--input", str(input_video),
         "--checkpoint-dir", str(ckpt_parent),
         "--detect-interval", "10",
+        "--track-sample-interval", "5",
+        "--min-face", "10",
         "--device", "cpu",
         "--schema-version", "2.1",
         "--emb-store", "sidecar",
@@ -209,8 +211,8 @@ def test_cli_e2e_realVideo(tmp_path: Path):
         "--output-global-json", str(out_cold),
         "--output-video", str(out_video),
         "--no-resume",                    # ensure fresh run
-        "--new-run",
-        # "--no-checkpoint-write", 
+        # "--new-run",  # incompatible with --no-checkpoint-write
+        "--no-checkpoint-write", # incompatible with --new-run
         "--log", "INFO",
     ]
     print("Running COLD ----------------------")

--- a/tests/special/test_track_embedding_sampling_real_video_characterization.py
+++ b/tests/special/test_track_embedding_sampling_real_video_characterization.py
@@ -1,0 +1,176 @@
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from facekit.common.obs_consts import Source
+from facekit.detection.face_detector import FaceDetector
+from facekit.detection.yolo5face_model import load_yolo5face_model
+from facekit.pipeline.track_across_segments import track_across_segments
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _require_file(path: Path, label: str) -> Path:
+    if not path.exists():
+        pytest.skip(f"Missing {label}: {path}")
+    return path
+
+
+def _write_single_shot_json(video_path: Path, shot_json_path: Path) -> None:
+    import cv2
+
+    cap = cv2.VideoCapture(str(video_path))
+    try:
+        nframes = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    finally:
+        cap.release()
+
+    if nframes <= 0:
+        pytest.skip(f"Could not read frame count from {video_path}")
+
+    payload = {
+        "shots": [
+            {
+                "shot_number": 1,
+                "first_frame": 0,
+                "last_frame": nframes - 1,
+            }
+        ]
+    }
+    shot_json_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class RecordingEmbedder:
+    def __init__(self):
+        self.calls = []
+
+    def get_embedding_batch(self, aligned_faces, batch_size=32):
+        self.calls.append(len(aligned_faces))
+        n = len(aligned_faces)
+        return np.zeros((n, 512), dtype=np.float32)
+
+
+@pytest.mark.integration
+def test_characterize_tracked_frame_embedding_counts_on_real_video(tmp_path, monkeypatch):
+    """
+    Characterization test for Phase 3 on a real clip.
+
+    This intentionally fails and reports the exact counts you should pin in the
+    real integration test after one local run.
+    """
+    repo = _repo_root()
+
+    # These may need to be adjusted to match the exact paths used in your repo.
+    video = _require_file(
+        repo / "tests" / "assets" / "videos" / "OGsTest_10sec_snippet.mp4",
+        "test video",
+    )
+    detector_weights = _require_file(
+        repo / "models" / "detector" / "yolov5n_state_dict.pt",
+        "detector weights",
+    )
+    detector_cfg = _require_file(
+        repo / "models" / "detector" / "yolov5n.yaml",
+        "detector config",
+    )
+
+    shot_json = tmp_path / "single_shot.json"
+    _write_single_shot_json(video, shot_json)
+
+    device = os.getenv("FACEKIT_DEVICE", "cpu")
+
+    model = load_yolo5face_model(
+        str(detector_weights),
+        str(detector_cfg),
+        device=device,
+    )
+    detector = FaceDetector(model)
+    embedder = RecordingEmbedder()
+
+    # Patch alignment to always succeed when landmarks are present.
+    # This isolates the Phase 3 tracked-frame sampling path.
+    import facekit.pipeline.track_across_segments as tas
+
+    align_call_count = {"n": 0}
+
+    def fake_align_face_for_arcface(frame, landmarks, *args, **kwargs):
+        align_call_count["n"] += 1
+        return np.zeros((112, 112, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face_for_arcface)
+
+    tracks = track_across_segments(
+        video,
+        str(shot_json),
+        detector=detector,
+        embedder=embedder,
+        detect_interval=8,
+        track_sample_interval=2,
+        checkpoint=None,
+        resume_enabled=False,
+    )
+
+    detected_total = 0
+    tracked_total = 0
+    detected_with_embedding = 0
+    tracked_with_landmarks = 0
+    tracked_with_embedding = 0
+
+    per_track_summary = []
+
+    for track in tracks:
+        track_detected = 0
+        track_tracked = 0
+        track_tracked_with_landmarks = 0
+        track_tracked_with_embedding = 0
+        track_detected_with_embedding = 0
+
+        for obs in getattr(track, "observations", []) or []:
+            if obs.source == Source.DETECTED:
+                detected_total += 1
+                track_detected += 1
+                if getattr(obs, "embedding", None) is not None:
+                    detected_with_embedding += 1
+                    track_detected_with_embedding += 1
+            elif obs.source == Source.TRACKED:
+                tracked_total += 1
+                track_tracked += 1
+                if getattr(obs, "landmarks", None) is not None:
+                    tracked_with_landmarks += 1
+                    track_tracked_with_landmarks += 1
+                if getattr(obs, "embedding", None) is not None:
+                    tracked_with_embedding += 1
+                    track_tracked_with_embedding += 1
+
+        per_track_summary.append(
+            {
+                "track_id": getattr(track, "track_id", None),
+                "detected": track_detected,
+                "tracked": track_tracked,
+                "tracked_with_landmarks": track_tracked_with_landmarks,
+                "tracked_with_embedding": track_tracked_with_embedding,
+                "detected_with_embedding": track_detected_with_embedding,
+            }
+        )
+
+    summary = {
+        "num_tracks": len(tracks),
+        "detected_total": detected_total,
+        "tracked_total": tracked_total,
+        "detected_with_embedding": detected_with_embedding,
+        "tracked_with_landmarks": tracked_with_landmarks,
+        "tracked_with_embedding": tracked_with_embedding,
+        "align_call_count": align_call_count["n"],
+        "embedder_batch_sizes": embedder.calls,
+        "per_track_summary": per_track_summary,
+    }
+
+    pytest.fail(
+        "Characterization counts for pinning Phase 3 integration assertions:\n"
+        + json.dumps(summary, indent=2, sort_keys=True)
+    )

--- a/tests/test_face_track_representative_embeddings.py
+++ b/tests/test_face_track_representative_embeddings.py
@@ -1,0 +1,220 @@
+import numpy as np
+
+from facekit.common.obs_consts import Source
+from facekit.embedding.embedding_selection import TrackEmbeddingSample
+from facekit.tracking.face_structures import FaceTrack
+
+def _norm(v):
+    arr = np.asarray(v, dtype=np.float32)
+    n = float(np.linalg.norm(arr))
+    if n == 0.0:
+        raise ValueError("zero vector not allowed in test")
+    return arr / n
+
+def _emb(seed: int) -> np.ndarray:
+    v = np.zeros(512, dtype=np.float32)
+    v[seed] = 1.0
+    return v
+
+def _sample(
+    frame_idx: int,
+    emb: np.array,
+    *,
+    track_local_index: int | None = None,
+    source=Source.TRACKED,
+) -> TrackEmbeddingSample:
+    if track_local_index is None:
+        track_local_index = frame_idx
+    return TrackEmbeddingSample(
+        frame_idx=int(frame_idx),
+        track_local_index=int(track_local_index),
+        source=source,
+        embedding=None if emb is None else _norm(emb),
+        quality_score=None,
+    )
+
+def _mean_embedding(samples):
+    return np.mean(
+        np.stack([s.embedding for s in samples if s.embedding is not None]),
+        axis=0,
+    )
+
+def test_finalize_embedding_representation_selects_subset_and_computes_representative_embedding():
+    """
+    Finalization should retain a consistent subset of samples and compute the
+    representative embedding from the retained subset.
+    """
+    track = FaceTrack(shot_id=1, track_id=7)
+    track.embedding_samples = [
+        _sample(10, [1.00, 0.00, 0.00], source=Source.DETECTED),
+        _sample(20, [0.99, 0.01, 0.00], source=Source.TRACKED),
+        _sample(30, [0.98, 0.02, 0.00], source=Source.TRACKED),
+        _sample(40, [0.97, 0.03, 0.00], source=Source.TRACKED),
+        _sample(50, [0.00, 1.00, 0.00], source=Source.TRACKED),  # outlier
+    ]
+
+    track.finalize_embedding_representation()
+
+    assert [s.frame_idx for s in track.selected_embedding_samples] == [10, 20, 30, 40]
+    assert np.allclose(
+        track.representative_embedding,
+        _mean_embedding(track.selected_embedding_samples),
+    )
+    assert track.embedding_stable is True
+
+
+def test_finalize_embedding_representation_preserves_selected_sample_metadata():
+    """
+    Selected samples should retain the metadata needed for later auditing and
+    debugging.
+    """
+    track = FaceTrack(shot_id=2, track_id=9)
+    track.embedding_samples = [
+        _sample(100, [1.00, 0.00, 0.00], track_local_index=0, source=Source.DETECTED),
+        _sample(110, [0.99, 0.01, 0.00], track_local_index=10, source=Source.TRACKED),
+        _sample(120, [0.98, 0.02, 0.00], track_local_index=20, source=Source.TRACKED),
+        _sample(130, [0.00, 1.00, 0.00], track_local_index=30, source=Source.TRACKED),
+    ]
+
+    track.finalize_embedding_representation()
+
+    assert [
+        (s.frame_idx, s.track_local_index, s.source)
+        for s in track.selected_embedding_samples
+    ] == [
+        (100, 0, Source.DETECTED),
+        (110, 10, Source.TRACKED),
+        (120, 20, Source.TRACKED),
+    ]
+
+
+def test_finalize_embedding_representation_marks_track_unstable_when_no_valid_embeddings():
+    """
+    A track with no usable embeddings should not crash finalization, should not
+    invent a representative embedding, and should be marked unstable.
+    """
+    track = FaceTrack(shot_id=3, track_id=11)
+    track.embedding_samples = [
+        _sample(10, None, track_local_index=0, source=Source.DETECTED),
+        _sample(20, None, track_local_index=10, source=Source.TRACKED),
+    ]
+
+    track.finalize_embedding_representation()
+
+    assert track.selected_embedding_samples == []
+    assert track.representative_embedding is None
+    assert track.embedding_stable is False
+
+
+def test_finalize_embedding_representation_uses_selected_subset_not_all_samples():
+    """
+    The representative embedding should be computed from the retained subset,
+    not from all original samples.
+    """
+    track = FaceTrack(shot_id=4, track_id=13)
+
+    inliers = [
+        _sample(10, [1.00, 0.00, 0.00], source=Source.DETECTED),
+        _sample(20, [0.99, 0.01, 0.00], source=Source.TRACKED),
+        _sample(30, [0.98, 0.02, 0.00], source=Source.TRACKED),
+    ]
+    outlier = _sample(40, [0.00, 1.00, 0.00], source=Source.TRACKED)
+
+    track.embedding_samples = inliers + [outlier]
+
+    track.finalize_embedding_representation()
+
+    expected_from_selected = _mean_embedding(track.selected_embedding_samples)
+    expected_from_all = _mean_embedding(track.embedding_samples)
+
+    assert np.allclose(track.representative_embedding, expected_from_selected)
+    assert not np.allclose(track.representative_embedding, expected_from_all)
+
+def test_finalize_embedding_representation_is_deterministic_across_resume_boundary():
+    """
+    A track finalized after a resume-style split should produce the same selected
+    sample frames and representative embedding as a cold run over the same logical
+    samples.
+    """
+    cold_track = FaceTrack(shot_id=1, track_id=1)
+    resumed_track = FaceTrack(shot_id=1, track_id=1)
+
+    all_samples = [
+        _sample(100, _emb(0), track_local_index=0, source=Source.DETECTED),
+        _sample(110, _emb(1), track_local_index=10, source=Source.TRACKED,),
+        _sample(120, _emb(2), track_local_index=20, source=Source.TRACKED,),
+        _sample(130, _emb(3), track_local_index=30, source=Source.TRACKED,),
+    ]
+
+    # Cold run: all samples arrive in one uninterrupted pass.
+    for s in all_samples:
+        cold_track.add_embedding_sample(s)
+
+    # Resume-style run: pre-boundary samples exist first, then post-boundary samples
+    # are attached later after resume.
+    for s in all_samples[:2]:
+        resumed_track.add_embedding_sample(s)
+    for s in all_samples[2:]:
+        resumed_track.add_embedding_sample(s)
+
+    cold_track.finalize_embedding_representation()
+    resumed_track.finalize_embedding_representation()
+
+    assert [s.frame_idx for s in cold_track.selected_embedding_samples] == [
+        s.frame_idx for s in resumed_track.selected_embedding_samples
+    ]
+    assert [s.track_local_index for s in cold_track.selected_embedding_samples] == [
+        s.track_local_index for s in resumed_track.selected_embedding_samples
+    ]
+    assert np.allclose(
+        cold_track.representative_embedding,
+        resumed_track.representative_embedding,
+    )
+    assert cold_track.embedding_stable is True
+    assert resumed_track.embedding_stable is True
+
+def test_finalize_embedding_representation_is_stable_when_pre_boundary_samples_are_not_duplicated():
+    """
+    Re-attaching pre-boundary samples should not change the selected sample set
+    or representative embedding for the logical track.
+    """
+    cold_track = FaceTrack(shot_id=1, track_id=1)
+    resumed_track = FaceTrack(shot_id=1, track_id=1)
+
+    all_samples = [
+        _sample(100, [1.00, 0.00, 0.00], track_local_index=0, source=Source.DETECTED),
+        _sample(110, [0.99, 0.01, 0.00], track_local_index=10, source=Source.TRACKED),
+        _sample(120, [0.98, 0.02, 0.00], track_local_index=20, source=Source.TRACKED),
+        _sample(130, [0.97, 0.03, 0.00], track_local_index=30, source=Source.TRACKED),
+    ]
+
+    # Cold run: one uninterrupted pass.
+    for s in all_samples:
+        cold_track.add_embedding_sample(s)
+
+    # Resume-style bug: pre-boundary samples get attached twice.
+    for s in all_samples[:2]:
+        resumed_track.add_embedding_sample(s)
+    for s in all_samples[:2]:
+        resumed_track.add_embedding_sample(s)
+    for s in all_samples[2:]:
+        resumed_track.add_embedding_sample(s)
+
+    cold_track.finalize_embedding_representation()
+    resumed_track.finalize_embedding_representation()
+
+    assert [s.frame_idx for s in cold_track.selected_embedding_samples] == [
+        s.frame_idx for s in resumed_track.selected_embedding_samples
+    ]
+    assert [s.track_local_index for s in cold_track.selected_embedding_samples] == [
+        s.track_local_index for s in resumed_track.selected_embedding_samples
+    ]
+    assert [s.source for s in cold_track.selected_embedding_samples] == [
+        s.source for s in resumed_track.selected_embedding_samples
+    ]
+    assert np.allclose(
+        cold_track.representative_embedding,
+        resumed_track.representative_embedding,
+    )
+    assert cold_track.embedding_stable is True
+    assert resumed_track.embedding_stable is True

--- a/tests/test_global_id_resolution.py
+++ b/tests/test_global_id_resolution.py
@@ -247,3 +247,48 @@ def test_resolver_raises_when_cuda_requested_but_unavailable(monkeypatch):
     monkeypatch.setattr(torch, "cuda", type("X", (), {"is_available": lambda: False}))
     with pytest.raises(RuntimeError):
         GlobalIdentityResolver(device="cuda")
+
+def test_identity_resolution_prefers_track_representative_embedding():
+    """
+    Identity resolution should prefer a track's representative_embedding when
+    that embedding is marked as stable.
+
+    Tracks may contain multiple observation embeddings collected during
+    processing. Once a representative_embedding has been finalized for a track,
+    it becomes the canonical identity signal for that track.
+
+    This test constructs a situation where:
+
+      • observation embeddings would NOT cause the tracks to match
+      • representative embeddings WOULD cause the tracks to match
+
+    The resolver should therefore merge the tracks based on the
+    representative embeddings.
+    """
+
+    resolver = GlobalIdentityResolver(embedding_threshold=0.95)
+
+    rep = make_vector(angle_rad=0.0, seed=100)
+
+    obs_a = make_vector(angle_rad=0.60, seed=101)
+    obs_b = make_vector(angle_rad=1.20, seed=102)
+
+    t0 = make_track_with_frames(0, obs_a, shot_id=0, start=0, end=20)
+    t1 = make_track_with_frames(1, obs_b, shot_id=1, start=0, end=20)
+
+    # Canonical identity signal for each track
+    t0.representative_embedding = rep.copy()
+    t1.representative_embedding = rep.copy()
+
+    t0.embedding_stable = True
+    t1.embedding_stable = True
+
+    # Observation embeddings disagree with the representative identity
+    t0.embeddings = [obs_a.astype(np.float32)]
+    t1.embeddings = [obs_b.astype(np.float32)]
+
+    resolver.resolve_global_ids([t0, t1], start_id=0)
+
+    assert (
+        t0.global_id == t1.global_id
+    ), "Stable representative embeddings should drive identity matching"

--- a/tests/test_resume_anchor_persistence.py
+++ b/tests/test_resume_anchor_persistence.py
@@ -317,7 +317,7 @@ def test_resume_starts_at_anchor_and_never_persists_preanchor(tmp_path: Path, mo
     # run with ckpt.write_disabled=True (no filesystem durability contract in this test).
     #
     # To keep this test focused and deterministic, bypass pre-anchor rehydration.
-    monkeypatch.setattr(_rr, "rehydrate_tracks", lambda *a, **k: [])
+    monkeypatch.setattr(_rr, "prepare_tracks_for_resume", lambda *a, **k: [])
 
     fp = SpyFP(total=400)
     _ = track_across_segments(

--- a/tests/test_resume_one_then_three_faces_consistency.py
+++ b/tests/test_resume_one_then_three_faces_consistency.py
@@ -519,6 +519,7 @@ def test_resume_three_phase_isolated(tmp_path: Path):
     emb_count_pre = int(emb_pre.shape[0])
 
     DET_CODE = int(src_to_code(Source.DETECTED.value))
+    TRK_CODE = int(src_to_code(Source.TRACKED.value))
 
     # Shot 1 is completed by anchor, so all its DETECTED rows must have embeddings.
     shot1_det = obs_pre[(obs_pre["shot"] == 1) & (obs_pre["src"] == DET_CODE)]
@@ -571,10 +572,15 @@ def test_resume_three_phase_isolated(tmp_path: Path):
     # - Frame 130 observations exist, but their embeddings are not yet persisted/linked.
 
     # Absolute persisted-embedding count pre-crash:
-    # - shot 1: 11 faces persisted (7 at frame 60 + 4 at shot boundary)
-    # - shot 2 through frame 120: 9 faces persisted (3 @ 103, 3 @ 110, 3 @ 120)
-    # Total = 20
-    assert emb_count_pre == 20, f"expected 20 persisted embeddings pre-crash, got {emb_count_pre}"
+    # - shot 1: 11 DET faces persisted (7 at frame 60 + 4 at shot boundary)
+    # - shot 2 DET through frame 120: 9 persisted (3 @ 103, 3 @ 110, 3 @ 120)
+    # - shot 2 TRACKED sampling is enabled by default (track_sample_interval=10):
+    #     * frame 113 is track-local index 10 relative to shot-start detection at 103
+    #     * therefore the 3 tracked observations at frame 113 are sampled for embedding
+    #     * they remain pending until the next detection flush boundary at frame 120
+    #     * thus they are persisted pre-crash as well
+    # Total = 11 + 9 + 3 = 23
+    assert emb_count_pre == 23, f"expected 23 persisted embeddings pre-crash, got {emb_count_pre}"
 
     shot2_det = obs_pre[(obs_pre["shot"] == 2) & (obs_pre["src"] == DET_CODE)]
     shot2_det_frames = sorted(set(int(f) for f in shot2_det["f"].astype(int).tolist()))
@@ -612,6 +618,25 @@ def test_resume_three_phase_isolated(tmp_path: Path):
         f"got {shot2_det_unsafe.shape[0]}"
     )
 
+    shot2_trk = obs_pre[(obs_pre["shot"] == 2) & (obs_pre["src"] == TRK_CODE)]
+
+    shot2_trk_safe = shot2_trk[shot2_trk["emb_idx"].astype(int) >= 0]
+    shot2_trk_unsafe = shot2_trk[shot2_trk["emb_idx"].astype(int) < 0]
+
+    shot2_trk_safe_frames = sorted(set(int(f) for f in shot2_trk_safe["f"].astype(int).tolist()))
+
+    assert shot2_trk_safe_frames == [113], (
+        "unexpected embedding-safe TRACKED frames for shot 2 before crash; "
+        "with track_sample_interval=10, only frame 113 should have persisted TRACKED embeddings "
+        "before the crash boundary at 134.\n"
+        f"got {shot2_trk_safe_frames}"
+    )
+
+    assert shot2_trk_safe.shape[0] == 3, (
+        f"expected 3 embedding-safe TRACKED rows for shot 2 pre-crash "
+        f"(3 faces x frame 113), got {shot2_trk_safe.shape[0]}"
+    )
+
     # emb_idx should reference valid embedding rows.
     max_idx = int(emb_idx.max()) if emb_idx.size else -1
     assert max_idx == 10, f"expected max emb_idx 10 for shot1 (0-based, 11 rows), got {max_idx}"
@@ -621,13 +646,17 @@ def test_resume_three_phase_isolated(tmp_path: Path):
     )
 
     # Across both shots, pre-crash persisted embeddings should cover:
-    # - shot 1 frames 0..100 inclusive on the 10-frame cadence (11 embeddings total)
-    # - shot 2 frames 103, 110, 120 with 3 faces each (9 embeddings total)
+    # - shot 1 DET frames 0..100 inclusive on the 10-frame cadence (11 embeddings total)
+    # - shot 2 DET frames 103, 110, 120 with 3 faces each (9 embeddings total)
+    # - shot 2 TRACKED sampled frame 113 with 3 faces (3 embeddings total)
     # This also documents why the pre-crash anchor is 120 rather than 130, and why Shot 1's
     # final embedding payload frame (100) differs from its shot-end embedding-safe frame (102).
-    shot2_max_idx = int(shot2_det["emb_idx"].astype(int).max()) if shot2_det.size else -1
-    assert shot2_max_idx == 19, (
-        f"expected last pre-crash embedding index to be 19, got {shot2_max_idx}"
+    shot2_max_idx = max(
+        int(shot2_det["emb_idx"].astype(int).max()) if shot2_det.size else -1,
+        int(shot2_trk["emb_idx"].astype(int).max()) if shot2_trk.size else -1,
+    )
+    assert shot2_max_idx == 22, (
+        f"expected last pre-crash embedding index to be 22, got {shot2_max_idx}"
     )
 
     # ---- C) Resume run (must use the crash-run sidecars) ----

--- a/tests/test_resume_rehydrate.py
+++ b/tests/test_resume_rehydrate.py
@@ -2,8 +2,7 @@ import numpy as np
 import pytest
 from facekit.output.json_v2 import ObservationsCollector
 from facekit.common.obs_consts import Source
-from facekit.pipeline.resume_rehydrate import rehydrate_observation_tracks
-
+from facekit.pipeline.resume_rehydrate import reconstruct_tracks_from_observations, prepare_tracks_for_resume
 
 def _rows(*items):
     return list(items)
@@ -21,7 +20,7 @@ def test_rehydrate_sanitizes_and_filters_bad_rows():
         {"shot":1,"track_id":7,"f":8,"bbox_xyxy":[5.0,5.0,5.0,10.0],"src":Source.TRACKED},
     ), emb_idx_fn=lambda _: -1)
 
-    tracks = rehydrate_observation_tracks(
+    tracks = reconstruct_tracks_from_observations(
         oc, frame_max=100, track_order={(1, 7): 0}
     )
     assert len(tracks) == 1
@@ -35,11 +34,82 @@ def test_rehydrate_sanitizes_and_filters_bad_rows():
         assert all(isinstance(v, int) for v in (x1,y1,x2,y2))
         assert x2 > x1 and y2 > y1
 
-
 def test_append_track_obs_allows_detected_without_landmarks():
     oc = ObservationsCollector()
     # Detected rows may omit landmarks under the current contract (no persisted landmarks).
     oc.append_track_obs(
         [{"shot":1,"track_id":1,"f":1,"bbox_xyxy":[0,0,10,10],"src":Source.DETECTED}],
         emb_idx_fn=lambda _: -1
+    )
+
+def test_rehydrate_tracks_rebuilds_track_level_identity_embedding():
+    """
+    Rehydration should restore usable track-level identity state for any track
+    that has durable pre-anchor DET embeddings.
+
+    This is the state that global identity resolution now prefers when present.
+    A resumed run should therefore not stop at merely repopulating track.embeddings;
+    it should also provide a representative_embedding and mark it stable.
+    """
+    collector = ObservationsCollector()
+
+    collector.append_track_obs(
+        [
+            {
+                "shot": 1,
+                "track_id": 7,
+                "f": 100,
+                "bbox_xyxy": [0.0, 0.0, 10.0, 10.0],
+                "src": Source.DETECTED,
+                "conf": 0.9,
+            },
+            {
+                "shot": 1,
+                "track_id": 7,
+                "f": 108,
+                "bbox_xyxy": [1.0, 1.0, 11.0, 11.0],
+                "src": Source.DETECTED,
+                "conf": 0.95,
+            },
+        ],
+        emb_idx_fn=lambda _: -1,
+    )
+
+    emb0 = np.zeros((512,), dtype=np.float32)
+    emb0[0] = 1.0
+
+    emb1 = np.zeros((512,), dtype=np.float32)
+    emb1[0] = 1.0
+
+    def emb_lookup(shot: int, track_id: int):
+        if (shot, track_id) != (1, 7):
+            return None
+        return [100, 108], np.stack([emb0, emb1], axis=0)
+
+    tracks = prepare_tracks_for_resume(
+        collector,
+        frame_max=200,
+        track_order={(1, 7): 0},
+        emb_lookup=emb_lookup,
+        emb_array_lookup=None,
+        anchor_shot_id=2,   # shot 1 is treated as completed/pre-anchor
+        strict=True,
+    )
+
+    assert len(tracks) == 1
+    track = tracks[0]
+
+    # Sanity: embeddings were attached at the observation/track level.
+    assert len(track.embeddings) == 2
+    assert track.has_embedding()
+
+    # Critical resume contract for identity resolution:
+    assert track.embedding_stable is True
+    assert track.representative_embedding is not None
+
+    expected = np.mean(np.stack([emb0, emb1], axis=0), axis=0)
+    np.testing.assert_allclose(
+        track.representative_embedding,
+        expected,
+        atol=1e-6,
     )

--- a/tests/test_resume_rehydrate_anchor_boundary.py
+++ b/tests/test_resume_rehydrate_anchor_boundary.py
@@ -111,7 +111,7 @@ def test_build_resume_plan_keeps_only_anchor_open_tracks_live(monkeypatch):
     )
     monkeypatch.setattr(
         rr,
-        "rehydrate_tracks",
+        "prepare_tracks_for_resume",
         lambda *a, **k: list(rehydrated_tracks),
     )
 
@@ -121,7 +121,7 @@ def test_build_resume_plan_keeps_only_anchor_open_tracks_live(monkeypatch):
         assert int(resume_frame) == 152
         prepared_tids.extend(int(t.track_id) for t in tracks)
 
-    monkeypatch.setattr(rr, "_prepare_tracks_for_resume_runtime", _fake_prepare)
+    monkeypatch.setattr(rr, "_prepare_runtime_state_for_resume", _fake_prepare)
 
     all_tracks: list[FaceTrack] = []
     plan, shots_trimmed = rr._build_resume_plan(
@@ -283,7 +283,7 @@ class _FakeCheckpoint:
 def test_build_resume_plan_partitions_anchor_tracks_without_monkeypatching_prepare(monkeypatch):
     """
     Stronger boundary test:
-    - let the real _prepare_tracks_for_resume_runtime() run
+    - let the real _prepare_runtime_state_for_resume() run
     - verify dead-by-anchor track does NOT remain in prior_tracks_anchor
     - verify live-at-anchor tracks DO remain and are normalized for runtime use
     """
@@ -324,7 +324,7 @@ def test_build_resume_plan_partitions_anchor_tracks_without_monkeypatching_prepa
     )
     monkeypatch.setattr(
         rr,
-        "rehydrate_tracks",
+        "prepare_tracks_for_resume",
         lambda *a, **k: list(rehydrated_tracks),
     )
 
@@ -353,7 +353,7 @@ def test_build_resume_plan_partitions_anchor_tracks_without_monkeypatching_prepa
     assert 0 not in live_tids
 
     # The live anchor tracks should have been normalized by the *real*
-    # _prepare_tracks_for_resume_runtime().
+    # _prepare_runtime_state_for_resume().
     by_tid = {int(t.track_id): t for t in plan.prior_tracks_anchor}
 
     assert getattr(by_tid[1], "is_active", None) is False
@@ -783,7 +783,7 @@ def test_build_resume_plan_midshot_keeps_live_anchor_tracks_unlabeled(monkeypatc
     monkeypatch.setattr(rr, "_resolve_anchor", lambda checkpoint, resume_enabled: 152)
     monkeypatch.setattr(rr, "_audit_preanchor_embedding_parity", lambda *a, **k: None)
     monkeypatch.setattr(rr, "_build_emb_lookups_for_checkpoint", lambda *a, **k: (None, None))
-    monkeypatch.setattr(rr, "rehydrate_tracks", lambda *a, **k: list(rehydrated))
+    monkeypatch.setattr(rr, "prepare_tracks_for_resume", lambda *a, **k: list(rehydrated))
 
     plan, trimmed_shots = rr._build_resume_plan(
         shots,

--- a/tests/test_track_embedding_sample_attachment.py
+++ b/tests/test_track_embedding_sample_attachment.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from facekit.tracking.face_structures import FaceTrack, FaceObservation
+from facekit.common.obs_consts import Source
+from facekit.pipeline.track_across_segments import _attach_and_persist_embedded_obs
+from facekit.tracking.aggregator import ShotFaceTrackAggregator
+
+def _emb(seed: int) -> np.ndarray:
+    v = np.zeros(512, dtype=np.float32)
+    v[seed] = 1.0
+    return v
+
+def _obs(frame_idx, embedding, source, track_id):
+    return FaceObservation(
+        frame_idx=frame_idx,
+        bbox=(0, 0, 10, 10),
+        track_id=track_id,
+        source=source,
+        embedding=np.asarray(embedding, dtype=np.float32),
+    )
+
+def test_attach_embeddings_registers_track_embedding_samples():
+    """
+    Embedded observations that already belong to a track should register
+    TrackEmbeddingSample metadata on that track.
+    """
+
+    aggregator = ShotFaceTrackAggregator(shot_number=1)
+
+    track = FaceTrack(shot_id=1, track_id=1)
+    track.observations = [
+        _obs(10, _emb(0), Source.DETECTED, track_id=1),
+        _obs(20, _emb(1), Source.TRACKED, track_id=1),
+    ]
+
+    aggregator.tracks.append(track)
+
+    embedded_obs = [
+        track.observations[0],
+        track.observations[1],
+    ]
+
+    _attach_and_persist_embedded_obs(
+        embedded_obs=embedded_obs,
+        aggregator=aggregator,
+        checkpoint=None,
+        shot_number=1,
+        shot_first_frame=0,
+    )
+
+    assert len(track.embedding_samples) == 2
+
+    frames = [s.frame_idx for s in track.embedding_samples]
+    assert frames == [10, 20]
+
+    indices = [s.track_local_index for s in track.embedding_samples]
+    assert indices == [0, 1]

--- a/tests/test_track_embedding_sampling.py
+++ b/tests/test_track_embedding_sampling.py
@@ -1,0 +1,53 @@
+import pytest
+
+from facekit.embedding.embedding_sampling import (
+    should_sample_track_observation,
+)
+
+
+def test_first_frame_of_track_is_always_sampled():
+    assert should_sample_track_observation(
+        track_local_index=0,
+        is_detection_frame=True,
+        track_sample_interval=5,
+    )
+
+
+def test_detection_frame_is_always_sampled_regardless_of_track_sample_interval():
+    assert should_sample_track_observation(
+        track_local_index=7,
+        is_detection_frame=True,
+        track_sample_interval=100,
+    )
+
+
+def test_track_sample_interval_uses_track_local_frame_index():
+    interval = 5
+
+    assert should_sample_track_observation(
+        track_local_index=5,
+        is_detection_frame=False,
+        track_sample_interval=interval,
+    )
+
+    assert should_sample_track_observation(
+        track_local_index=10,
+        is_detection_frame=False,
+        track_sample_interval=interval,
+    )
+
+
+def test_non_detection_non_interval_frame_is_not_sampled():
+    assert not should_sample_track_observation(
+        track_local_index=3,
+        is_detection_frame=False,
+        track_sample_interval=5,
+    )
+
+
+def test_detection_frame_sampling_is_not_blocked_by_interval_logic():
+    assert should_sample_track_observation(
+        track_local_index=3,
+        is_detection_frame=True,
+        track_sample_interval=5,
+    )

--- a/tests/test_track_embedding_sampling_enqueue.py
+++ b/tests/test_track_embedding_sampling_enqueue.py
@@ -1,0 +1,438 @@
+import numpy as np
+
+from facekit.common.obs_consts import Source
+from facekit.pipeline import track_across_segments as tas
+from facekit.tracking.face_structures import FaceObservation
+
+
+class DummyTrack:
+    def __init__(self, track_id, observations):
+        self.track_id = track_id
+        self.observations = observations
+        self.shot_id = 1
+
+
+class DummyAggregator:
+    def __init__(self, tracks, observations_for_frame):
+        self.tracks = tracks
+        self._observations_for_frame = observations_for_frame
+
+    def observations_at(self, frame_idx, require_track_id=True):
+        assert frame_idx == 42
+        return self._observations_for_frame
+
+
+class DummyQueue:
+    def __init__(self):
+        self.pending = []
+
+    def enqueue(self, item):
+        self.pending.append(item)
+
+
+def make_obs(*, frame_idx, track_id, bbox, source, landmarks=None, aligned_face=None):
+    return FaceObservation(
+        frame_idx=frame_idx,
+        track_id=track_id,
+        bbox=bbox,
+        embedding=None,
+        confidence=None,
+        aligned_face=aligned_face,
+        landmarks=landmarks,
+        source=source,
+    )
+
+
+def test_enqueue_tracked_observation_when_sampling_interval_hits(monkeypatch):
+    prev_obs = make_obs(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        source=Source.TRACKED,
+        landmarks=np.array(
+            [
+                [120.0, 80.0],
+                [180.0, 80.0],
+                [150.0, 105.0],
+                [130.0, 130.0],
+                [170.0, 130.0],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    tracked_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.TRACKED,
+        landmarks=np.array(
+            [
+                [132.0, 98.0],
+                [192.0, 98.0],
+                [162.0, 123.0],
+                [142.0, 148.0],
+                [182.0, 148.0],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+    track = DummyTrack(track_id=7, observations=[prev_obs, tracked_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[tracked_obs])
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    aligned_face = np.ones((112, 112, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        assert frame_bgr is frame
+        assert landmarks is tracked_obs.landmarks
+        return aligned_face
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=1,
+        embedding_queue=queue,
+    )
+
+    assert tracked_obs.aligned_face is aligned_face
+    assert len(queue.pending) == 1
+    assert queue.pending[0] is tracked_obs
+
+
+def test_do_not_enqueue_tracked_observation_off_sampling_interval(monkeypatch):
+    prev_obs = make_obs(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    tracked_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+
+    track = DummyTrack(track_id=7, observations=[prev_obs, tracked_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[tracked_obs])
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        raise AssertionError("alignment should not be attempted off sampling interval")
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=3,  # track_local_index for tracked_obs is 1
+        embedding_queue=queue,
+    )
+
+    assert tracked_obs.aligned_face is None
+    assert queue.pending == []
+
+
+def test_do_not_enqueue_tracked_observation_without_landmarks(monkeypatch):
+    prev_obs = make_obs(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    tracked_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.TRACKED,
+        landmarks=None,
+    )
+
+    track = DummyTrack(track_id=7, observations=[prev_obs, tracked_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[tracked_obs])
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        raise AssertionError("alignment should not be attempted without landmarks")
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=1,
+        embedding_queue=queue,
+    )
+
+    assert tracked_obs.aligned_face is None
+    assert queue.pending == []
+
+
+def test_skip_observation_with_existing_aligned_face(monkeypatch):
+    detected_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.DETECTED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+        aligned_face=np.ones((112, 112, 3), dtype=np.uint8),
+    )
+
+    track = DummyTrack(track_id=7, observations=[detected_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[detected_obs])
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        raise AssertionError("alignment should not be attempted when aligned_face already exists")
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=1,
+        embedding_queue=queue,
+    )
+
+    assert len(queue.pending) == 0
+
+def test_enqueue_tracked_observation_only_when_track_local_index_matches_interval(monkeypatch):
+    history = [
+        make_obs(
+            frame_idx=38,
+            track_id=7,
+            bbox=(100, 50, 200, 150),
+            source=Source.TRACKED,
+            landmarks=np.ones((5, 2), dtype=np.float32),
+        ),
+        make_obs(
+            frame_idx=39,
+            track_id=7,
+            bbox=(101, 51, 201, 151),
+            source=Source.TRACKED,
+            landmarks=np.ones((5, 2), dtype=np.float32),
+        ),
+        make_obs(
+            frame_idx=40,
+            track_id=7,
+            bbox=(102, 52, 202, 152),
+            source=Source.TRACKED,
+            landmarks=np.ones((5, 2), dtype=np.float32),
+        ),
+        make_obs(
+            frame_idx=41,
+            track_id=7,
+            bbox=(103, 53, 203, 153),
+            source=Source.TRACKED,
+            landmarks=np.ones((5, 2), dtype=np.float32),
+        ),
+    ]
+    tracked_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(104, 54, 204, 154),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+
+    track = DummyTrack(track_id=7, observations=history + [tracked_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[tracked_obs])
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    aligned_face = np.ones((112, 112, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        return aligned_face
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    queue = DummyQueue()
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=3,  # track_local_index is 4, so do not enqueue
+        embedding_queue=queue,
+    )
+
+    assert queue.pending == []
+    assert tracked_obs.aligned_face is None
+
+    queue = DummyQueue()
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=2,  # 4 % 2 == 0, so enqueue
+        embedding_queue=queue,
+    )
+
+    assert len(queue.pending) == 1
+    assert queue.pending[0] is tracked_obs
+    assert tracked_obs.aligned_face is aligned_face
+
+
+def test_enqueue_tracked_observation_uses_latest_matching_track_history_position(monkeypatch):
+    old_obs = make_obs(
+        frame_idx=10,
+        track_id=7,
+        bbox=(0, 0, 100, 100),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    newer_obs = make_obs(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    tracked_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+
+    track = DummyTrack(track_id=7, observations=[old_obs, newer_obs, tracked_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[tracked_obs])
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    aligned_face = np.ones((112, 112, 3), dtype=np.uint8)
+
+    call_count = {"n": 0}
+
+    def fake_align_face(frame_bgr, landmarks):
+        call_count["n"] += 1
+        return aligned_face
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=2,  # track_local_index is 2, so enqueue
+        embedding_queue=queue,
+    )
+
+    assert call_count["n"] == 1
+    assert len(queue.pending) == 1
+    assert queue.pending[0] is tracked_obs
+    assert tracked_obs.aligned_face is aligned_face
+
+
+def test_do_not_enqueue_tracked_observation_when_latest_matching_history_lacks_landmarks(monkeypatch):
+    earlier_obs = make_obs(
+        frame_idx=40,
+        track_id=7,
+        bbox=(99, 49, 199, 149),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    latest_prior_obs = make_obs(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        source=Source.TRACKED,
+        landmarks=None,
+    )
+    tracked_obs = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.TRACKED,
+        landmarks=None,
+    )
+
+    track = DummyTrack(track_id=7, observations=[earlier_obs, latest_prior_obs, tracked_obs])
+    aggregator = DummyAggregator(tracks=[track], observations_for_frame=[tracked_obs])
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        raise AssertionError("alignment should not be attempted without landmarks")
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=1,
+        embedding_queue=queue,
+    )
+
+    assert tracked_obs.aligned_face is None
+    assert queue.pending == []
+
+
+def test_do_not_enqueue_other_track_observation_even_if_earlier_matching_interval_exists(monkeypatch):
+    track7_prev = make_obs(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    track7_curr = make_obs(
+        frame_idx=42,
+        track_id=7,
+        bbox=(112, 68, 212, 168),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    track9_prev = make_obs(
+        frame_idx=41,
+        track_id=9,
+        bbox=(300, 100, 380, 180),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+    track9_curr = make_obs(
+        frame_idx=42,
+        track_id=9,
+        bbox=(304, 104, 384, 184),
+        source=Source.TRACKED,
+        landmarks=np.ones((5, 2), dtype=np.float32),
+    )
+
+    track7 = DummyTrack(track_id=7, observations=[track7_prev, track7_curr])
+    track9 = DummyTrack(track_id=9, observations=[track9_prev, track9_curr])
+
+    aggregator = DummyAggregator(
+        tracks=[track7, track9],
+        observations_for_frame=[track7_curr, track9_curr],
+    )
+    queue = DummyQueue()
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
+    def fake_align_face(frame_bgr, landmarks):
+        raise AssertionError("alignment should not be attempted off sampling interval")
+
+    monkeypatch.setattr(tas, "align_face_for_arcface", fake_align_face)
+
+    tas._maybe_enqueue_track_embedding_observations_for_frame(
+        aggregator=aggregator,
+        frame_idx=42,
+        frame=frame,
+        track_sample_interval=3,  # both current obs have track_local_index 1
+        embedding_queue=queue,
+    )
+
+    assert queue.pending == []
+    assert track7_curr.aligned_face is None
+    assert track9_curr.aligned_face is None

--- a/tests/test_track_embedding_sampling_queue_integration.py
+++ b/tests/test_track_embedding_sampling_queue_integration.py
@@ -1,0 +1,197 @@
+import numpy as np
+
+from facekit.embedding.embedding_queue import AlignedFaceEmbeddingQueue
+from facekit.embedding.track_embedding_queueing import (
+    maybe_enqueue_track_observation_for_embedding,
+)
+from facekit.tracking.face_structures import FaceObservation, Source
+
+
+class DummyQueue:
+    def __init__(self) -> None:
+        self.pending = []
+
+    def enqueue(self, item) -> None:
+        self.pending.append(item)
+
+
+class DummyEmbedder:
+    def __init__(self, outputs):
+        self.outputs = np.asarray(outputs, dtype=np.float32)
+
+    def get_embedding_batch(self, aligned_faces, max_batch_size):
+        assert len(aligned_faces) == self.outputs.shape[0]
+        assert max_batch_size == 4
+        return self.outputs
+
+
+def make_observation(*, source, landmarks=None):
+    return FaceObservation(
+        frame_idx=42,
+        track_id=7,
+        bbox=(10, 20, 110, 120),
+        embedding=None,
+        confidence=0.9,
+        aligned_face=None,
+        source=source,
+        landmarks=landmarks,
+    )
+
+
+def test_sampled_observation_with_successful_alignment_sets_aligned_face_and_enqueues():
+    queue = DummyQueue()
+
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    landmarks = np.array(
+        [
+            [80.0, 90.0],
+            [176.0, 90.0],
+            [128.0, 128.0],
+            [96.0, 176.0],
+            [160.0, 176.0],
+        ],
+        dtype=np.float32,
+    )
+    aligned_face = np.ones((112, 112, 3), dtype=np.uint8)
+
+    obs = make_observation(source=Source.DETECTED, landmarks=landmarks)
+
+    def fake_align_face_fn(frame_bgr, face_landmarks):
+        assert frame_bgr is frame
+        assert face_landmarks is landmarks
+        return aligned_face
+
+    enqueued = maybe_enqueue_track_observation_for_embedding(
+        observation=obs,
+        track_local_index=6,
+        track_sample_interval=5,
+        frame=frame,
+        align_face_fn=fake_align_face_fn,
+        embedding_queue=queue,
+    )
+
+    assert enqueued is True
+    assert obs.aligned_face is aligned_face
+    assert len(queue.pending) == 1
+    assert queue.pending[0] is obs
+
+
+def test_non_sampled_observation_is_not_aligned_or_enqueued():
+    queue = DummyQueue()
+
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    landmarks = np.zeros((5, 2), dtype=np.float32)
+
+    obs = make_observation(source=Source.TRACKED, landmarks=landmarks)
+
+    def fake_align_face_fn(frame_bgr, face_landmarks):
+        raise AssertionError(
+            "alignment should not be attempted for non-sampled observations"
+        )
+
+    enqueued = maybe_enqueue_track_observation_for_embedding(
+        observation=obs,
+        track_local_index=3,
+        track_sample_interval=5,
+        frame=frame,
+        align_face_fn=fake_align_face_fn,
+        embedding_queue=queue,
+    )
+
+    assert enqueued is False
+    assert obs.aligned_face is None
+    assert queue.pending == []
+
+
+def test_alignment_failure_does_not_enqueue_observation():
+    queue = DummyQueue()
+
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    landmarks = np.zeros((5, 2), dtype=np.float32)
+
+    obs = make_observation(source=Source.TRACKED, landmarks=landmarks)
+
+    def fake_align_face_fn(frame_bgr, face_landmarks):
+        return None
+
+    enqueued = maybe_enqueue_track_observation_for_embedding(
+        observation=obs,
+        track_local_index=5,
+        track_sample_interval=5,
+        frame=frame,
+        align_face_fn=fake_align_face_fn,
+        embedding_queue=queue,
+    )
+
+    assert enqueued is False
+    assert obs.aligned_face is None
+    assert queue.pending == []
+
+
+def test_missing_landmarks_does_not_enqueue_observation():
+    queue = DummyQueue()
+
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
+    obs = make_observation(source=Source.TRACKED, landmarks=None)
+
+    def fake_align_face_fn(frame_bgr, face_landmarks):
+        raise AssertionError("alignment should not be attempted without landmarks")
+
+    enqueued = maybe_enqueue_track_observation_for_embedding(
+        observation=obs,
+        track_local_index=5,
+        track_sample_interval=5,
+        frame=frame,
+        align_face_fn=fake_align_face_fn,
+        embedding_queue=queue,
+    )
+
+    assert enqueued is False
+    assert obs.aligned_face is None
+    assert queue.pending == []
+
+
+def test_queue_flush_populates_embedding_and_clears_aligned_face_on_observation():
+    obs = make_observation(source=Source.TRACKED, landmarks=None)
+    obs.aligned_face = np.ones((112, 112, 3), dtype=np.uint8)
+
+    queue = AlignedFaceEmbeddingQueue(
+        embedder=DummyEmbedder([[1.0, 2.0, 3.0]]),
+        max_pending=8,
+        max_batch_size=4,
+    )
+
+    queue.enqueue(obs)
+    queue.flush()
+
+    assert np.allclose(obs.embedding, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    assert obs.aligned_face is None
+
+
+def test_multiple_queued_observations_receive_correct_embeddings():
+    obs_a = make_observation(source=Source.DETECTED, landmarks=None)
+    obs_b = make_observation(source=Source.TRACKED, landmarks=None)
+
+    obs_a.aligned_face = np.ones((112, 112, 3), dtype=np.uint8)
+    obs_b.aligned_face = np.full((112, 112, 3), 2, dtype=np.uint8)
+
+    queue = AlignedFaceEmbeddingQueue(
+        embedder=DummyEmbedder(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+            ]
+        ),
+        max_pending=8,
+        max_batch_size=4,
+    )
+
+    queue.enqueue(obs_a)
+    queue.enqueue(obs_b)
+    queue.flush()
+
+    assert np.allclose(obs_a.embedding, np.array([1.0, 0.0], dtype=np.float32))
+    assert np.allclose(obs_b.embedding, np.array([0.0, 1.0], dtype=np.float32))
+    assert obs_a.aligned_face is None
+    assert obs_b.aligned_face is None

--- a/tests/test_track_finalization_representation.py
+++ b/tests/test_track_finalization_representation.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from facekit.tracking.face_structures import FaceTrack
+from facekit.tracking.aggregator import ShotFaceTrackAggregator
+from facekit.embedding.embedding_selection import TrackEmbeddingSample
+from facekit.common.obs_consts import Source
+
+
+def _emb(seed):
+    v = np.zeros(512, dtype=np.float32)
+    v[seed] = 1.0
+    return v
+
+
+def test_finalize_tracks_computes_representative_embedding():
+    """
+    When the aggregator finalizes tracks, the track should compute its
+    representative embedding from collected embedding samples.
+    """
+
+    aggregator = ShotFaceTrackAggregator(shot_number=1)
+
+    track = FaceTrack(shot_id=1, track_id=1)
+
+    track.embedding_samples = [
+        TrackEmbeddingSample(10, 0, Source.DETECTED, _emb(0)),
+        TrackEmbeddingSample(20, 1, Source.TRACKED, _emb(1)),
+        TrackEmbeddingSample(30, 2, Source.TRACKED, _emb(2)),
+    ]
+
+    aggregator.tracks.append(track)
+
+    aggregator.finalize_tracks()
+
+    assert track.representative_embedding is not None
+    assert track.embedding_stable is True

--- a/tests/test_track_representative_embeddings.py
+++ b/tests/test_track_representative_embeddings.py
@@ -1,0 +1,179 @@
+import numpy as np
+
+from facekit.embedding.embedding_selection import (
+    TrackEmbeddingSample,
+    select_consistent_embedding_subset,
+)
+
+def _norm(v):
+    arr = np.asarray(v, dtype=np.float32)
+    n = np.linalg.norm(arr)
+    if n == 0:
+        raise ValueError("zero vector not allowed in test")
+    return arr / n
+
+
+def _sample(frame_idx: int, emb, track_local_index: int | None = None) -> TrackEmbeddingSample:
+    if track_local_index is None:
+        track_local_index = frame_idx
+    return TrackEmbeddingSample(
+        frame_idx=frame_idx,
+        track_local_index=track_local_index,
+        source="tracking",
+        embedding=_norm(emb),
+        quality_score=None,
+    )
+
+
+def _frame_ids(samples):
+    return [s.frame_idx for s in samples]
+
+
+def test_select_representative_embeddings_uses_all_when_one_sample():
+    samples = [
+        _sample(10, [1.0, 0.0, 0.0]),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen) == [10]
+
+
+def test_select_representative_embeddings_uses_all_when_two_samples():
+    samples = [
+        _sample(10, [1.0, 0.0, 0.0]),
+        _sample(20, [0.99, 0.01, 0.0]),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen) == [10, 20]
+
+
+def test_select_representative_embeddings_uses_all_when_three_samples():
+    samples = [
+        _sample(10, [1.0, 0.0, 0.0]),
+        _sample(20, [0.99, 0.01, 0.0]),
+        _sample(30, [0.98, 0.02, 0.0]),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen) == [10, 20, 30]
+
+
+def test_select_representative_embeddings_discards_all_outside_best_similarity_cluster():
+    samples = [
+        _sample(10, [1.00, 0.00, 0.00]),
+        _sample(20, [0.99, 0.01, 0.00]),
+        _sample(30, [0.98, 0.02, 0.00]),
+        _sample(40, [0.97, 0.03, 0.00]),
+        _sample(50, [0.00, 1.00, 0.00]),
+        _sample(60, [0.00, 0.00, 1.00]),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen) == [10, 20, 30, 40]
+
+
+def test_select_representative_embeddings_may_discard_more_than_two_samples():
+    samples = [
+        _sample(10, [1.00, 0.00, 0.00]),
+        _sample(20, [0.99, 0.01, 0.00]),
+        _sample(30, [0.98, 0.02, 0.00]),
+        _sample(40, [0.00, 1.00, 0.00]),
+        _sample(50, [0.00, 0.00, 1.00]),
+        _sample(60, [-1.00, 0.00, 0.00]),
+        _sample(70, [0.00, -1.00, 0.00]),
+        _sample(80, [0.00, 0.00, -1.00]),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen) == [10, 20, 30]
+
+
+def test_select_representative_embeddings_prefers_larger_consistent_cluster_over_smaller_tighter_pair():
+    samples = [
+        _sample(10, [1.000, 0.000, 0.000]),
+        _sample(20, [0.999, 0.001, 0.000]),
+        _sample(30, [0.850, 0.527, 0.000]),
+        _sample(40, [0.845, 0.535, 0.000]),
+        _sample(50, [0.840, 0.543, 0.000]),
+        _sample(60, [0.835, 0.550, 0.000]),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert len(chosen) == 4
+    assert _frame_ids(chosen) == [30, 40, 50, 60]
+
+
+def test_select_representative_embeddings_is_deterministic_for_same_inputs():
+    samples = [
+        _sample(10, [1.00, 0.00, 0.00]),
+        _sample(20, [0.99, 0.01, 0.00]),
+        _sample(30, [0.98, 0.02, 0.00]),
+        _sample(40, [0.97, 0.03, 0.00]),
+        _sample(50, [0.00, 1.00, 0.00]),
+        _sample(60, [0.00, 0.00, 1.00]),
+    ]
+
+    chosen_a = select_consistent_embedding_subset(samples)
+    chosen_b = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen_a) == _frame_ids(chosen_b)
+
+
+def test_select_representative_embeddings_ignores_samples_without_embeddings():
+    samples = [
+        TrackEmbeddingSample(
+            frame_idx=10,
+            track_local_index=0,
+            source="detection",
+            embedding=_norm([1.0, 0.0, 0.0]),
+            quality_score=None,
+        ),
+        TrackEmbeddingSample(
+            frame_idx=20,
+            track_local_index=10,
+            source="tracking",
+            embedding=None,
+            quality_score=None,
+        ),
+        TrackEmbeddingSample(
+            frame_idx=30,
+            track_local_index=20,
+            source="tracking",
+            embedding=_norm([0.99, 0.01, 0.0]),
+            quality_score=None,
+        ),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert _frame_ids(chosen) == [10, 30]
+
+
+def test_select_representative_embeddings_returns_empty_when_no_valid_embeddings():
+    samples = [
+        TrackEmbeddingSample(
+            frame_idx=10,
+            track_local_index=0,
+            source="detection",
+            embedding=None,
+            quality_score=None,
+        ),
+        TrackEmbeddingSample(
+            frame_idx=20,
+            track_local_index=10,
+            source="tracking",
+            embedding=None,
+            quality_score=None,
+        ),
+    ]
+
+    chosen = select_consistent_embedding_subset(samples)
+
+    assert chosen == []

--- a/tests/test_tracked_landmark_propagation.py
+++ b/tests/test_tracked_landmark_propagation.py
@@ -1,0 +1,141 @@
+import numpy as np
+
+from facekit.tracking.landmark_propagation import (
+    propagate_landmarks_by_bbox_transform,
+)
+
+
+def test_landmarks_translate_when_bbox_translates_without_scale_change():
+    prev_bbox = (100, 50, 200, 150)
+    curr_bbox = (112, 68, 212, 168)  # +12 x, +18 y
+
+    prev_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    propagated = propagate_landmarks_by_bbox_transform(
+        prev_landmarks=prev_landmarks,
+        prev_bbox=prev_bbox,
+        curr_bbox=curr_bbox,
+    )
+
+    expected = prev_landmarks + np.array([12.0, 18.0], dtype=np.float32)
+
+    assert propagated is not None
+    assert propagated.dtype == np.float32
+    assert propagated.shape == (5, 2)
+    assert np.allclose(propagated, expected)
+
+
+def test_landmarks_scale_with_bbox_resize():
+    prev_bbox = (100, 50, 200, 150)   # width=100, height=100
+    curr_bbox = (100, 50, 250, 200)   # width=150, height=150
+
+    prev_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    propagated = propagate_landmarks_by_bbox_transform(
+        prev_landmarks=prev_landmarks,
+        prev_bbox=prev_bbox,
+        curr_bbox=curr_bbox,
+    )
+
+    expected = np.array(
+        [
+            [130.0, 95.0],
+            [220.0, 95.0],
+            [175.0, 132.5],
+            [145.0, 170.0],
+            [205.0, 170.0],
+        ],
+        dtype=np.float32,
+    )
+
+    assert propagated is not None
+    assert np.allclose(propagated, expected)
+
+
+def test_missing_previous_landmarks_returns_none():
+    propagated = propagate_landmarks_by_bbox_transform(
+        prev_landmarks=None,
+        prev_bbox=(100, 50, 200, 150),
+        curr_bbox=(110, 60, 210, 160),
+    )
+
+    assert propagated is None
+
+
+def test_invalid_previous_bbox_returns_none():
+    prev_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    propagated = propagate_landmarks_by_bbox_transform(
+        prev_landmarks=prev_landmarks,
+        prev_bbox=(100, 50, 100, 150),  # zero width
+        curr_bbox=(110, 60, 210, 160),
+    )
+
+    assert propagated is None
+
+
+def test_invalid_current_bbox_returns_none():
+    prev_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    propagated = propagate_landmarks_by_bbox_transform(
+        prev_landmarks=prev_landmarks,
+        prev_bbox=(100, 50, 200, 150),
+        curr_bbox=(110, 60, 110, 160),  # zero width
+    )
+
+    assert propagated is None
+
+
+def test_returns_none_for_wrong_landmark_shape():
+    bad_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+        ],
+        dtype=np.float32,
+    )
+
+    propagated = propagate_landmarks_by_bbox_transform(
+        prev_landmarks=bad_landmarks,
+        prev_bbox=(100, 50, 200, 150),
+        curr_bbox=(110, 60, 210, 160),
+    )
+
+    assert propagated is None

--- a/tests/test_tracking_observation_building.py
+++ b/tests/test_tracking_observation_building.py
@@ -1,0 +1,212 @@
+import numpy as np
+
+from facekit.common.obs_consts import Source
+from facekit.pipeline.track_across_segments import append_tracking_observation
+from facekit.tracking.face_structures import FaceObservation
+
+
+class DummyTrack:
+    def __init__(self, track_id, observations):
+        self.track_id = track_id
+        self.observations = observations
+
+
+class DummyAggregator:
+    def __init__(self, tracks):
+        self.tracks = tracks
+
+
+def make_previous_observation(*, frame_idx=41, track_id=7, bbox, landmarks):
+    return FaceObservation(
+        frame_idx=frame_idx,
+        track_id=track_id,
+        bbox=bbox,
+        embedding=None,
+        confidence=None,
+        aligned_face=None,
+        landmarks=landmarks,
+        source=Source.TRACKED,
+    )
+
+
+def test_append_tracking_observation_converts_xywh_to_xyxy_bbox():
+    observations = []
+    aggregator = DummyAggregator(tracks=[])
+
+    result = append_tracking_observation(
+        observations,
+        frame_idx=42,
+        track_id=7,
+        tracked_box=(100.0, 50.0, 80.0, 120.0),
+        aggregator=aggregator,
+    )
+
+    assert result is None
+    assert len(observations) == 1
+
+    obs = observations[0]
+    assert obs.frame_idx == 42
+    assert obs.track_id == 7
+    assert obs.bbox == (100, 50, 180, 170)
+    assert obs.source == Source.TRACKED
+    assert obs.embedding is None
+    assert obs.confidence is None
+    assert obs.aligned_face is None
+    assert obs.landmarks is None
+
+
+def test_append_tracking_observation_propagates_from_latest_prior_observation_on_matching_track():
+    prev_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    prior_obs = make_previous_observation(
+        bbox=(100, 50, 200, 150),
+        landmarks=prev_landmarks,
+    )
+
+    aggregator = DummyAggregator(
+        tracks=[DummyTrack(track_id=7, observations=[prior_obs])]
+    )
+    observations = []
+
+    append_tracking_observation(
+        observations,
+        frame_idx=42,
+        track_id=7,
+        tracked_box=(112.0, 68.0, 100.0, 100.0),
+        aggregator=aggregator,
+    )
+
+    assert len(observations) == 1
+    obs = observations[0]
+
+    assert obs.frame_idx == 42
+    assert obs.track_id == 7
+    assert obs.bbox == (112, 68, 212, 168)
+    assert obs.source == Source.TRACKED
+    assert obs.landmarks is not None
+    assert obs.landmarks.shape == (5, 2)
+
+
+def test_append_tracking_observation_leaves_landmarks_none_without_prior_landmarks():
+    prior_obs = make_previous_observation(
+        bbox=(100, 50, 200, 150),
+        landmarks=None,
+    )
+
+    aggregator = DummyAggregator(
+        tracks=[DummyTrack(track_id=7, observations=[prior_obs])]
+    )
+    observations = []
+
+    append_tracking_observation(
+        observations,
+        frame_idx=42,
+        track_id=7,
+        tracked_box=(112.0, 68.0, 100.0, 100.0),
+        aggregator=aggregator,
+    )
+
+    assert len(observations) == 1
+    assert observations[0].landmarks is None
+
+
+def test_append_tracking_observation_uses_latest_matching_track_observation():
+    old_landmarks = np.array(
+        [
+            [10.0, 10.0],
+            [20.0, 10.0],
+            [15.0, 15.0],
+            [12.0, 20.0],
+            [18.0, 20.0],
+        ],
+        dtype=np.float32,
+    )
+    new_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    old_obs = make_previous_observation(
+        frame_idx=10,
+        track_id=7,
+        bbox=(0, 0, 100, 100),
+        landmarks=old_landmarks,
+    )
+    new_obs = make_previous_observation(
+        frame_idx=41,
+        track_id=7,
+        bbox=(100, 50, 200, 150),
+        landmarks=new_landmarks,
+    )
+
+    aggregator = DummyAggregator(
+        tracks=[DummyTrack(track_id=7, observations=[old_obs, new_obs])]
+    )
+    observations = []
+
+    append_tracking_observation(
+        observations,
+        frame_idx=42,
+        track_id=7,
+        tracked_box=(112.0, 68.0, 100.0, 100.0),
+        aggregator=aggregator,
+    )
+
+    assert len(observations) == 1
+    obs = observations[0]
+
+    assert obs.track_id == 7
+    assert obs.bbox == (112, 68, 212, 168)
+    assert obs.landmarks is not None
+    assert obs.landmarks.shape == (5, 2)
+
+
+def test_append_tracking_observation_ignores_history_from_other_tracks():
+    prev_landmarks = np.array(
+        [
+            [120.0, 80.0],
+            [180.0, 80.0],
+            [150.0, 105.0],
+            [130.0, 130.0],
+            [170.0, 130.0],
+        ],
+        dtype=np.float32,
+    )
+
+    other_track_obs = make_previous_observation(
+        track_id=99,
+        bbox=(100, 50, 200, 150),
+        landmarks=prev_landmarks,
+    )
+
+    aggregator = DummyAggregator(
+        tracks=[DummyTrack(track_id=99, observations=[other_track_obs])]
+    )
+    observations = []
+
+    append_tracking_observation(
+        observations,
+        frame_idx=42,
+        track_id=7,
+        tracked_box=(112.0, 68.0, 100.0, 100.0),
+        aggregator=aggregator,
+    )
+
+    assert len(observations) == 1
+    assert observations[0].track_id == 7
+    assert observations[0].landmarks is None


### PR DESCRIPTION
- add multi-embedding-per-track support
- flow landmarks from detection frame to tracking frames
- tracking frames can now contribute embedding samples on specified cadence (track-sample-interval)
- compute representative embeddings per track
- prefer representative embeddings in global identity resolution
- expose --track-sample-interval in the CLI