### PR TITLE
Fix short track filtering

### DIFF
--- a/facekit/tracking/track_consolidation_and_pruning.py
+++ b/facekit/tracking/track_consolidation_and_pruning.py
@@ -44,9 +44,8 @@ def apply_track_consolidation_and_pruning(
             min_track_len=min_track_len,
             iou_threshold=iou_threshold,
         )
-        apply_assigned_global_ids(shot_tracks, assignments)
 
-        shot_tracks = prune_short_tracks(shot_tracks, min_track_len=min_track_len)
+        apply_assigned_global_ids(shot_tracks, assignments)
 
         # NOTE: this may merge tracks (reduce count) and inject observations
         fill_short_gaps_within_shot_and_merge(
@@ -54,6 +53,8 @@ def apply_track_consolidation_and_pruning(
             min_gap_len=min_gap_len,
             iou_threshold=iou_threshold,
         )
+
+        shot_tracks = prune_short_tracks(shot_tracks, min_track_len=min_track_len)
 
         out.extend(shot_tracks)
 
@@ -379,19 +380,23 @@ def prune_short_tracks(
     """
     Keep:
       - any track len >= min_track_len
-      - short tracks that have a non-None global_id
     Drop:
-      - short tracks with global_id None
+      - any remaining track len < min_track_len
     """
     out: list[FaceTrack] = []
     for t in shot_tracks:
-        if track_len(t) >= int(min_track_len):
+        tlen = track_len(t)
+        if tlen >= int(min_track_len):
             out.append(t)
             continue
-        if getattr(t, "global_id", None) is None:
-            logger.debug("prune short track: shot=%s tid=%s len=%s", t.shot_id, t.track_id, track_len(t))
-            continue
-        out.append(t)
+
+        logger.debug(
+            "prune short track: shot=%s tid=%s gid=%s len=%s",
+            t.shot_id,
+            t.track_id,
+            getattr(t, "global_id", None),
+            tlen,
+        )
     return out
 
 
@@ -762,3 +767,5 @@ def span(t: FaceTrack) -> Tuple[int, int]:
 
 def ranges_overlap(a0: int, a1: int, b0: int, b1: int) -> bool:
     return not (a1 < b0 or b1 < a0)
+
+

--- a/tests/special/test_cli_e2e_realVideo.py
+++ b/tests/special/test_cli_e2e_realVideo.py
@@ -168,8 +168,8 @@ def test_cli_e2e_realVideo(tmp_path: Path):
     results_dir.mkdir(parents=True, exist_ok=True)
 
     # video_name = "53-man-roster-decisions"
-    video_name = "hot-to-go"
-    # video_name = "OGsTest_10sec_snippet"
+    # video_name = "hot-to-go"
+    video_name = "OGsTest_10sec_snippet"
     # video_name = "3fiUUxKMiBGn6kF4Puczvi"
 
     print(f"Video: {video_name}")
@@ -203,6 +203,7 @@ def test_cli_e2e_realVideo(tmp_path: Path):
         "--detect-interval", "10",
         "--track-sample-interval", "5",
         "--min-face", "10",
+        "--post-min-track-len", "80",
         "--device", "cpu",
         "--schema-version", "2.1",
         "--emb-store", "sidecar",

--- a/tests/test_track_consolidation_and_pruning.py
+++ b/tests/test_track_consolidation_and_pruning.py
@@ -51,76 +51,89 @@ def frames(t: FaceTrack) -> list[int]:
 def sources_by_frame(t: FaceTrack) -> dict[int, Source]:
     return {int(o.frame_idx): o.source for o in (t.observations or [])}
 
-
 # ----------------------------
-# Tests: Phase 1 reassignment
+# Tests: reassignment + final survival contract
 # ----------------------------
 
-def test_short_track_competition_same_gid_winner_keeps_loser_falls_back():
+def test_reassigned_short_tracks_are_pruned_from_final_output():
     """
-    Two short tracks overlap in time and both want gid=10.
-    The better-fitting one (higher IoU evidence) keeps gid=10.
-    The loser should fall back to gid=11 (its second-best candidate),
-    not be pruned just because it lost.
+    Two short tracks can still participate in reassignment competition, but
+    final output should prune them unconditionally if they remain below
+    min_track_len.
     """
     shot = 1
 
-    # Left caps:
-    # L10 ends at 4; bbox is very close to short1 start bbox -> strong IoU
     L10 = make_track(
         shot_id=shot, track_id=100, global_id=10,
         frames_and_bboxes=[(4, (10, 10, 50, 50))]
     )
-    # L11 also ends at 4; bbox is closer to short2 start bbox -> good fallback
     L11 = make_track(
         shot_id=shot, track_id=101, global_id=11,
         frames_and_bboxes=[(4, (100, 100, 140, 140))]
     )
 
-    # Two short tracks that overlap in time:
-    # short1: frames 5-6 near L10 bbox => wants gid=10
     S1 = make_track(
         shot_id=shot, track_id=1, global_id=None,
         frames_and_bboxes=[(5, (11, 11, 51, 51)), (6, (12, 12, 52, 52))]
     )
-    # short2: frames 6-7 closer to L11 bbox, but still can "see" L10 as a candidate
     S2 = make_track(
         shot_id=shot, track_id=2, global_id=None,
         frames_and_bboxes=[(6, (102, 102, 142, 142)), (7, (103, 103, 143, 143))]
     )
 
-    tracks = [L10, L11, S1, S2]
-
     out = apply_track_consolidation_and_pruning(
-        tracks,
+        [L10, L11, S1, S2],
         min_gap_len=10,
-        min_track_len=3,      # S1 and S2 are short (len 2)
-        iou_threshold=0.1,    # permissive
+        min_track_len=3,   # S1/S2 are len 2, so they should be pruned
+        iou_threshold=0.1,
     )
 
-    # S1 should take gid=10; S2 should take gid=11 (fallback)
     by_tid = {t.track_id: t for t in out}
-    assert by_tid[1].global_id == 10
-    assert by_tid[2].global_id == 11
+    assert 1 not in by_tid
+    assert 2 not in by_tid
 
-    # Both should survive (they now have gids)
-    assert 1 in by_tid and 2 in by_tid
-
-
-def test_short_track_cannot_take_gid_if_it_overlaps_fixed_track_with_that_gid():
+def test_long_enough_overlapping_track_survives_final_output():
     """
-    If a short track overlaps in time with a fixed (non-short) track that already has gid=10,
-    it must not be reassigned to gid=10 even if IoU would suggest it.
-    It should fall back to gid=11 if available.
+    Final prune should keep a track that is long enough, even if it does not
+    receive a fallback global_id in this end-to-end path.
     """
     shot = 1
 
-    # Fixed (long) track with gid=10 spanning 5..20
     fixed10 = make_track(
         shot_id=shot, track_id=200, global_id=10,
         frames_and_bboxes=[(5, (10, 10, 50, 50)), (20, (10, 10, 50, 50))]
     )
-    # Left caps for gid=10 and gid=11 end at 9, within min_gap_len of the short track at 10
+    S = make_track(
+        shot_id=shot, track_id=3, global_id=None,
+        frames_and_bboxes=[
+            (10, (11, 11, 51, 51)),
+            (11, (12, 12, 52, 52)),
+            (12, (13, 13, 53, 53)),
+        ],
+    )
+
+    out = apply_track_consolidation_and_pruning(
+        [fixed10, S],
+        min_gap_len=10,
+        min_track_len=3,
+        iou_threshold=0.1,
+    )
+
+    by_tid = {t.track_id: t for t in out}
+    assert 3 in by_tid
+
+def test_short_track_that_cannot_take_overlapping_gid_is_pruned():
+    """
+    A short track that cannot take gid=10 because it overlaps a fixed gid=10
+    track may still fall back internally, but it should not survive final
+    output if it remains shorter than min_track_len.
+    """
+    shot = 1
+
+    fixed10 = make_track(
+        shot_id=shot, track_id=200, global_id=10,
+        frames_and_bboxes=[(5, (10, 10, 50, 50)), (20, (10, 10, 50, 50))]
+    )
     L10 = make_track(
         shot_id=shot, track_id=201, global_id=10,
         frames_and_bboxes=[(9, (10, 10, 50, 50))]
@@ -130,24 +143,46 @@ def test_short_track_cannot_take_gid_if_it_overlaps_fixed_track_with_that_gid():
         frames_and_bboxes=[(9, (12, 12, 52, 52))]
     )
 
-    # Short track overlaps fixed10 in time (10..11)
     S = make_track(
         shot_id=shot, track_id=3, global_id=None,
         frames_and_bboxes=[(10, (11, 11, 51, 51)), (11, (12, 12, 52, 52))]
     )
 
-    tracks = [fixed10, L10, L11, S]
-
     out = apply_track_consolidation_and_pruning(
-        tracks,
+        [fixed10, L10, L11, S],
         min_gap_len=10,
-        min_track_len=3,     # S is short
+        min_track_len=3,   # S is len 2, so it should be pruned
         iou_threshold=0.1,
     )
 
     by_tid = {t.track_id: t for t in out}
-    assert by_tid[3].global_id == 11, "Should fall back because gid=10 overlaps fixed gid=10 track"
+    assert 3 not in by_tid
 
+def test_long_enough_unassigned_track_survives_final_output():
+    """
+    Final prune should keep tracks whose length meets min_track_len,
+    even if they still have global_id=None.
+    """
+    shot = 1
+    T = make_track(
+        shot_id=shot, track_id=1, global_id=None,
+        frames_and_bboxes=[
+            (5, (11, 11, 51, 51)),
+            (6, (12, 12, 52, 52)),
+            (7, (13, 13, 53, 53)),
+        ],
+    )
+
+    out = apply_track_consolidation_and_pruning(
+        [T],
+        min_gap_len=10,
+        min_track_len=3,
+        iou_threshold=0.1,
+    )
+
+    by_tid = {t.track_id: t for t in out}
+    assert 1 in by_tid
+    assert by_tid[1].global_id is None
 
 # ----------------------------
 # Tests: Phase 3 gap filling + merge
@@ -241,3 +276,109 @@ def test_fill_gap_is_blocked_if_any_gap_frame_is_occupied_by_any_track():
     srcsA = sources_by_frame(gid1[0])
     assert 3 not in srcsA or srcsA[3] != Source.INTERPOLATED
     assert 4 not in srcsA or srcsA[4] != Source.INTERPOLATED
+ 
+
+ # ----------------------------
+# Tests: ordering + final prune contract
+# ----------------------------
+
+def test_apply_consolidation_runs_before_final_prune(monkeypatch):
+    """
+    Desired contract:
+      short tracks get a chance to be rescued by consolidation before final prune.
+
+    Under the current implementation, prune runs first, so this test should fail.
+    """
+    class DummyTrack:
+        def __init__(self, shot_id, track_id, length, global_id=None):
+            self.shot_id = shot_id
+            self.track_id = track_id
+            self.global_id = global_id
+            self._length = length
+
+    rescued = DummyTrack(shot_id=1, track_id=10, length=2, global_id=None)
+
+    def fake_group_tracks_by_shot(tracks):
+        return {1: [rescued]}
+
+    def fake_propose_gid_reassignments_for_short_tracks(
+        shot_tracks, *, min_gap_len, min_track_len, iou_threshold
+    ):
+        return []
+
+    def fake_apply_assigned_global_ids(shot_tracks, assignments):
+        return None
+
+    def fake_fill_short_gaps_within_shot_and_merge(
+        shot_tracks, *, min_gap_len, iou_threshold
+    ):
+        # Under the desired ordering, the short track should still be present here
+        # and can be "rescued" before final prune.
+        assert len(shot_tracks) == 1, (
+            "track was pruned before consolidation ran"
+        )
+        shot_tracks[0]._length = 100
+
+    def fake_track_len(track):
+        return int(track._length)
+
+    monkeypatch.setattr(
+        "facekit.tracking.track_consolidation_and_pruning.group_tracks_by_shot",
+        fake_group_tracks_by_shot,
+    )
+    monkeypatch.setattr(
+        "facekit.tracking.track_consolidation_and_pruning.propose_gid_reassignments_for_short_tracks",
+        fake_propose_gid_reassignments_for_short_tracks,
+    )
+    monkeypatch.setattr(
+        "facekit.tracking.track_consolidation_and_pruning.apply_assigned_global_ids",
+        fake_apply_assigned_global_ids,
+    )
+    monkeypatch.setattr(
+        "facekit.tracking.track_consolidation_and_pruning.fill_short_gaps_within_shot_and_merge",
+        fake_fill_short_gaps_within_shot_and_merge,
+    )
+    monkeypatch.setattr(
+        "facekit.tracking.track_consolidation_and_pruning.track_len",
+        fake_track_len,
+    )
+
+    out = apply_track_consolidation_and_pruning(
+        [rescued],
+        min_gap_len=5,
+        min_track_len=70,
+        iou_threshold=0.0,
+    )
+
+    assert len(out) == 1
+    assert out[0].track_id == 10
+    assert out[0]._length == 100
+
+
+def test_final_prune_drops_short_track_even_if_it_has_global_id():
+    """
+    Desired contract:
+      after all reassignment / merge attempts are done, any remaining track
+      shorter than min_track_len is dropped unconditionally.
+
+    This track has a global_id, but it is still too short and cannot merge with
+    anything else, so it should not survive final output.
+    """
+    shot = 1
+
+    short_with_gid = make_track(
+        shot_id=shot, track_id=50, global_id=123,
+        frames_and_bboxes=[(10, (50, 50, 60, 60)), (11, (50, 50, 60, 60))]
+    )
+
+    out = apply_track_consolidation_and_pruning(
+        [short_with_gid],
+        min_gap_len=5,
+        min_track_len=5,
+        iou_threshold=0.0,
+    )
+
+    by_tid = {t.track_id: t for t in out}
+    assert 50 not in by_tid, (
+        "Short track should be pruned from final output even though it has a global_id"
+    )


### PR DESCRIPTION
--post-min-track-len now filters all tracks even those with global-ids that were incorrectly kept