### PR TITLE
Add frame-range execution with resume-safe checkpoint exports

### DIFF
--- a/facekit/cli/resolve_face_ids_v2_cli.py
+++ b/facekit/cli/resolve_face_ids_v2_cli.py
@@ -98,6 +98,57 @@ def _validate_manifest_dict(
                                  total_frame_count=total_frame_count,
                                  schema_dir=schema_dir,
                                  )
+    
+def _validate_frame_range(
+    start_frame: int | None,
+    end_frame: int | None,
+    total_frames: int,
+) -> None:
+    """
+    Validate a requested inclusive frame range against the video bounds.
+
+    Frame-range semantics:
+    - start_frame=None means "beginning of video" (frame 0)
+    - end_frame=None means "end of video" (frame total_frames - 1)
+
+    Validation is therefore performed against the normalized inclusive range:
+
+        [effective_start_frame, effective_end_frame]
+
+    where:
+        effective_start_frame =
+            0 if start_frame is None else start_frame
+
+        effective_end_frame =
+            total_frames - 1 if end_frame is None else end_frame
+
+    Raises:
+        ResumeSafetyError:
+            If the normalized range is invalid or out of bounds.
+    """
+    effective_start_frame = 0 if start_frame is None else int(start_frame)
+    effective_end_frame = total_frames - 1 if end_frame is None else int(end_frame)
+
+    if effective_start_frame < 0:
+        raise ResumeSafetyError(f"--start-frame must be >= 0 (got {start_frame})")
+
+    if effective_end_frame < 0:
+        raise ResumeSafetyError(f"--end-frame must be >= 0 (got {end_frame})")
+
+    if effective_start_frame >= total_frames:
+        raise ResumeSafetyError(
+            f"--start-frame {start_frame} is out of bounds for video with {total_frames} frames"
+        )
+
+    if effective_end_frame >= total_frames:
+        raise ResumeSafetyError(
+            f"--end-frame {end_frame} is out of bounds for video with {total_frames} frames"
+        )
+
+    if effective_end_frame < effective_start_frame:
+        raise ResumeSafetyError(
+            f"--end-frame ({end_frame}) must be >= --start-frame ({start_frame})"
+        )
 
 def run_pipeline(args):
     # ---- forbid inline embeddings for 2.1 ----
@@ -138,7 +189,29 @@ def run_pipeline(args):
         fps = float(fp.fps() or 0.0)
         size = fp.size() or (0, 0)
         width, height = int(size[0]), int(size[1])
+
         total_frames = int(fp.total_frames() or 0)
+        if total_frames <= 0:
+            raise ResumeSafetyError(
+                f"video reports invalid total frame count: {total_frames}"
+            )
+
+        requested_start_frame = getattr(args, "start_frame", None)
+        start_frame = (
+            None
+            if requested_start_frame is None
+            else int(requested_start_frame)
+        )
+
+        requested_end_frame = getattr(args, "end_frame", None)
+        end_frame = (
+            None
+            if requested_end_frame is None
+            else int(requested_end_frame)
+        )
+        
+        _validate_frame_range(start_frame, end_frame, total_frames)
+
         embedding_queue_max_pending = int(getattr(args, "embedding_queue_max_pending", 1024))
 
         # Shots (if not provided, build to a temp file then read back)
@@ -270,6 +343,8 @@ def run_pipeline(args):
             shot_json_path=str(shot_json_path),
             detector=detector,
             embedder=embedder,
+            start_frame=start_frame,
+            end_frame=end_frame,
             detect_interval=int(args.detect_interval),
             track_sample_interval=args.track_sample_interval,
             embedding_batch_size_max=int(args.embedding_batch_size_max),
@@ -470,8 +545,10 @@ def run_pipeline(args):
 
             if ckpt is not None:
                 ckpt.copy_ckpt_sidecars_to_final(
-                    obs_sidecar_path=None,   # <-- prevent overwrite
-                    emb_sidecar_path=None
+                    obs_sidecar_path=args.obs_sidecar_path,
+                    emb_sidecar_path=args.emb_sidecar_path,
+                    requested_start_frame=args.start_frame,
+                    requested_end_frame=args.end_frame,
                 )
                 ckpt.mark_completed()
 
@@ -519,7 +596,7 @@ def main() -> None:
     parser.add_argument("--device",  choices=["auto", "cuda", "cpu"], default="auto",
                         help="Compute device for detector/embedder (default: auto)")
     
-    # control detection interval, embedding sampling interval, queue depth and batch size
+    # control tuning
     parser.add_argument("--detect-interval", type=int, default=30,
                         help="frame count between forced face detection frame")
     parser.add_argument("--embedding-queue-max-pending", type=int, default=1024,
@@ -529,6 +606,10 @@ def main() -> None:
                         help=("Subsampling interval for selecting frames to generate embeddings from non-detection frames. "
                                 "Lower values increase embedding density and identity stability at the cost "
                                 "of additional compute. A value of 1 uses every eligible frame."),)
+    parser.add_argument("--start-frame", type=int, default=None,
+                        help="Inclusive first frame to process/output (default: 0).")
+    parser.add_argument("--end-frame", type=int, default=None,
+                        help="Inclusive last frame to process/output. If omitted, run to the end.")
 
     # Post processing
     parser.add_argument("--post-min-gap-len", type=int, default=210,
@@ -571,7 +652,7 @@ def main() -> None:
     parser.add_argument("--log", default="INFO", choices=["DEBUG","INFO","WARNING","ERROR","CRITICAL"])
     parser.add_argument("--log-file", default=None)
 
-    args = parser.parse_args()
+    args = parser.parse_args(sys.argv[1:])
 
     try:
         run_pipeline(args)

--- a/facekit/pipeline/checkpoint.py
+++ b/facekit/pipeline/checkpoint.py
@@ -60,6 +60,8 @@ class TrackingCheckpoint(Protocol):
     # resuming
     def get_resume_anchor(self) -> tuple[int, int, int] | None: ...     # Return (frame_idx, shot_number, shot_first_frame) or None for fresh run.
 
+    def get_embedding_safe_frames(self) -> list[int]: ...
+
 _PROTECTED_KEYS = (
     "video_path",
     "detector_model_path",
@@ -1019,7 +1021,37 @@ class CheckpointManager(TrackingCheckpoint):
         except Exception:
             logging.exception("ckpt:mark_embedding_safe: sidecar dump failed (non-fatal)")
 
-        self._write_status(note)
+        existing_status = self.read_status() or {}
+        history = list(existing_status.get("embedding_safe_frames") or [])
+
+        frame_idx_i = int(frame_idx)
+
+        if not any(
+            int(row.get("frame_idx", -1)) == frame_idx_i
+            for row in history
+        ):
+            history.append(
+                {
+                    "frame_idx": frame_idx_i,
+                    "shot_number": (
+                        int(shot_number)
+                        if shot_number is not None
+                        else None
+                    ),
+                    "shot_first_frame": (
+                        int(shot_first_frame)
+                        if shot_first_frame is not None
+                        else None
+                    ),
+                }
+            )
+
+        history.sort(key=lambda row: int(row["frame_idx"]))
+
+        self._write_status(
+            note,
+            extra_status={"embedding_safe_frames": history},
+        )
 
     def matches_video(self, video_path: Union[str, Path]) -> bool:
         """Return True if the stored checkpoint was created for this video path."""
@@ -1041,38 +1073,94 @@ class CheckpointManager(TrackingCheckpoint):
         self,
         obs_sidecar_path: str | None = None,
         emb_sidecar_path: str | None = None,
+        requested_start_frame: int | None = None,
+        requested_end_frame: int | None = None,
     ) -> None:
         """
-        Export sidecars from the live checkpoint directory to the final locations.
-        Copy the observations NPZ verbatim so the final file contains a single 
-        structured array under the key `'observations'`
-        with fields: f, shot, track_id, bbox_xyxy, src, conf, emb_idx.
-        Embeddings are also copied verbatim.
-        Safe no-ops if a given source file doesn't exist or a target path is None.
+        Export sidecar data from checkpoint storage to run output paths.
+
+        The checkpoint sidecars under ckpt/ are resume artifacts and reflect the
+        executed checkpoint state. This method does not mutate them.
+
+        The user-facing embedding sidecar, when requested via --emb-sidecar-path,
+        should reflect the requested output frame range, not necessarily the full
+        checkpoint execution history.
+
+        obs_sidecar_path is internal/export plumbing used to keep observation
+        rows consistent with the exported embedding rows; it is not a separate
+        user-facing CLI output option.
+
+        If a requested frame range is supplied:
+        - filter observations to the inclusive requested frame range
+        - keep only embeddings referenced by exported observations
+        - remap exported obs.emb_idx to the compact exported embedding array
+
+        If no requested frame range is supplied, sidecars are copied verbatim.
         """
         if self._writes_disabled():
             return
-        
-        try:
-            if obs_sidecar_path:
-                src = self.ckpt_dir / "obs_ckpt.npz"
-                if src.exists():
-                    shutil.copy2(src, obs_sidecar_path)
-                    logging.info("ckpt:export wrote legacy structured obs sidecar -> %s", obs_sidecar_path)
-                else:
-                    logging.info("ckpt:export obs sidecar missing at %s", src)
 
-            if emb_sidecar_path:
-                src = self.ckpt_dir / "emb_ckpt.npz"
-                if src.exists():
-                    shutil.copy2(src, emb_sidecar_path)
-                    logging.info("ckpt:export copied emb sidecar -> %s", emb_sidecar_path)
-                else:
-                    logging.info("ckpt:export emb sidecar missing at %s", src)
+        obs_src = self.ckpt_dir / "obs_ckpt.npz"
+        emb_src = self.ckpt_dir / "emb_ckpt.npz"
 
-        except Exception as e:
-            # Do not crash pipeline completion if export copy fails; just log.
-            logging.error("ckpt:export failed: %s", e)
+        has_frame_filter = (
+            requested_start_frame is not None
+            or requested_end_frame is not None
+        )
+
+        if not has_frame_filter:
+            if obs_sidecar_path and obs_src.exists():
+                shutil.copy2(obs_src, obs_sidecar_path)
+                logging.info("ckpt:export copied obs sidecar -> %s", obs_sidecar_path)
+
+            if emb_sidecar_path and emb_src.exists():
+                shutil.copy2(emb_src, emb_sidecar_path)
+                logging.info("ckpt:export copied emb sidecar -> %s", emb_sidecar_path)
+
+            return
+
+        if not obs_src.exists():
+            logging.info("ckpt:export obs sidecar missing at %s", obs_src)
+            return
+
+        with np.load(obs_src, allow_pickle=False) as data:
+            obs = data["observations"]
+
+        mask = np.ones(obs.shape[0], dtype=bool)
+
+        if requested_start_frame is not None:
+            mask &= obs["f"] >= int(requested_start_frame)
+
+        if requested_end_frame is not None:
+            mask &= obs["f"] <= int(requested_end_frame)
+
+        out_obs = obs[mask].copy()
+
+        used_emb_indices = sorted({
+            int(idx)
+            for idx in out_obs["emb_idx"]
+            if int(idx) >= 0
+        })
+
+        emb_index_map = {
+            old_idx: new_idx
+            for new_idx, old_idx in enumerate(used_emb_indices)
+        }
+
+        for old_idx, new_idx in emb_index_map.items():
+            out_obs["emb_idx"][out_obs["emb_idx"] == old_idx] = new_idx
+
+        if obs_sidecar_path:
+            np.savez(obs_sidecar_path, observations=out_obs)
+            logging.info("ckpt:export wrote filtered obs sidecar -> %s", obs_sidecar_path)
+
+        if emb_sidecar_path:
+            with np.load(emb_src, allow_pickle=False) as data:
+                embeddings = data["embeddings"]
+
+            out_embeddings = embeddings[used_emb_indices]
+            np.savez(emb_sidecar_path, embeddings=out_embeddings)
+            logging.info("ckpt:export wrote compact emb sidecar -> %s", emb_sidecar_path)
 
     def mark_completed(self) -> None:
         """
@@ -1122,6 +1210,26 @@ class CheckpointManager(TrackingCheckpoint):
             pass
 
         return None
+    
+    def get_embedding_safe_frames(self) -> list[int]:
+        """
+        Return historical embedding-safe frame boundaries in ascending order.
+
+        These boundaries are persisted in status.json and are used for
+        requested-start anchor selection.
+        """
+        status = self.read_status() or {}
+
+        rows = status.get("embedding_safe_frames") or []
+
+        frames = []
+        for row in rows:
+            try:
+                frames.append(int(row["frame_idx"]))
+            except Exception:
+                continue
+
+        return sorted(set(frames))
     
     def _obs_np(self):
         """
@@ -1773,16 +1881,42 @@ class CheckpointManager(TrackingCheckpoint):
                 )
 
             status = mgr.read_status() or {}
-            # Extract minimal signals of progress/anchors
+            # Extract minimal signals of progress/anchors.
+            #
+            # Resume is embedding-safe based. A checkpoint with an
+            # embedding-safe anchor/history is not an empty run even if the
+            # legacy detection-anchor fields are unset.
             frames_done = int(status.get("frames_done", 0) or 0)
             shots_done  = int(status.get("shots_done", 0) or 0)
             obs_anchor  = int(status.get("obs_rows_at_last_detection", 0) or 0)
             emb_anchor  = int(status.get("emb_rows_at_last_detection", 0) or 0)
-            track_order = status.get("track_order") if isinstance(status.get("track_order"), list) else []
+
+            emb_safe_frame = status.get("last_embedding_safe_frame")
+            obs_emb_safe = int(status.get("obs_rows_at_last_embedding_safe", 0) or 0)
+            emb_emb_safe = int(status.get("emb_rows_at_last_embedding_safe", 0) or 0)
+
+            track_order = (
+                status.get("track_order")
+                if isinstance(status.get("track_order"), list)
+                else []
+            )
+
+            embedding_safe_frames = (
+                status.get("embedding_safe_frames")
+                if isinstance(status.get("embedding_safe_frames"), list)
+                else []
+            )
+
             had_progress = any([
-                frames_done > 0, shots_done > 0,
-                obs_anchor > 0, emb_anchor > 0,
-                len(track_order) > 0
+                frames_done > 0,
+                shots_done > 0,
+                obs_anchor > 0,
+                emb_anchor > 0,
+                emb_safe_frame is not None,
+                obs_emb_safe > 0,
+                emb_emb_safe > 0,
+                len(track_order) > 0,
+                len(embedding_safe_frames) > 0,
             ])
 
             mgr._had_prior_progress = bool(had_progress)
@@ -1795,13 +1929,15 @@ class CheckpointManager(TrackingCheckpoint):
                 # If anchors > 0, the corresponding sidecar MUST exist.
                 if not have_obs:
                     raise ResumeSafetyError(
-                        f"ckpt.open: inconsistent checkpoint: obs_anchor={obs_anchor} "
-                        f"but {obs_sidecar_path} is missing."
+                        "ckpt.open: inconsistent checkpoint: status.json records "
+                        "prior progress or an embedding-safe anchor, but "
+                        f"{obs_sidecar_path} is missing."
                     )
                 if not have_emb:
                     raise ResumeSafetyError(
-                        f"ckpt.open: inconsistent checkpoint: emb_anchor={emb_anchor} "
-                        f"but {emb_sidecar_path} is missing."
+                        "ckpt.open: inconsistent checkpoint: status.json records "
+                        "prior progress or an embedding-safe anchor, but "
+                        f"{emb_sidecar_path} is missing."
                     )
                 # structural sanity 
                 try:
@@ -1823,20 +1959,56 @@ class CheckpointManager(TrackingCheckpoint):
 
         return mgr
 
+    @staticmethod
+    def _publish_run_dir(tmp_run_dir: Path, final_run_dir: Path) -> None:
+        tmp_run_dir = Path(tmp_run_dir)
+        final_run_dir = Path(final_run_dir)
+
+        if tmp_run_dir.parent != final_run_dir.parent:
+            raise ValueError(
+                "tmp_run_dir and final_run_dir must share the same parent"
+            )
+
+        os.replace(tmp_run_dir, final_run_dir)
+        fsync_parent_dir(final_run_dir)
+
+
     @classmethod
-    def _create_new_run_dir(cls, parent_dir: Path, snapshot: dict) -> Path:
-        rid = f"run-{_utcstamp_compact()}-{_paramhash8(snapshot)}"
-        run_dir = parent_dir / rid
-        run_dir.mkdir(parents=True, exist_ok=False)
-        # Best-effort convenience symlink
+    def _create_new_run_dir(cls, parent_dir: Path, options_snapshot: dict) -> Path:
+        ts = _utcstamp_compact()
+        h = _paramhash8(options_snapshot)
+
+        final_name = f"run-{ts}-{h}"
+        tmp_name = f".tmp-{final_name}"
+
+        tmp_run_dir = parent_dir / tmp_name
+        final_run_dir = parent_dir / final_name
+
+        if tmp_run_dir.exists():
+            raise FileExistsError(
+                f"temporary checkpoint run directory already exists: {tmp_run_dir}"
+            )
+
+        if final_run_dir.exists():
+            raise FileExistsError(
+                f"checkpoint run directory already exists: {final_run_dir}"
+            )
+
+        (tmp_run_dir / "ckpt").mkdir(parents=True, exist_ok=False)
+
+        cls._publish_run_dir(tmp_run_dir, final_run_dir)
+
+        # Best-effort convenience symlink. This must happen after publish so
+        # current never points at an unpublished temp run.
         try:
             cur = parent_dir / "current"
             if cur.exists() or cur.is_symlink():
                 cur.unlink()
-            cur.symlink_to(run_dir.name)
+            cur.symlink_to(final_run_dir.name)
         except Exception:
             pass
-        return run_dir
+
+        return final_run_dir
 
     # ---------- resume safety ----------
 
@@ -2351,7 +2523,11 @@ class CheckpointManager(TrackingCheckpoint):
             return 0
      
     # ---------- internals ----------
-    def _write_status(self, note: str) -> None:
+    def _write_status(
+        self,
+        note: str = "",
+        extra_status: dict | None = None,
+    ) -> None:
         if self._writes_disabled():
             return
         # derive a stable, ordered list from the dict
@@ -2399,7 +2575,17 @@ class CheckpointManager(TrackingCheckpoint):
             **snap,
             note=note,
         )
-        _atomic_write_text(self.status_path, status.to_json())
+
+        status_dict = asdict(status)
+
+        if extra_status:
+            status_dict.update(extra_status)
+
+        _atomic_write_text(
+            self.status_path,
+            json.dumps(status_dict, indent=2),
+        )
+
         logging.debug("in checkpoint._write_status - just called _atomic_write_text()")
 
     def _rewrite_obs_npz_to_flat(self, src_path, dst_path) -> bool:

--- a/facekit/pipeline/resume_rehydrate.py
+++ b/facekit/pipeline/resume_rehydrate.py
@@ -906,6 +906,8 @@ class ResumePlan:
 def _resolve_anchor(
     checkpoint: TrackingCheckpoint | None,
     resume_enabled: bool,
+    *,
+    requested_start_frame: int | None = None,
 ) -> int:
     """
     Decide the global resume anchor frame for this run.
@@ -935,6 +937,28 @@ def _resolve_anchor(
     if not (resume_enabled and checkpoint):
         logging.info("_resolve_anchor: disabled or no checkpoint -> start=0")
         return 0
+    
+    if requested_start_frame is not None:
+        get_safe_frames = getattr(checkpoint, "get_embedding_safe_frames", None)
+
+        if callable(get_safe_frames):
+            try:
+                safe_frames = list(get_safe_frames() or [])
+            except Exception:
+                safe_frames = []
+
+            selected = _select_embedding_safe_anchor(
+                safe_frames,
+                requested_start_frame=requested_start_frame,
+            )
+
+            if selected > 0:
+                logging.info(
+                    "_resolve_anchor: selected embedding-safe anchor=%d for requested_start_frame=%d",
+                    int(selected),
+                    int(requested_start_frame),
+                )
+                return int(selected)
 
     # Resume starts at anchor+1.
     try:
@@ -947,8 +971,40 @@ def _resolve_anchor(
         return 0
 
     safe_f = int(anchors[0])
+
     logging.info("_resolve_anchor: embedding-safe anchor=%d", safe_f)
     return safe_f
+
+def _select_embedding_safe_anchor(
+    safe_frames: list[int],
+    *,
+    requested_start_frame: int | None,
+) -> int:
+    """
+    Select the embedding-safe frame to use as the hydration boundary.
+
+    Modes
+    -----
+    Legacy resume execution:
+        If requested_start_frame is None, use the latest/final safe frame.
+
+    History-preserving range execution:
+        If requested_start_frame is explicit, use the latest safe frame strictly
+        less than requested_start_frame.
+
+    Fallback fresh execution:
+        If there is no usable safe frame, return 0.
+    """
+    frames = sorted(int(f) for f in safe_frames if f is not None)
+
+    if not frames:
+        return 0
+
+    if requested_start_frame is None:
+        return int(frames[-1])
+
+    prior = [f for f in frames if f < int(requested_start_frame)]
+    return int(prior[-1]) if prior else 0
 
 def _shot_idx_by_abs_frame(shots, abs_frame_idx: int) -> int:
     """
@@ -1010,6 +1066,7 @@ def _build_resume_plan(
     checkpoint: TrackingCheckpoint | None,
     resume_enabled: bool,
     all_tracks: List[FaceTrack],
+    requested_start_frame: int | None = None,
 ) -> tuple[ResumePlan, list]:
     """
     Construct a ResumePlan and trim the shot list to the anchor-containing shot.
@@ -1049,7 +1106,11 @@ def _build_resume_plan(
     trackid_seed_by_shot: Dict[int, int] = {}
     prior_tracks: List[FaceTrack] = []
 
-    resume_abs_frame: int = _resolve_anchor(checkpoint, resume_enabled)
+    resume_abs_frame: int = _resolve_anchor(
+        checkpoint,
+        resume_enabled,
+        requested_start_frame=requested_start_frame,
+    )
 
     # === AUDIT FENCE #0: record collector rows BEFORE any new work ===
     try:

--- a/facekit/pipeline/track_across_segments.py
+++ b/facekit/pipeline/track_across_segments.py
@@ -37,6 +37,39 @@ from facekit.embedding.embedding_selection import TrackEmbeddingSample
 
 logger = logging.getLogger(__name__)
 
+# Execution mode vocabulary
+# -------------------------
+# User-facing requested bounds:
+#   requested_start_frame:
+#       Inclusive first frame requested by the user, or None for legacy/full-start behavior.
+#   requested_end_frame:
+#       Inclusive last frame requested by the user, or None for video end.
+#
+# Processing concepts:
+#   execution_start_frame:
+#       First frame actually processed for the current shot.
+#   execution_end_frame:
+#       Last frame actually processed for the current shot.
+#   hydrate_through_frame:
+#       Last frame restored from checkpoint history before execution begins.
+#
+# Modes:
+#   Full fresh execution:
+#       No requested start/end, resume disabled. Execute from frame 0.
+#   Legacy resume execution:
+#       No requested start, resume enabled, valid checkpoint with an embedding-safe
+#       frame. Hydrate through final safe frame, execute from final_safe + 1.
+#   Full fallback fresh execution:
+#       Resume enabled but no usable checkpoint/safe frame. Execute from frame 0.
+#   Local range execution:
+#       Requested start is provided and no history is used. Execute from requested start.
+#   History-preserving range execution:
+#       Requested start is provided and a usable checkpoint safe frame exists before it.
+#       Hydrate through that safe frame; execute from safe_frame + 1.
+#   History-covered output only:
+#       Requested start is None, requested end is within already-safe history.
+#       Hydrate only through requested end; execute no new frames.
+
 def _snapshot_open_tracks_for_status(aggregator, shot_number: int) -> list[dict]:
     rows: list[dict] = []
     for t in getattr(aggregator, "tracks", []):
@@ -59,8 +92,8 @@ def _init_shot_aggregator(
     *,
     shot_idx: int,
     shot_number: int,
-    first: int,
-    last: int,
+    execution_start_frame: int,
+    execution_end_frame: int,
     detect_interval: int,
     resume_plan: ResumePlan,
     iou_thresh: float,
@@ -68,30 +101,37 @@ def _init_shot_aggregator(
     checkpoint: TrackingCheckpoint | None,
 ) -> tuple[int, ShotFaceTrackAggregator, int]:
     """
-    Initialize a ShotFaceTrackAggregator for a single shot, applying resume rules.
+    Initialize a ShotFaceTrackAggregator for a single shot, applying resume-aware
+    track seeding and per-shot ID initialization.
 
     Responsibilities
     ----------------
-    * Decide the starting frame for this shot:
-        - First processed shot starts at max(first_frame, anchor_frame).
-        - Subsequent shots start at their first_frame.
-    * For the anchor-containing shot, seed the aggregator with pre-anchor tracks
-      so that labels and embeddings continue seamlessly.
-    * Apply track_id seeding and (optional) forced tid reuse at the resume boundary.
-    * Compute the per-shot segment-id seed returned as seg_seed.
+    * Build the per-shot aggregator.
+    * Seed the aggregator with rehydrated pre-resume tracks when this is the
+    resume-containing shot.
+    * Normalize seeded track open/closed state using checkpoint-declared open
+    track IDs at the embedding-safe boundary.
+    * Apply track_id seeding and compute the initial per-shot segment-id seed.
+
+    This helper does not decide the execution frame range for the shot. The caller
+    is responsible for computing:
+    - execution_start_frame
+    - execution_end_frame
 
     Parameters
     ----------
     shot_idx :
-        0-based index of this shot within the trimmed shot list.
+        0-based index of this shot within the shot list being processed.
     shot_number :
         Logical shot identifier from the shot JSON.
-    first, last :
-        Absolute first and last frame indices for this shot.
+    execution_start_frame :
+        Absolute frame index at which processing for this shot will begin.
+    execution_end_frame :
+        Absolute last frame index that may be processed for this shot.
     detect_interval :
-        Detection interval used for logging the resume fence.
+        Detection interval used for logging/debugging.
     resume_plan :
-        ResumePlan containing anchor frame and per-shot seeds.
+        ResumePlan containing embedding-safe-frame information and per-shot seeds.
     iou_thresh, embedding_thresh :
         Aggregator matching and within-shot identity thresholds.
     checkpoint :
@@ -99,34 +139,27 @@ def _init_shot_aggregator(
 
     Returns
     -------
-    start_at, aggregator, seg_seed :
-        start_at : int
-            Absolute frame index at which this shot-loop should start.
+    execution_start_frame, aggregator, seg_seed :
+        execution_start_frame : int
+            The absolute frame index at which this shot-loop should begin.
         aggregator : ShotFaceTrackAggregator
             Fully initialized aggregator for this shot.
         seg_seed : int
-            Initial segment_id_counter seed for this shot (used at resolve_segment_ids()).
+            Initial segment_id_counter seed for this shot.
     """
-    # Decide starting frame
-    # Under the embedding-safe-frame contract, resume begins at the frame
-    # *following* the embedding-safe frame.
-    if shot_idx == 0 and resume_plan.is_resume:
-        start_at = max(first, int(resume_plan.anchor_frame) + 1)
-    else:
-        start_at = first
-
     if shot_idx == 0:
         logging.info(
-            "resume: first_new_frame=%d (shot=[%d..%d]) detect_interval=%d mod=%d",
-            start_at,
-            first,
-            last,
+            "resume: execution_start_frame=%d (execution_range=[%d..%d]) detect_interval=%d mod=%d",
+            execution_start_frame,
+            execution_start_frame,
+            execution_end_frame,
             detect_interval,
-            ((start_at - first) % max(1, detect_interval)),
+            ((execution_start_frame - execution_start_frame) % max(1, detect_interval)),
         )
-        if start_at > last:
+        if execution_start_frame > execution_end_frame:
             raise ResumeSafetyError(
-                f"empty work-range at resume: start_at={start_at} > shot_last={last} for shot={shot_number}"
+                f"empty execution range: execution_start_frame={execution_start_frame} "
+                f"> execution_end_frame={execution_end_frame} for shot={shot_number}"
             )
         
     is_resume_shot = (
@@ -197,7 +230,7 @@ def _init_shot_aggregator(
             iou_threshold=iou_thresh,
             embedding_threshold=embedding_thresh,
             prior_tracks=seeded_tracks,
-            resume_abs_frame=start_at,
+            resume_abs_frame=execution_start_frame,
             next_tid_seed=int(resume_plan.trackid_seed_by_shot.get(int(shot_number), 0)),
         )
 
@@ -268,7 +301,7 @@ def _init_shot_aggregator(
         elif hasattr(aggregator, "_next_track_id"):
             setattr(aggregator, "_next_track_id", seed_tid)
 
-    return start_at, aggregator, seg_seed
+    return execution_start_frame, aggregator, seg_seed
 
 
 def _guard_seek_failure(
@@ -331,7 +364,11 @@ def _guard_no_rewind(frame_idx: int, resume_plan: ResumePlan) -> None:
     Any attempt to produce observations for a frame strictly before
     resume_plan.anchor_frame is treated as a bug and raises ResumeSafetyError.
     """
-    if resume_plan.anchor_frame and frame_idx < resume_plan.anchor_frame:
+    if (
+        resume_plan.is_resume
+        and resume_plan.anchor_frame
+        and frame_idx < resume_plan.anchor_frame
+    ):
         raise ResumeSafetyError(
             f"Illegal rewind: got frame_idx={frame_idx} < anchor={resume_plan.anchor_frame}"
         )
@@ -789,6 +826,8 @@ def track_across_segments(
     detect_interval: int = 10,
     embedding_batch_size_max: int = 32,
     *,
+    start_frame: int = 0,
+    end_frame: int | None = None,
     embedding_queue_max_pending: int = 1024,
     track_sample_interval: int = 10,
     checkpoint: TrackingCheckpoint | None = None,
@@ -836,16 +875,42 @@ def track_across_segments(
         Run the detector every `detect_interval` frames (and on the first frame of a shot or after tracker reset).
     embedding_batch_size_max : int, default 32
         Maximum batch size for `embedder.get_embedding_batch`.
+    start_frame : int, default 0
+        - Inclusive first frame to process/output.
+        - For cold runs (no resume), processing begins exactly at this frame.
+        - For resume runs, the internal starting frame may be earlier than this frame
+          if required to safely rehydrate tracker state (e.g., at an embedding-safe
+          boundary). In such cases, frames prior to `start_frame` are processed
+          internally but should not be considered part of the requested output range.
+    end_frame : int | None, default None
+        - Inclusive last frame to process/output.
+        - If None, processing continues to the end of the video.
+        - If specified, the pipeline must not emit results beyond this frame.
     checkpoint : TrackingCheckpoint | None, optional
         Checkpoint interface used for sidecar persistence (observations/embeddings),
         status.json updates, and rehydration of prior observations/tracks.
     resume_enabled : bool, default True
-        When True, this function resolves a resume anchor from the `checkpoint`
-        (preferring `get_resume_anchor()`, then `last_detection_frame` from status,
-        then the maximum observed frame in the observations collector). The tracker
-        will start at `max(anchor, shot_first)` within the containing shot and will
-        rehydrate prior observations strictly *before* the anchor. When False,
-        the function ignores any resume state and starts from the first shot frame.
+        When True
+            - if checkpoint artifacts are located and compatible, they are used to determine 
+              last embedding-safe frame
+                - resume processing from the last embedding-safe frame, if there is one 
+                - The embedding-safe frame is the most recent frame for which all required
+                  embeddings have been durably persisted. Resume begins at the frame
+                  immediately following this boundary.
+                - For the shot containing the embedding-safe frame:
+                    - The tracker state is rehydrated from checkpointed observations.
+                    - Only tracks that were open at the embedding-safe boundary are
+                      considered active and eligible for continuation.
+                - The pipeline guarantees:
+                    - No recomputation of embeddings for frames at or before the
+                      embedding-safe frame.
+                - No emission of observations for frames prior to the embedding-safe
+                  frame (no rewind).
+            - If resume is not possible (e.g., incompatible checkpoint), the function
+              must fail rather than silently falling back to a cold run.
+        When False
+            - the function ignores any checkpoint state and processes the
+              video from the beginning (or from `start_frame` if provided).
 
     Returns
     -------
@@ -863,6 +928,14 @@ def track_across_segments(
       the internally constructed provider is closed automatically via `ExitStack()`.
     - **Performance knobs:** `detect_interval` trades accuracy for speed; increasing it reduces detector calls.
       `embedding_batch_size_max` controls memory/throughput on the embedder.
+
+    Frame range semantics
+    ---------------------
+    - The requested [start_frame, end_frame] defines the user-visible output range.
+    - Resume logic may require internal processing prior to start_frame in order
+      to rehydrate track state safely.
+    - Implementations should ensure that any internal replay does not leak
+      observations or outputs outside the requested frame range.
 
     Resume semantics & label continuity
     -----------------------------------
@@ -906,12 +979,16 @@ def track_across_segments(
 
         all_tracks: List[FaceTrack] = []
 
+        requested_start_frame = None if start_frame is None else int(start_frame)
+        requested_end_frame = None if end_frame is None else int(end_frame)
+
         # Centralized resume/rehydrate logic
         resume_plan, shots = _build_resume_plan(
             shots,
             checkpoint=checkpoint,
             resume_enabled=resume_enabled,
             all_tracks=all_tracks,
+            requested_start_frame=requested_start_frame,
         )
 
         for shot_idx, shot_num in enumerate(shots):
@@ -922,12 +999,62 @@ def track_across_segments(
             first = shot_num["first_frame"]
             last = shot_num["last_frame"]
 
+            # No resume plan was selected.
+            #
+            # If resume was disabled, this is local range execution: start exactly
+            # at requested_start_frame.
+            #
+            # If resume was enabled but no usable checkpoint/safe frame was selected,
+            # this is fallback fresh execution: start at frame 0 so requested output
+            # can be produced with complete forward context.
+            if not resume_plan.is_resume:
+                if resume_enabled:
+                    # Resume was requested, but no usable embedding-safe
+                    # boundary was selected. For history-preserving fallback,
+                    # execute from frame 0 rather than from requested_start_frame.
+                    effective_start_frame = 0
+                else:
+                    # Local range execution: resume/history is intentionally
+                    # disabled, so start exactly at requested_start_frame.
+                     effective_start_frame = 0 if requested_start_frame is None else requested_start_frame
+
+                if last < effective_start_frame:
+                    continue
+                if requested_end_frame is not None and first > requested_end_frame:
+                    break
+
+                execution_start_frame = max(int(first), effective_start_frame)
+                execution_end_frame = (
+                    min(int(last), requested_end_frame)
+                    if requested_end_frame is not None
+                    else int(last)
+                )
+            else:
+                # the first processed resume shot begins at the frame
+                # immediately after the embedding-safe anchor.
+                if shot_idx == 0:
+                    execution_start_frame = max(
+                        int(first),
+                        int(resume_plan.anchor_frame) + 1,
+                    )
+                else:
+                    execution_start_frame = int(first)
+
+                execution_end_frame = (
+                    min(int(last), requested_end_frame)
+                    if requested_end_frame is not None
+                    else int(last)
+                )
+
+                if execution_start_frame > execution_end_frame:
+                    continue
+
             # Initialize shot-level aggregator and seeds (resume aware)
             start_at, aggregator, seg_seed = _init_shot_aggregator(
                 shot_idx=shot_idx,
                 shot_number=shot_number,
-                first=first,
-                last=last,
+                execution_start_frame=execution_start_frame,
+                execution_end_frame=execution_end_frame,
                 detect_interval=detect_interval,
                 resume_plan=resume_plan,
                 iou_thresh=iou_thresh,
@@ -956,7 +1083,7 @@ def track_across_segments(
 
             frame_provider.reset_to_frame(int(start_at))
 
-            for frame_idx in range(start_at, last + 1):
+            for frame_idx in range(start_at, execution_end_frame + 1):
                 frame = frame_provider.next()
                 frame = _guard_seek_failure(
                     frame=frame,

--- a/tests/integration/test_no_resume_frame_ranges.py
+++ b/tests/integration/test_no_resume_frame_ranges.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.integration.test_resume_completed_run_frame_ranges import (
+    SHIM_SOURCE,
+    _load_rows,
+    _make_tiny_video,
+    _run_python,
+    _with_repo_env,
+    _write_shots_json,
+)
+
+def _load_embeddings(npz_path: Path) -> np.ndarray:
+    with np.load(npz_path, allow_pickle=False) as data:
+        assert "embeddings" in data.files
+        return data["embeddings"]
+
+@pytest.mark.integration
+def test_no_resume_frame_range_ignores_existing_checkpoint_for_embedding_sidecar(
+    tmp_path: Path,
+):
+    shim = tmp_path / "run_cli_with_stubs.py"
+    shim.write_text(SHIM_SOURCE)
+
+    total_frames = 60
+
+    vid = tmp_path / "toy.mp4"
+    shots_path = tmp_path / "shots.json"
+
+    _make_tiny_video(vid, frames=total_frames, size=(192, 108))
+    _write_shots_json(shots_path, 0, total_frames - 1)
+
+    polluted_ckpt_parent = tmp_path / "polluted_ckpt"
+    clean_ckpt_parent = tmp_path / "clean_ckpt"
+
+    polluted_ckpt_parent.mkdir()
+    clean_ckpt_parent.mkdir()
+
+    # Create a fake/latest-looking checkpoint that must not be read when
+    # --no-resume is supplied.
+    trap_run = polluted_ckpt_parent / "run-99999999T999999Z-deadbeef"
+    trap_ckpt = trap_run / "ckpt"
+    trap_ckpt.mkdir(parents=True)
+
+    trap_embeddings = np.full((3, 512), 999.0, dtype=np.float32)
+    np.savez(trap_ckpt / "emb_ckpt.npz", embeddings=trap_embeddings)
+
+    trap_obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+    trap_obs = np.array(
+        [
+            (25, 1, 0, [0, 0, 1, 1], 0, 0.99, 0),
+            (30, 1, 0, [0, 0, 1, 1], 0, 0.99, 1),
+            (35, 1, 0, [0, 0, 1, 1], 0, 0.99, 2),
+        ],
+        dtype=trap_obs_dtype,
+    )
+    np.savez(trap_ckpt / "obs_ckpt.npz", observations=trap_obs)
+
+    (trap_run / "status.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "2.3",
+                "video_path": str(vid.resolve()),
+                "last_embedding_safe_frame": 35,
+                "last_embedding_safe_shot_number": 1,
+                "last_embedding_safe_shot_first_frame": 0,
+                "obs_rows_at_last_embedding_safe": 3,
+                "emb_rows_at_last_embedding_safe": 3,
+                "embedding_safe_frames": [
+                    {
+                        "frame_idx": 35,
+                        "shot_number": 1,
+                        "shot_first_frame": 0,
+                    }
+                ],
+            }
+        )
+    )
+
+    polluted_obs = tmp_path / "polluted_obs.npz"
+    polluted_emb = tmp_path / "polluted_emb.npz"
+
+    clean_obs = tmp_path / "clean_obs.npz"
+    clean_emb = tmp_path / "clean_emb.npz"
+
+    common = [
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "sidecar",
+        "--start-frame", "25",
+        "--end-frame", "35",
+        "--no-resume",
+        "--log", "INFO",
+    ]
+
+    _run_python(
+        shim,
+        *common,
+        "--checkpoint-dir", str(polluted_ckpt_parent),
+        "--obs-sidecar-path", str(polluted_obs),
+        "--emb-sidecar-path", str(polluted_emb),
+        "--output-global-json", str(tmp_path / "polluted.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    _run_python(
+        shim,
+        *common,
+        "--checkpoint-dir", str(clean_ckpt_parent),
+        "--obs-sidecar-path", str(clean_obs),
+        "--emb-sidecar-path", str(clean_emb),
+        "--output-global-json", str(tmp_path / "clean.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    polluted_rows = _load_rows(polluted_obs)
+    clean_rows = _load_rows(clean_obs)
+
+    polluted_embeddings = _load_embeddings(polluted_emb)
+    clean_embeddings = _load_embeddings(clean_emb)
+
+    assert polluted_rows.shape[0] > 0
+    assert polluted_rows[:, 2].min() >= 25
+    assert polluted_rows[:, 2].max() <= 35
+
+    np.testing.assert_array_equal(polluted_rows, clean_rows)
+    np.testing.assert_array_equal(polluted_embeddings, clean_embeddings)
+
+    assert not np.any(polluted_embeddings == 999.0)

--- a/tests/integration/test_resume_completed_run_frame_ranges.py
+++ b/tests/integration/test_resume_completed_run_frame_ranges.py
@@ -1,0 +1,608 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+def _with_repo_env() -> dict:
+    repo_root = Path(__file__).resolve().parents[2]
+    existing = os.environ.get("PYTHONPATH", "")
+    extras = [str(repo_root)] + [p for p in sys.path if p]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        os.pathsep.join([*extras, existing])
+        if existing
+        else os.pathsep.join(extras)
+    )
+    return env
+
+def _make_tiny_video(path: Path, frames=60, size=(192, 108)):
+    import cv2
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    vw = cv2.VideoWriter(str(path), fourcc, 30.0, size)
+    blank = np.zeros((size[1], size[0], 3), dtype=np.uint8)
+
+    for _ in range(frames):
+        vw.write(blank)
+
+    vw.release()
+
+def _write_shots_json(path: Path, first: int, last: int):
+    path.write_text(
+        json.dumps(
+            {
+                "shots": [
+                    {
+                        "shot_number": 1,
+                        "first_frame": int(first),
+                        "last_frame": int(last),
+                    }
+                ]
+            }
+        )
+    )
+
+def _run_python(shim: Path, *args, ok=(0,), env=None, cwd=None):
+    cp = subprocess.run(
+        [sys.executable, str(shim), *args],
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=cwd or shim.parent,
+    )
+
+    if cp.returncode not in ok:
+        raise AssertionError(
+            f"Return code {cp.returncode} not in {ok}\n"
+            f"=== STDOUT ===\n{cp.stdout}\n"
+            f"=== STDERR ===\n{cp.stderr}\n"
+        )
+
+    return cp
+
+def _load_rows(npz_path: Path) -> np.ndarray:
+    with np.load(npz_path) as data:
+        assert "observations" in data.files
+
+        obs = data["observations"]
+
+        if obs.size == 0:
+            return np.empty((0, 8))
+
+        bbox = obs["bbox_xyxy"].astype(np.float32)
+
+        return np.stack(
+            [
+                obs["shot"].astype(int),
+                obs["track_id"].astype(int),
+                obs["f"].astype(int),
+                bbox[:, 0],
+                bbox[:, 1],
+                bbox[:, 2],
+                bbox[:, 3],
+                obs["src"].astype(int),
+            ],
+            axis=1,
+        )
+    
+def _load_embeddings(npz_path: Path) -> np.ndarray:
+    with np.load(npz_path, allow_pickle=False) as data:
+        assert "embeddings" in data.files
+        return data["embeddings"]
+
+SHIM_SOURCE = r"""
+import os, sys, numpy as np
+
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
+def _dummy_loader(*a, **k):
+    return object()
+
+import facekit.detection.yolo5face_model as y5
+y5.load_yolo5face_model = _dummy_loader
+
+class _DummyEmbedder:
+    def __init__(self, *a, **k):
+        pass
+
+    def get_embedding_batch(self, chips, batch_size=None, **kwargs):
+        vecs = []
+
+        for chip in chips:
+            h = int(np.uint64(
+                chip.sum()
+                + chip.shape[0] * 1009
+                + chip.shape[1] * 2741
+            ))
+
+            rng = np.random.RandomState(h % (2**32))
+            v = rng.rand(512).astype(np.float32)
+            v /= (np.linalg.norm(v) + 1e-12)
+            vecs.append(v)
+
+        return np.stack(vecs, axis=0)
+
+    def get_embedding(self, chip, **kwargs):
+        return self.get_embedding_batch([chip], **kwargs)[0]
+
+import facekit.embedding.embedder as emb_mod
+emb_mod.FaceEmbedder = _DummyEmbedder
+
+from facekit.pipeline import track_across_segments as track_mod
+from facekit.cli import resolve_face_ids_v2_cli as cli_mod
+
+class _EmitOneMovingBox:
+    def detect_faces_in_frame(self, frame, frame_index=None):
+        f = int(frame_index or 0)
+
+        x1 = 10.0 + f
+        y1 = 10.0
+        x2 = 50.0 + f
+        y2 = 50.0
+
+        boxes = np.array([[x1, y1, x2, y2]], np.float32)
+
+        lms = np.array(
+            [[
+                [x1, y1],
+                [x2, y1],
+                [x1, y2],
+                [x2, y2],
+                [(x1 + x2) / 2.0, (y1 + y2) / 2.0],
+            ]],
+            np.float32,
+        )
+
+        conf = np.array([0.99], np.float32)
+
+        return boxes, lms, conf
+
+def _fake_align(frame, landmarks, frame_idx=None, **k):
+    return np.zeros((112, 112, 3), np.uint8)
+
+track_mod.align_face_for_arcface = _fake_align
+
+_orig_track = track_mod.track_across_segments
+
+def _wrapped_track(*a, **k):
+    k["detector"] = _EmitOneMovingBox()
+    return _orig_track(*a, **k)
+
+track_mod.track_across_segments = _wrapped_track
+
+try:
+    cli_mod.main()
+except SystemExit:
+    raise
+"""
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "start_frame,end_frame,expected_min_frame,expected_max_frame",
+    [
+        pytest.param(25, 35, 25, 35, id="explicit-start-explicit-end"),
+        pytest.param(25, None, 25, 59, id="explicit-start-no-end"),
+        pytest.param(None, 35, 0, 35, id="no-start-explicit-end"),
+        pytest.param(25, 25, 25, 25, id="single-frame-range"),
+    ],
+)
+def test_completed_run_resume_frame_range_matches_original_subset(
+    tmp_path: Path,
+    start_frame: int | None,
+    end_frame: int | None,
+    expected_min_frame: int,
+    expected_max_frame: int,
+):
+    shim = tmp_path / "run_cli_with_stubs.py"
+    shim.write_text(SHIM_SOURCE)
+
+    total_frames = 60
+
+    vid = tmp_path / "toy.mp4"
+    shots_path = tmp_path / "shots.json"
+
+    _make_tiny_video(vid, frames=total_frames, size=(192, 108))
+    _write_shots_json(shots_path, 0, total_frames - 1)
+
+    ckpt_parent = tmp_path / "ckpt"
+    ckpt_parent.mkdir()
+
+    full_obs = tmp_path / "full_obs.npz"
+    rerun_obs = tmp_path / "rerun_obs.npz"
+
+    common = [
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "none",
+        "--checkpoint-dir", str(ckpt_parent),
+        "--log", "INFO",
+    ]
+    _run_python(
+        shim,
+        *common,
+        "--obs-sidecar-path", str(full_obs),
+        "--output-global-json", str(tmp_path / "full.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    range_args = ["--resume-latest"]
+
+    if start_frame is not None:
+        range_args.extend(["--start-frame", str(start_frame)])
+
+    if end_frame is not None:
+        range_args.extend(["--end-frame", str(end_frame)])
+
+    _run_python(
+        shim,
+        *common,
+        *range_args,
+        "--obs-sidecar-path", str(rerun_obs),
+        "--output-global-json", str(tmp_path / "rerun.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    full_rows = _load_rows(full_obs)
+    rerun_rows = _load_rows(rerun_obs)
+
+    assert full_rows.shape[0] > 0
+    assert rerun_rows.shape[0] > 0
+
+    expected_rows = full_rows[
+        (full_rows[:, 2] >= expected_min_frame)
+        & (full_rows[:, 2] <= expected_max_frame)
+    ]
+
+    assert expected_rows.shape[0] > 0
+
+    assert rerun_rows.shape == expected_rows.shape
+    assert np.array_equal(rerun_rows, expected_rows)
+
+@pytest.mark.integration
+def test_completed_run_resume_frame_range_user_embedding_sidecar_reflects_range(
+    tmp_path: Path,
+):
+    shim = tmp_path / "run_cli_with_stubs.py"
+    shim.write_text(SHIM_SOURCE)
+
+    total_frames = 60
+
+    vid = tmp_path / "toy.mp4"
+    shots_path = tmp_path / "shots.json"
+
+    _make_tiny_video(vid, frames=total_frames, size=(192, 108))
+    _write_shots_json(shots_path, 0, total_frames - 1)
+
+    ckpt_parent = tmp_path / "ckpt"
+    ckpt_parent.mkdir()
+
+    full_obs = tmp_path / "full_obs.npz"
+    full_emb = tmp_path / "full_emb.npz"
+
+    rerun_obs = tmp_path / "rerun_obs.npz"
+    rerun_emb = tmp_path / "rerun_emb.npz"
+
+    common = [
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "sidecar",
+        "--checkpoint-dir", str(ckpt_parent),
+        "--log", "INFO",
+    ]
+
+    _run_python(
+        shim,
+        *common,
+        "--obs-sidecar-path", str(full_obs),
+        "--emb-sidecar-path", str(full_emb),
+        "--output-global-json", str(tmp_path / "full.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    _run_python(
+        shim,
+        *common,
+        "--resume-latest",
+        "--start-frame", "25",
+        "--end-frame", "35",
+        "--obs-sidecar-path", str(rerun_obs),
+        "--emb-sidecar-path", str(rerun_emb),
+        "--output-global-json", str(tmp_path / "rerun.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    full_rows = _load_rows(full_obs)
+    rerun_rows = _load_rows(rerun_obs)
+
+    expected_rows = full_rows[
+        (full_rows[:, 2] >= 25)
+        & (full_rows[:, 2] <= 35)
+    ]
+
+    assert expected_rows.shape[0] > 0
+    assert rerun_rows.shape == expected_rows.shape
+    assert np.array_equal(rerun_rows, expected_rows)
+
+    full_embeddings = _load_embeddings(full_emb)
+    rerun_embeddings = _load_embeddings(rerun_emb)
+
+    assert full_embeddings.shape[0] > rerun_embeddings.shape[0] > 0
+
+    with np.load(rerun_obs, allow_pickle=False) as data:
+        rerun_observations = data["observations"]
+
+    used_emb_idx = sorted({
+        int(idx)
+        for idx in rerun_observations["emb_idx"]
+        if int(idx) >= 0
+    })
+
+    assert used_emb_idx == list(range(rerun_embeddings.shape[0]))
+
+@pytest.mark.integration
+def test_resume_latest_ignores_tmp_run_dirs_for_frame_range_embedding_sidecar(
+    tmp_path: Path,
+):
+    shim = tmp_path / "run_cli_with_stubs.py"
+    shim.write_text(SHIM_SOURCE)
+
+    total_frames = 60
+
+    vid = tmp_path / "toy.mp4"
+    shots_path = tmp_path / "shots.json"
+
+    _make_tiny_video(vid, frames=total_frames, size=(192, 108))
+    _write_shots_json(shots_path, 0, total_frames - 1)
+
+    ckpt_parent = tmp_path / "ckpt"
+    ckpt_parent.mkdir()
+
+    full_obs = tmp_path / "full_obs.npz"
+    full_emb = tmp_path / "full_emb.npz"
+
+    range_obs = tmp_path / "range_obs.npz"
+    range_emb = tmp_path / "range_emb.npz"
+
+    common = [
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "sidecar",
+        "--checkpoint-dir", str(ckpt_parent),
+        "--log", "INFO",
+    ]
+
+    _run_python(
+        shim,
+        *common,
+        "--obs-sidecar-path", str(full_obs),
+        "--emb-sidecar-path", str(full_emb),
+        "--output-global-json", str(tmp_path / "full.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    tmp_run = ckpt_parent / ".tmp-run-99999999T999999Z-deadbeef"
+    tmp_ckpt = tmp_run / "ckpt"
+    tmp_ckpt.mkdir(parents=True)
+
+    trap_embeddings = np.full((3, 512), 999.0, dtype=np.float32)
+    np.savez(tmp_ckpt / "emb_ckpt.npz", embeddings=trap_embeddings)
+
+    trap_obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+    trap_obs = np.array(
+        [
+            (25, 1, 0, [0, 0, 1, 1], 0, 0.99, 0),
+            (30, 1, 0, [0, 0, 1, 1], 0, 0.99, 1),
+            (35, 1, 0, [0, 0, 1, 1], 0, 0.99, 2),
+        ],
+        dtype=trap_obs_dtype,
+    )
+    np.savez(tmp_ckpt / "obs_ckpt.npz", observations=trap_obs)
+
+    (tmp_run / "status.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "2.3",
+                "video_path": str(vid.resolve()),
+                "last_embedding_safe_frame": 35,
+                "last_embedding_safe_shot_number": 1,
+                "last_embedding_safe_shot_first_frame": 0,
+                "obs_rows_at_last_embedding_safe": 3,
+                "emb_rows_at_last_embedding_safe": 3,
+                "embedding_safe_frames": [
+                    {
+                        "frame_idx": 35,
+                        "shot_number": 1,
+                        "shot_first_frame": 0,
+                    }
+                ],
+            }
+        )
+    )
+
+    _run_python(
+        shim,
+        *common,
+        "--resume-latest",
+        "--start-frame", "25",
+        "--end-frame", "35",
+        "--obs-sidecar-path", str(range_obs),
+        "--emb-sidecar-path", str(range_emb),
+        "--output-global-json", str(tmp_path / "range.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    rows = _load_rows(range_obs)
+    embeddings = _load_embeddings(range_emb)
+
+    assert rows.shape[0] > 0
+    assert rows[:, 2].min() >= 25
+    assert rows[:, 2].max() <= 35
+
+    assert embeddings.shape[0] > 0
+    assert not np.any(embeddings == 999.0)
+
+@pytest.mark.integration
+def test_resume_latest_missing_checkpoint_sidecars_fails_fast(
+    tmp_path: Path,
+):
+    shim = tmp_path / "run_cli_with_stubs.py"
+    shim.write_text(SHIM_SOURCE)
+
+    total_frames = 60
+
+    vid = tmp_path / "toy.mp4"
+    shots_path = tmp_path / "shots.json"
+
+    _make_tiny_video(vid, frames=total_frames, size=(192, 108))
+    _write_shots_json(shots_path, 0, total_frames - 1)
+
+    ckpt_parent = tmp_path / "ckpt"
+    ckpt_parent.mkdir()
+
+    # Older valid-looking published run. If fallback is incorrectly allowed,
+    # resume-latest could use this after rejecting the corrupt latest run.
+    old_run = ckpt_parent / "run-20000101T000000Z-oldvalid"
+    old_ckpt = old_run / "ckpt"
+    old_ckpt.mkdir(parents=True)
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    old_obs = np.array(
+        [
+            (25, 1, 0, [0, 0, 1, 1], 0, 0.99, 0),
+        ],
+        dtype=obs_dtype,
+    )
+    old_embeddings = np.full((1, 512), 111.0, dtype=np.float32)
+
+    np.savez(old_ckpt / "obs_ckpt.npz", observations=old_obs)
+    np.savez(old_ckpt / "emb_ckpt.npz", embeddings=old_embeddings)
+
+    (old_run / "status.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "2.3",
+                "video_path": str(vid.resolve()),
+                "last_embedding_safe_frame": 25,
+                "last_embedding_safe_shot_number": 1,
+                "last_embedding_safe_shot_first_frame": 0,
+                "obs_rows_at_last_embedding_safe": 1,
+                "emb_rows_at_last_embedding_safe": 1,
+                "embedding_safe_frames": [
+                    {
+                        "frame_idx": 25,
+                        "shot_number": 1,
+                        "shot_first_frame": 0,
+                    }
+                ],
+            }
+        )
+    )
+
+    # Newest published run is corrupt: status exists, but required checkpoint
+    # sidecars are missing. This must fail fast, not fall back to old_run.
+    corrupt_run = ckpt_parent / "run-99999999T999999Z-corrupt"
+    corrupt_run.mkdir()
+
+    (corrupt_run / "status.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "2.3",
+                "video_path": str(vid.resolve()),
+                "last_embedding_safe_frame": 35,
+                "last_embedding_safe_shot_number": 1,
+                "last_embedding_safe_shot_first_frame": 0,
+                "obs_rows_at_last_embedding_safe": 1,
+                "emb_rows_at_last_embedding_safe": 1,
+                "embedding_safe_frames": [
+                    {
+                        "frame_idx": 35,
+                        "shot_number": 1,
+                        "shot_first_frame": 0,
+                    }
+                ],
+            }
+        )
+    )
+
+    range_obs = tmp_path / "range_obs.npz"
+    range_emb = tmp_path / "range_emb.npz"
+
+    cp =_run_python(
+        shim,
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "sidecar",
+        "--checkpoint-dir", str(ckpt_parent),
+        "--resume-latest",
+        "--start-frame", "25",
+        "--end-frame", "35",
+        "--obs-sidecar-path", str(range_obs),
+        "--emb-sidecar-path", str(range_emb),
+        "--output-global-json", str(tmp_path / "range.json"),
+        "--log", "INFO",
+        ok=(1,2),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    assert cp.returncode != 0
+    assert "inconsistent checkpoint" in cp.stdout
+    assert "obs_ckpt.npz is missing" in cp.stdout
+
+    assert not range_obs.exists()
+    assert not range_emb.exists()

--- a/tests/integration/test_resume_crash_frame_ranges.py
+++ b/tests/integration/test_resume_crash_frame_ranges.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.integration.test_resume_completed_run_frame_ranges import (
+    SHIM_SOURCE,
+    _load_rows,
+    _make_tiny_video,
+    _run_python,
+    _with_repo_env,
+    _write_shots_json,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "start_frame,end_frame",
+    [
+        (10, 20),      # both before crash
+        (40, 50),      # both after crash
+        (20, 40),      # straddles crash
+        (30, 40),      # start == crash frame
+        (20, 30),      # end == crash frame
+        (20, None),    # start before crash, no end
+        (40, None),    # start after crash, no end
+        (None, 20),    # no start, end before crash
+        (None, 40),    # no start, end after crash
+    ],
+)
+def test_resume_after_crash_matches_full_run_subset(
+    tmp_path: Path,
+    start_frame: int | None,
+    end_frame: int | None,
+):
+    """
+    History-preserving crash+resume behavior:
+
+    1. Produce a gold full run.
+    2. Produce a crashed run.
+    3. Resume with explicit frame-range arguments.
+    4. Verify exported observations exactly match the equivalent subset
+       from the gold full run.
+    """
+
+    shim = tmp_path / "run_cli_with_stubs.py"
+    shim.write_text(SHIM_SOURCE)
+
+    total_frames = 60
+
+    vid = tmp_path / "toy.mp4"
+    shots_path = tmp_path / "shots.json"
+
+    _make_tiny_video(
+        vid,
+        frames=total_frames,
+        size=(192, 108),
+    )
+
+    _write_shots_json(
+        shots_path,
+        0,
+        total_frames - 1,
+    )
+
+    # ------------------------------------------------------------------
+    # GOLD FULL RUN
+    # ------------------------------------------------------------------
+
+    gold_ckpt = tmp_path / "gold_ckpt"
+    gold_ckpt.mkdir()
+
+    gold_obs = tmp_path / "gold_obs.npz"
+
+    common_gold = [
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "none",
+        "--checkpoint-dir", str(gold_ckpt),
+        "--obs-sidecar-path", str(gold_obs),
+        "--output-global-json", str(tmp_path / "gold.json"),
+        "--log", "INFO",
+    ]
+
+    _run_python(
+        shim,
+        *common_gold,
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    gold_rows = _load_rows(gold_obs)
+
+    # ------------------------------------------------------------------
+    # CRASH RUN
+    # ------------------------------------------------------------------
+
+    crash_ckpt = tmp_path / "crash_ckpt"
+    crash_ckpt.mkdir()
+
+    crash_obs = tmp_path / "crash_obs.npz"
+
+    common_crash = [
+        "--input", str(vid),
+        "--shot-segmentation", str(shots_path),
+        "--schema-version", "2.1",
+        "--detect-interval", "1",
+        "--embedding-batch-size-max", "16",
+        "--embedding-queue-max-pending", "16",
+        "--emb-store", "none",
+        "--checkpoint-dir", str(crash_ckpt),
+        "--obs-sidecar-path", str(crash_obs),
+        "--output-global-json", str(tmp_path / "crash.json"),
+        "--log", "INFO",
+    ]
+
+    # crash around frame 30
+    _run_python(
+        shim,
+        "--stub-mode",
+        "crash:30",
+        *common_crash,
+        ok=(1, 2),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    # ------------------------------------------------------------------
+    # RESUME RUN
+    # ------------------------------------------------------------------
+
+    resumed_obs = tmp_path / "resumed_obs.npz"
+
+    resume_args = [
+        "--resume-latest",
+    ]
+
+    if start_frame is not None:
+        resume_args.extend(["--start-frame", str(start_frame)])
+
+    if end_frame is not None:
+        resume_args.extend(["--end-frame", str(end_frame)])
+
+    _run_python(
+        shim,
+        *resume_args,
+        *common_crash,
+        "--obs-sidecar-path", str(resumed_obs),
+        "--output-global-json", str(tmp_path / "resumed.json"),
+        ok=(0,),
+        cwd=tmp_path,
+        env=_with_repo_env(),
+    )
+
+    resumed_rows = _load_rows(resumed_obs)
+
+    # ------------------------------------------------------------------
+    # EXPECTED SUBSET
+    # ------------------------------------------------------------------
+
+    effective_start = 0 if start_frame is None else start_frame
+    effective_end = (
+        total_frames - 1
+        if end_frame is None
+        else end_frame
+    )
+
+    expected_rows = gold_rows[
+        (gold_rows[:, 2] >= effective_start)
+        & (gold_rows[:, 2] <= effective_end)
+    ]
+
+    assert expected_rows.shape[0] > 0
+    assert resumed_rows.shape == expected_rows.shape
+
+    np.testing.assert_array_equal(
+        resumed_rows,
+        expected_rows,
+    )

--- a/tests/test_checkpoint_atomic_publish.py
+++ b/tests/test_checkpoint_atomic_publish.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from facekit.pipeline.checkpoint import CheckpointManager
+
+def test_new_checkpoint_run_is_published_as_run_directory_not_tmp_directory(tmp_path: Path):
+    """
+    New run initialization should use atomic publish semantics:
+
+    - build under a temporary non-resumable directory
+    - publish by renaming to run-*
+    - only run-* directories are resume candidates
+    """
+    parent = tmp_path / "ckpt_parent"
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager.open(
+        parent_dir=parent,
+        video_path=video_path,
+        options_snapshot={},
+        no_resume=False,
+        force_new_run=False,
+        run_id=None,
+        resume_latest=False,
+    )
+
+    assert ckpt.root.parent == parent
+    assert ckpt.root.name.startswith("run-")
+    assert not ckpt.root.name.startswith(".tmp-run-")
+    assert ckpt.root.exists()
+    assert ckpt.ckpt_dir.exists()
+
+    tmp_runs = list(parent.glob(".tmp-run-*"))
+    assert tmp_runs == []
+
+def test_resume_latest_ignores_unpublished_tmp_run_directories(tmp_path: Path):
+    """
+    Directories named .tmp-run-* are incomplete/unpublished runs.
+
+    --resume-latest must not treat them as resumable candidates.
+    """
+    parent = tmp_path / "ckpt_parent"
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    tmp_run = parent / ".tmp-run-20990101T000000Z-deadbeef"
+    (tmp_run / "ckpt").mkdir(parents=True)
+    (tmp_run / "status.json").write_text(
+        json.dumps({"last_embedding_safe_frame": 10}),
+        encoding="utf-8",
+    )
+
+    ckpt = CheckpointManager.open(
+        parent_dir=parent,
+        video_path=video_path,
+        options_snapshot={},
+        no_resume=False,
+        force_new_run=False,
+        run_id=None,
+        resume_latest=True,
+    )
+
+    assert ckpt.root != tmp_run
+    assert ckpt.root.name.startswith("run-")
+    assert ckpt.resume_enabled is False
+
+def test_resume_latest_fails_if_latest_published_run_is_incomplete(tmp_path: Path):
+    """
+    A published run-* directory is a resume candidate.
+
+    If the latest published run exists but lacks required resume artifacts,
+    --resume-latest should fail fast rather than silently falling back to an
+    older run or a fresh run.
+    """
+    parent = tmp_path / "ckpt_parent"
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    older_complete = parent / "run-20260101T000000Z-complete"
+    (older_complete / "ckpt").mkdir(parents=True)
+    (older_complete / "status.json").write_text(
+        json.dumps({"last_embedding_safe_frame": 10}),
+        encoding="utf-8",
+    )
+
+    latest_incomplete = parent / "run-20990101T000000Z-incomplete"
+    (latest_incomplete / "ckpt").mkdir(parents=True)
+    # Intentionally no status.json.
+
+    with pytest.raises(Exception, match="status.json|missing|incomplete|resume"):
+        CheckpointManager.open(
+            parent_dir=parent,
+            video_path=video_path,
+            options_snapshot={},
+            no_resume=False,
+            force_new_run=False,
+            run_id=None,
+            resume_latest=True,
+        )
+
+def test_create_new_run_dir_uses_publish_helper(monkeypatch, tmp_path: Path):
+    """
+    New run creation should publish a staged temp run directory by calling
+    _publish_run_dir(tmp_run_dir, final_run_dir).
+    """
+    calls = []
+
+    def fake_publish(tmp_run_dir: Path, final_run_dir: Path) -> None:
+        calls.append((Path(tmp_run_dir), Path(final_run_dir)))
+        Path(final_run_dir).mkdir(parents=True, exist_ok=False)
+        Path(final_run_dir, "ckpt").mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        CheckpointManager,
+        "_publish_run_dir",
+        staticmethod(fake_publish),
+    )
+
+    parent = tmp_path / "ckpt_parent"
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager.open(
+        parent_dir=parent,
+        video_path=video_path,
+        options_snapshot={},
+        no_resume=False,
+        force_new_run=False,
+        run_id=None,
+        resume_latest=False,
+    )
+
+    assert len(calls) == 1
+
+    tmp_run_dir, final_run_dir = calls[0]
+
+    assert tmp_run_dir.parent == parent
+    assert final_run_dir.parent == parent
+
+    assert tmp_run_dir.name.startswith(".tmp-run-")
+    assert final_run_dir.name.startswith("run-")
+    assert tmp_run_dir.name.removeprefix(".tmp-") == final_run_dir.name
+
+    assert ckpt.root == final_run_dir
+
+def test_publish_run_dir_renames_tmp_run_to_final_run(monkeypatch, tmp_path: Path):
+    """
+    _publish_run_dir should perform a same-parent directory rename from
+    .tmp-run-* to run-*.
+    """
+    calls = []
+
+    def fake_replace(src, dst):
+        calls.append((Path(src), Path(dst)))
+        Path(dst).mkdir(parents=True, exist_ok=False)
+
+    monkeypatch.setattr("os.replace", fake_replace)
+
+    parent = tmp_path / "ckpt_parent"
+    tmp_run_dir = parent / ".tmp-run-20260101T000000Z-deadbeef"
+    final_run_dir = parent / "run-20260101T000000Z-deadbeef"
+
+    tmp_run_dir.mkdir(parents=True)
+
+    CheckpointManager._publish_run_dir(tmp_run_dir, final_run_dir)
+
+    assert calls == [(tmp_run_dir, final_run_dir)]
+
+def test_publish_run_dir_rejects_cross_parent_publish(tmp_path: Path):
+    """
+    Atomic directory rename is only safe when temp and final directories share
+    the same parent directory.
+    """
+    tmp_parent = tmp_path / "tmp_parent"
+    final_parent = tmp_path / "final_parent"
+
+    tmp_run_dir = tmp_parent / ".tmp-run-20260101T000000Z-deadbeef"
+    final_run_dir = final_parent / "run-20260101T000000Z-deadbeef"
+
+    tmp_run_dir.mkdir(parents=True)
+    final_parent.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="same parent|parent"):
+        CheckpointManager._publish_run_dir(tmp_run_dir, final_run_dir)
+
+def test_create_new_run_dir_current_symlink_points_to_published_run(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    run_dir = CheckpointManager._create_new_run_dir(
+        tmp_path,
+        {
+            "video_path": "video.mp4",
+            "detector_model_path": "det.pt",
+            "embedding_model_path": "emb.onnx",
+            "yolo_config_path": "yolo.yaml",
+            "shot_segmentation_path": "shots.json",
+            "detect_interval": 1,
+        },
+    )
+
+    current = tmp_path / "current"
+
+    assert run_dir.name.startswith("run-")
+    assert not run_dir.name.startswith(".tmp-")
+
+    assert current.is_symlink()
+    assert current.readlink() == Path(run_dir.name)
+    assert (tmp_path / current.readlink()).resolve() == run_dir.resolve()

--- a/tests/test_checkpoint_embedding_safe_frames.py
+++ b/tests/test_checkpoint_embedding_safe_frames.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+def test_checkpoint_exposes_embedding_safe_frame_history(tmp_path: Path):
+    """
+    Checkpoint API:
+    expose historical embedding-safe frames so _resolve_anchor() can choose
+    the latest safe frame strictly before requested_start_frame.
+    """
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    ckpt.mark_embedding_safe(
+        frame_idx=5,
+        shot_number=1,
+        shot_first_frame=0,
+        open_tracks=[],
+        note="test",
+    )
+    ckpt.mark_embedding_safe(
+        frame_idx=12,
+        shot_number=1,
+        shot_first_frame=0,
+        open_tracks=[],
+        note="test",
+    )
+    ckpt.mark_embedding_safe(
+        frame_idx=19,
+        shot_number=1,
+        shot_first_frame=0,
+        open_tracks=[],
+        note="test",
+    )
+
+    assert ckpt.get_embedding_safe_frames() == [5, 12, 19]

--- a/tests/test_checkpoint_embedding_sidecar_frame_range_export.py
+++ b/tests/test_checkpoint_embedding_sidecar_frame_range_export.py
@@ -1,0 +1,450 @@
+from pathlib import Path
+
+import numpy as np
+
+
+def test_frame_range_export_compacts_embeddings_and_remaps_emb_idx(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            # outside requested range, references embedding 0
+            (24, 1, 0, [24, 0, 34, 10], 0, 0.99, 0),
+
+            # inside requested range, references embeddings 2 and 4
+            (25, 1, 0, [25, 0, 35, 10], 0, 0.99, 2),
+            (30, 1, 0, [30, 0, 40, 10], 0, 0.99, 4),
+
+            # inside requested range, no embedding
+            (35, 1, 0, [35, 0, 45, 10], 0, 0.99, -1),
+
+            # outside requested range, references embedding 5
+            (36, 1, 0, [36, 0, 46, 10], 0, 0.99, 5),
+        ],
+        dtype=obs_dtype,
+    )
+
+    embeddings = np.array(
+        [
+            np.full((4,), 0.0, dtype=np.float32),
+            np.full((4,), 1.0, dtype=np.float32),
+            np.full((4,), 2.0, dtype=np.float32),
+            np.full((4,), 3.0, dtype=np.float32),
+            np.full((4,), 4.0, dtype=np.float32),
+            np.full((4,), 5.0, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+    np.savez(ckpt.ckpt_dir / "emb_ckpt.npz", embeddings=embeddings)
+
+    final_obs = tmp_path / "filtered_obs.npz"
+    final_emb = tmp_path / "filtered_emb.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=str(final_obs),
+        emb_sidecar_path=str(final_emb),
+        requested_start_frame=25,
+        requested_end_frame=35,
+    )
+
+    with np.load(final_obs, allow_pickle=False) as data:
+        out_obs = data["observations"]
+
+    with np.load(final_emb, allow_pickle=False) as data:
+        out_emb = data["embeddings"]
+
+    assert out_obs["f"].tolist() == [25, 30, 35]
+
+    # Original emb_idx values 2 and 4 should be compacted to 0 and 1.
+    assert out_obs["emb_idx"].tolist() == [0, 1, -1]
+
+    assert out_emb.shape == (2, 4)
+    np.testing.assert_array_equal(out_emb[0], embeddings[2])
+    np.testing.assert_array_equal(out_emb[1], embeddings[4])
+
+def test_frame_range_export_discards_unreferenced_embeddings(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            # Inside requested range, two observations share embedding 2.
+            (25, 1, 0, [25, 0, 35, 10], 0, 0.99, 2),
+            (30, 1, 0, [30, 0, 40, 10], 0, 0.99, 2),
+
+            # Inside requested range, references embedding 5.
+            (35, 1, 0, [35, 0, 45, 10], 0, 0.99, 5),
+        ],
+        dtype=obs_dtype,
+    )
+
+    embeddings = np.array(
+        [
+            np.full((4,), 0.0, dtype=np.float32),
+            np.full((4,), 1.0, dtype=np.float32),
+            np.full((4,), 2.0, dtype=np.float32),
+            np.full((4,), 3.0, dtype=np.float32),
+            np.full((4,), 4.0, dtype=np.float32),
+            np.full((4,), 5.0, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+    np.savez(ckpt.ckpt_dir / "emb_ckpt.npz", embeddings=embeddings)
+
+    final_obs = tmp_path / "filtered_obs.npz"
+    final_emb = tmp_path / "filtered_emb.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=str(final_obs),
+        emb_sidecar_path=str(final_emb),
+        requested_start_frame=25,
+        requested_end_frame=35,
+    )
+
+    with np.load(final_obs, allow_pickle=False) as data:
+        out_obs = data["observations"]
+
+    with np.load(final_emb, allow_pickle=False) as data:
+        out_emb = data["embeddings"]
+
+    assert out_obs["f"].tolist() == [25, 30, 35]
+
+    # Original embedding indices 2 and 5 should compact to 0 and 1.
+    # Both observations that shared original embedding 2 should still share it.
+    assert out_obs["emb_idx"].tolist() == [0, 0, 1]
+
+    assert out_emb.shape == (2, 4)
+    np.testing.assert_array_equal(out_emb[0], embeddings[2])
+    np.testing.assert_array_equal(out_emb[1], embeddings[5])
+
+def test_frame_range_export_preserves_embedding_lookup_semantics(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            (20, 1, 0, [20, 0, 30, 10], 0, 0.99, 0),
+            (25, 1, 0, [25, 0, 35, 10], 0, 0.99, 4),
+            (30, 1, 1, [30, 0, 40, 10], 0, 0.99, 2),
+            (35, 1, 0, [35, 0, 45, 10], 0, 0.99, -1),
+            (40, 1, 0, [40, 0, 50, 10], 0, 0.99, 5),
+        ],
+        dtype=obs_dtype,
+    )
+
+    embeddings = np.array(
+        [
+            np.full((4,), 0.0, dtype=np.float32),
+            np.full((4,), 1.0, dtype=np.float32),
+            np.full((4,), 2.0, dtype=np.float32),
+            np.full((4,), 3.0, dtype=np.float32),
+            np.full((4,), 4.0, dtype=np.float32),
+            np.full((4,), 5.0, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+    np.savez(ckpt.ckpt_dir / "emb_ckpt.npz", embeddings=embeddings)
+
+    final_obs = tmp_path / "filtered_obs.npz"
+    final_emb = tmp_path / "filtered_emb.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=str(final_obs),
+        emb_sidecar_path=str(final_emb),
+        requested_start_frame=25,
+        requested_end_frame=35,
+    )
+
+    with np.load(final_obs, allow_pickle=False) as data:
+        out_obs = data["observations"]
+
+    with np.load(final_emb, allow_pickle=False) as data:
+        out_emb = data["embeddings"]
+
+    assert out_obs["f"].tolist() == [25, 30, 35]
+
+    original_by_frame = {
+        int(row["f"]): embeddings[int(row["emb_idx"])]
+        for row in obs
+        if int(row["emb_idx"]) >= 0
+    }
+
+    for row in out_obs:
+        exported_idx = int(row["emb_idx"])
+        if exported_idx < 0:
+            continue
+
+        frame = int(row["f"])
+
+        np.testing.assert_array_equal(
+            out_emb[exported_idx],
+            original_by_frame[frame],
+        )
+
+def test_frame_range_export_with_no_observations_writes_empty_sidecars(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            (10, 1, 0, [10, 0, 20, 10], 0, 0.99, 0),
+            (20, 1, 0, [20, 0, 30, 10], 0, 0.99, 1),
+        ],
+        dtype=obs_dtype,
+    )
+
+    embeddings = np.array(
+        [
+            np.full((4,), 0.0, dtype=np.float32),
+            np.full((4,), 1.0, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+    np.savez(ckpt.ckpt_dir / "emb_ckpt.npz", embeddings=embeddings)
+
+    final_obs = tmp_path / "filtered_obs.npz"
+    final_emb = tmp_path / "filtered_emb.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=str(final_obs),
+        emb_sidecar_path=str(final_emb),
+        requested_start_frame=30,
+        requested_end_frame=40,
+    )
+
+    with np.load(final_obs, allow_pickle=False) as data:
+        out_obs = data["observations"]
+
+    with np.load(final_emb, allow_pickle=False) as data:
+        out_emb = data["embeddings"]
+
+    assert out_obs.shape == (0,)
+    assert out_obs.dtype == obs_dtype
+
+    assert out_emb.shape == (0, 4)
+    assert out_emb.dtype == np.float32
+
+
+def test_user_embedding_sidecar_reflects_requested_frame_range(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            # Outside requested range.
+            (20, 1, 0, [20, 0, 30, 10], 0, 0.99, 0),
+
+            # Inside requested range.
+            (25, 1, 0, [25, 0, 35, 10], 0, 0.99, 4),
+            (30, 1, 1, [30, 0, 40, 10], 0, 0.99, 2),
+            (35, 1, 0, [35, 0, 45, 10], 0, 0.99, -1),
+
+            # Outside requested range.
+            (40, 1, 0, [40, 0, 50, 10], 0, 0.99, 5),
+        ],
+        dtype=obs_dtype,
+    )
+
+    embeddings = np.array(
+        [
+            np.full((4,), 0.0, dtype=np.float32),
+            np.full((4,), 1.0, dtype=np.float32),
+            np.full((4,), 2.0, dtype=np.float32),
+            np.full((4,), 3.0, dtype=np.float32),
+            np.full((4,), 4.0, dtype=np.float32),
+            np.full((4,), 5.0, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+    np.savez(ckpt.ckpt_dir / "emb_ckpt.npz", embeddings=embeddings)
+
+    final_emb = tmp_path / "user_requested_emb.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=None,
+        emb_sidecar_path=str(final_emb),
+        requested_start_frame=25,
+        requested_end_frame=35,
+    )
+
+    with np.load(final_emb, allow_pickle=False) as data:
+        out_emb = data["embeddings"]
+
+    assert out_emb.shape == (2, 4)
+    np.testing.assert_array_equal(out_emb[0], embeddings[2])
+    np.testing.assert_array_equal(out_emb[1], embeddings[4])
+
+def test_user_embedding_sidecar_empty_when_range_has_no_embeddings(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            # Outside requested range, has embeddings.
+            (20, 1, 0, [20, 0, 30, 10], 0, 0.99, 0),
+            (40, 1, 0, [40, 0, 50, 10], 0, 0.99, 1),
+
+            # Inside requested range, no embeddings.
+            (25, 1, 0, [25, 0, 35, 10], 0, 0.99, -1),
+            (30, 1, 0, [30, 0, 40, 10], 0, 0.99, -1),
+            (35, 1, 0, [35, 0, 45, 10], 0, 0.99, -1),
+        ],
+        dtype=obs_dtype,
+    )
+
+    embeddings = np.array(
+        [
+            np.full((4,), 0.0, dtype=np.float32),
+            np.full((4,), 1.0, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+    np.savez(ckpt.ckpt_dir / "emb_ckpt.npz", embeddings=embeddings)
+
+    final_emb = tmp_path / "user_requested_emb.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=None,
+        emb_sidecar_path=str(final_emb),
+        requested_start_frame=25,
+        requested_end_frame=35,
+    )
+
+    with np.load(final_emb, allow_pickle=False) as data:
+        out_emb = data["embeddings"]
+
+    assert out_emb.shape == (0, 4)
+    assert out_emb.dtype == np.float32

--- a/tests/test_checkpoint_frame_range_export.py
+++ b/tests/test_checkpoint_frame_range_export.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import numpy as np
+
+
+def test_copy_ckpt_sidecars_to_final_filters_observations_by_requested_frame_range(
+    tmp_path: Path,
+):
+    from facekit.pipeline.checkpoint import CheckpointManager
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    obs_dtype = np.dtype(
+        [
+            ("f", "i4"),
+            ("shot", "i4"),
+            ("track_id", "i4"),
+            ("bbox_xyxy", "f4", (4,)),
+            ("src", "i4"),
+            ("conf", "f4"),
+            ("emb_idx", "i4"),
+        ]
+    )
+
+    obs = np.array(
+        [
+            (24, 1, 0, [24, 0, 34, 10], 0, 0.99, -1),
+            (25, 1, 0, [25, 0, 35, 10], 0, 0.99, -1),
+            (30, 1, 0, [30, 0, 40, 10], 0, 0.99, -1),
+            (35, 1, 0, [35, 0, 45, 10], 0, 0.99, -1),
+            (36, 1, 0, [36, 0, 46, 10], 0, 0.99, -1),
+        ],
+        dtype=obs_dtype,
+    )
+
+    ckpt.ckpt_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(ckpt.ckpt_dir / "obs_ckpt.npz", observations=obs)
+
+    # Embeddings are not relevant to this test, but the method may try to copy
+    # them if a target path is supplied. We omit emb_sidecar_path.
+    final_obs = tmp_path / "filtered_obs.npz"
+
+    ckpt.copy_ckpt_sidecars_to_final(
+        obs_sidecar_path=str(final_obs),
+        emb_sidecar_path=None,
+        requested_start_frame=25,
+        requested_end_frame=35,
+    )
+
+    with np.load(final_obs, allow_pickle=False) as data:
+        out = data["observations"]
+
+    assert out["f"].tolist() == [25, 30, 35]

--- a/tests/test_cli_frame_ranges.py
+++ b/tests/test_cli_frame_ranges.py
@@ -1,0 +1,365 @@
+# tests/test_cli_frame_range_resume.py
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+import inspect
+import pytest
+
+from facekit.cli import resolve_face_ids_v2_cli as cli
+from facekit.errors import ResumeSafetyError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeReader:
+    def __init__(self, path: str, total_frames: int = 100):
+        self.path = path
+        self._fps = 30.0
+        self._size = (640, 360)
+        self._total_frames = total_frames
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def fps(self):
+        return self._fps
+
+    def size(self):
+        return self._size
+
+    def total_frames(self):
+        return self._total_frames
+
+class _FakeEmbedder:
+    def __init__(self, *args, **kwargs):
+        self.max_batch_size = None
+
+    def set_max_batch_size(self, n: int):
+        self.max_batch_size = n
+
+class _FakeCkpt:
+    def __init__(
+        self,
+        *,
+        root: Path,
+        resume_enabled: bool = False,
+        validate_exc: Exception | None = None,
+        anchor_frame: int | None = None,
+    ):
+        self.root = root
+        self.resume_enabled = resume_enabled
+        self._validate_exc = validate_exc
+        self._anchor_frame = anchor_frame
+
+        self.validate_called = 0
+        self.start_called = 0
+        self.rehydrate_called = 0
+        self.finalize_called = 0
+        self.mark_completed_called = 0
+
+    def read_status(self):
+        return {}
+
+    def validate_resume_or_raise(self, *args, **kwargs):
+        self.validate_called += 1
+        if self._validate_exc is not None:
+            raise self._validate_exc
+
+    def start(self, *args, **kwargs):
+        self.start_called += 1
+
+    def rehydrate_runtime(self, *args, **kwargs):
+        self.rehydrate_called += 1
+        if self._anchor_frame is None:
+            return {}
+        return {
+            "anchor_frame": self._anchor_frame,
+            "anchor_shot": 1,
+            "anchor_shot_first_frame": 0,
+            "track_order_entries": 0,
+        }
+
+    def finalize(self):
+        self.finalize_called += 1
+
+    def copy_ckpt_sidecars_to_final(self, *args, **kwargs):
+        return None
+
+    def mark_completed(self):
+        self.mark_completed_called += 1
+
+def _write_minimal_shots(path: Path, *, first_frame: int = 0, last_frame: int = 99) -> None:
+    payload = {
+        "shots": [
+            {
+                "shot_number": 1,
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+            }
+        ]
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+def _base_args(tmp_path: Path, **overrides):
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"FAKE")
+
+    shots_path = tmp_path / "shots.json"
+    _write_minimal_shots(shots_path, last_frame=99)
+
+    args = types.SimpleNamespace(
+        input=str(video_path),
+        detector_model="models/detector/yolov5n_state_dict.pt",
+        embedding_model="models/embedding/glintr100_dynamic.onnx",
+        config="models/detector/yolov5n.yaml",
+        min_face=10,
+        shot_segmentation=str(shots_path),
+        schema_version="2.1",
+        schema_dir=None,
+        output_segment_json=None,
+        output_global_json=None,
+        output_video=None,
+        device="auto",
+        detect_interval=30,
+        embedding_queue_max_pending=1024,
+        embedding_batch_size_max=32,
+        track_sample_interval=4,
+        post_min_gap_len=210,
+        post_min_track_len=70,
+        post_iou_threshold=0.2,
+        emb_store="sidecar",
+        emb_sidecar_path=None,
+        obs_sidecar_path=None,
+        checkpoint_dir=str(tmp_path / "ckpt_parent"),
+        no_resume=False,
+        force=False,
+        resume_latest=False,
+        checkpoint_run_id=None,
+        new_run=False,
+        no_checkpoint_write=True,
+        log="INFO",
+        log_file=None,
+        # NEW CONTRACT
+        start_frame=0,
+        end_frame=None,
+    )
+
+    for k, v in overrides.items():
+        setattr(args, k, v)
+
+    return args
+
+def _patch_minimal_pipeline(monkeypatch, tmp_path: Path, *, ckpt: _FakeCkpt, total_frames: int = 100, track_impl=None):
+    monkeypatch.setattr(cli, "ReaderCoordinator", lambda p: _FakeReader(p, total_frames=total_frames))
+    monkeypatch.setattr(cli, "load_yolo5face_model", lambda *a, **k: object())
+    monkeypatch.setattr(cli, "FaceDetector", lambda yolo: object())
+    monkeypatch.setattr(cli, "FaceEmbedder", lambda *a, **k: _FakeEmbedder())
+    monkeypatch.setattr(cli.CheckpointManager, "compute_parent_dir", lambda *a, **k: tmp_path / "computed_ckpts")
+    monkeypatch.setattr(cli.CheckpointManager, "open", lambda *a, **k: ckpt)
+
+    if track_impl is None:
+        monkeypatch.setattr(
+            cli.track_across_segments,
+            "track_across_segments",
+            lambda **kwargs: [],
+        )
+    else:
+        monkeypatch.setattr(
+            cli.track_across_segments,
+            "track_across_segments",
+            track_impl,
+        )
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_start_frame_defaults_to_none(monkeypatch):
+    """
+    CLI contract:
+      --start-frame exists and defaults to None.
+
+    None means "no explicit requested start"; downstream range validation
+    interprets that as beginning-of-video for bounds checking.
+    """
+    captured = {}
+
+    def fake_run_pipeline(args):
+        captured["start_frame"] = args.start_frame
+        captured["end_frame"] = args.end_frame
+        return None
+
+    monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(
+        cli,
+        "sys",
+        types.SimpleNamespace(argv=["prog", "--input", "dummy.mp4"]),
+    )
+
+    cli.main()
+
+    assert captured["start_frame"] is None
+    assert captured["end_frame"] is None
+
+def test_end_frame_before_start_frame_exits_fast(monkeypatch, tmp_path: Path):
+    """
+    New run contract:
+      end_frame < start_frame is invalid and should raise a user-facing error.
+    """
+    ckpt = _FakeCkpt(root=tmp_path / "ckpt_run", resume_enabled=False)
+    _patch_minimal_pipeline(monkeypatch, tmp_path, ckpt=ckpt, total_frames=100)
+
+    args = _base_args(tmp_path, start_frame=20, end_frame=19)
+
+    with pytest.raises(ResumeSafetyError):
+        cli.run_pipeline(args)
+
+def test_end_frame_equal_to_total_frames_exits_fast(monkeypatch, tmp_path: Path):
+    """
+    New run contract:
+      end_frame is inclusive, so end_frame >= total_frames is out of bounds.
+    """
+    ckpt = _FakeCkpt(root=tmp_path / "ckpt_run", resume_enabled=False)
+    _patch_minimal_pipeline(monkeypatch, tmp_path, ckpt=ckpt, total_frames=100)
+
+    args = _base_args(tmp_path, start_frame=0, end_frame=100)
+
+    with pytest.raises(ResumeSafetyError):
+        cli.run_pipeline(args)
+
+def test_no_resume_with_start_frame_cold_starts_at_start_frame(monkeypatch, tmp_path: Path, caplog):
+    """
+    If --no-resume is set, the pipeline must cold-start at start_frame
+    and must not attempt checkpoint rehydration.
+    """
+    ckpt = _FakeCkpt(root=tmp_path / "ckpt_run", resume_enabled=True)
+
+    seen = {}
+
+    def fake_track_across_segments(**kwargs):
+        seen["kwargs"] = kwargs
+        return []
+
+    _patch_minimal_pipeline(
+        monkeypatch,
+        tmp_path,
+        ckpt=ckpt,
+        total_frames=100,
+        track_impl=fake_track_across_segments,
+    )
+
+    args = _base_args(tmp_path, no_resume=True, start_frame=25, end_frame=50)
+
+    cli.run_pipeline(args)
+
+    assert ckpt.rehydrate_called == 0
+    assert seen["kwargs"]["resume_enabled"] is False
+
+    # This is a forward-looking assertion for the new API contract.
+    # It should fail until start_frame is plumbed into the tracking layer.
+    assert seen["kwargs"]["start_frame"] == 25
+    assert seen["kwargs"]["end_frame"] == 50
+
+def test_incompatible_checkpoint_with_start_frame_exits_fast(monkeypatch, tmp_path: Path):
+    """
+    If normal resume logic finds a checkpoint but it is incompatible with the
+    requested run, the CLI must exit fast rather than falling back to cold start.
+    """
+    ckpt = _FakeCkpt(
+        root=tmp_path / "ckpt_run",
+        resume_enabled=True,
+        validate_exc=ResumeSafetyError("checkpoint incompatible with requested run"),
+    )
+
+    called = {"track": 0}
+
+    def fake_track_across_segments(**kwargs):
+        called["track"] += 1
+        return []
+
+    _patch_minimal_pipeline(
+        monkeypatch,
+        tmp_path,
+        ckpt=ckpt,
+        total_frames=100,
+        track_impl=fake_track_across_segments,
+    )
+
+    args = _base_args(tmp_path, no_resume=False, start_frame=10, end_frame=20)
+
+    with pytest.raises(ResumeSafetyError, match="incompatible"):
+        cli.run_pipeline(args)
+
+    assert ckpt.validate_called == 1
+    assert ckpt.rehydrate_called == 0
+    assert called["track"] == 0
+
+def test_real_track_across_segments_accepts_frame_range_kwargs():
+    """
+    Guard against interface drift:
+    if the CLI passes start_frame/end_frame into the real tracking entry point,
+    the real function signature must accept them.
+    """
+    sig = inspect.signature(cli.track_across_segments.track_across_segments)
+
+    assert "start_frame" in sig.parameters
+    assert "end_frame" in sig.parameters
+
+    assert sig.parameters["start_frame"].default == 0
+    assert sig.parameters["end_frame"].default is None
+
+def test_resume_with_start_frame_passes_frame_range_to_tracking_layer(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    History-preserving frame-range execution:
+
+    When resume is enabled and the user explicitly requests a start frame,
+    the CLI must pass start_frame/end_frame through to the tracking layer
+    so resume anchor selection can choose the latest embedding-safe frame
+    strictly before the requested start.
+    """
+    ckpt = _FakeCkpt(
+        root=tmp_path / "ckpt_run",
+        resume_enabled=True,
+        anchor_frame=19,
+    )
+
+    seen = {}
+
+    def fake_track_across_segments(**kwargs):
+        seen["kwargs"] = kwargs
+        return []
+
+    _patch_minimal_pipeline(
+        monkeypatch,
+        tmp_path,
+        ckpt=ckpt,
+        total_frames=100,
+        track_impl=fake_track_across_segments,
+    )
+
+    args = _base_args(
+        tmp_path,
+        no_resume=False,
+        resume_latest=True,
+        start_frame=25,
+        end_frame=50,
+    )
+
+    cli.run_pipeline(args)
+
+    assert ckpt.validate_called == 1
+
+    assert seen["kwargs"]["resume_enabled"] is True
+
+    assert seen["kwargs"]["start_frame"] == 25
+    assert seen["kwargs"]["end_frame"] == 50

--- a/tests/test_cli_manifest.py
+++ b/tests/test_cli_manifest.py
@@ -247,7 +247,7 @@ def test_cli_v2_1_manifest_includes_trackless_shots_with_full_coverage(tmp_path:
         schema_version="2.1",
         schema_dir=None,
         output_segment_json=None,
-        output_global_json=True,             # trigger JSON manifest write
+        output_global_json=True,
         output_video=None,
         detect_interval=30,
         post_min_gap_len=210,
@@ -256,6 +256,8 @@ def test_cli_v2_1_manifest_includes_trackless_shots_with_full_coverage(tmp_path:
         embedding_batch_size_max=32,
         embedding_queue_max_pending=1024,
         track_sample_interval=4,
+        start_frame=None,
+        end_frame=None,
         device="cpu",
         emb_store="sidecar",
         emb_sidecar_path=None,

--- a/tests/test_resume_anchor_embedding_safe.py
+++ b/tests/test_resume_anchor_embedding_safe.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import numpy as np
 
 from facekit.pipeline.checkpoint import CheckpointManager
 
@@ -7,7 +8,20 @@ def _write_run(parent: Path, run_id: str, status: dict) -> Path:
     run_dir = parent / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "status.json").write_text(json.dumps(status))
-    (run_dir / "ckpt").mkdir(exist_ok=True)
+
+    ckpt_dir = run_dir / "ckpt"
+    ckpt_dir.mkdir(exist_ok=True)
+
+    np.savez(
+        ckpt_dir / "obs_ckpt.npz",
+        observations=np.empty(0, dtype=[("f", "i4")]),
+    )
+
+    np.savez(
+        ckpt_dir / "emb_ckpt.npz",
+        embeddings=np.empty((0, 512), dtype=np.float32),
+    )
+
     return run_dir
 
 def test_resume_anchor_uses_last_embedding_safe_frame_when_present(tmp_path: Path):

--- a/tests/test_resume_anchor_selection.py
+++ b/tests/test_resume_anchor_selection.py
@@ -1,0 +1,141 @@
+from facekit.pipeline.resume_rehydrate import _select_embedding_safe_anchor
+
+
+def test_select_embedding_safe_anchor_legacy_uses_final_safe_frame():
+    assert _select_embedding_safe_anchor(
+        [5, 12, 19, 40],
+        requested_start_frame=None,
+    ) == 40
+
+
+def test_select_embedding_safe_anchor_explicit_start_uses_latest_prior_safe_frame():
+    assert _select_embedding_safe_anchor(
+        [5, 12, 19, 40],
+        requested_start_frame=25,
+    ) == 19
+
+
+def test_select_embedding_safe_anchor_explicit_start_ignores_safe_frame_equal_to_start():
+    assert _select_embedding_safe_anchor(
+        [5, 12, 25, 40],
+        requested_start_frame=25,
+    ) == 12
+
+
+def test_select_embedding_safe_anchor_explicit_start_without_prior_safe_frame_returns_zero():
+    assert _select_embedding_safe_anchor(
+        [25, 40],
+        requested_start_frame=25,
+    ) == 0
+
+def test_resolve_anchor_uses_frame_component_of_checkpoint_anchor_tuple():
+    """
+    Current checkpoint contract:
+
+    checkpoint.get_resume_anchor() returns:
+        (frame_idx, shot_number, shot_first_frame)
+
+    _resolve_anchor() should use only the frame component as the
+    embedding-safe resume boundary.
+    """
+
+    from facekit.pipeline.resume_rehydrate import _resolve_anchor
+
+    class _FakeCheckpoint:
+        def get_resume_anchor(self):
+            return (15, 2, 103)
+
+    checkpoint = _FakeCheckpoint()
+
+    result = _resolve_anchor(
+        checkpoint,
+        resume_enabled=True,
+        requested_start_frame=None,
+    )
+
+    assert result == 15
+
+def test_resolve_anchor_uses_frozen_checkpoint_anchor_frame():
+    """
+    Current implementation limitation:
+
+    The checkpoint API exposes only a single frozen embedding-safe
+    anchor, not historical safe-frame history.
+
+    Therefore requested_start_frame does not yet influence
+    anchor selection.
+    """
+
+    from facekit.pipeline.resume_rehydrate import _resolve_anchor
+
+    class _FakeCheckpoint:
+        def get_resume_anchor(self):
+            return (40, 2, 103)
+
+    checkpoint = _FakeCheckpoint()
+
+    result = _resolve_anchor(
+        checkpoint,
+        resume_enabled=True,
+        requested_start_frame=25,
+    )
+
+    # Current behavior:
+    # still uses the checkpoint's single frozen safe boundary.
+    assert result == 40
+
+def test_resolve_anchor_selects_latest_prior_safe_frame_when_checkpoint_exposes_history():
+    """
+    When the checkpoint can expose historical embedding-safe frames,
+    explicit requested_start_frame should select the latest safe frame
+    strictly before the requested start.
+    """
+
+    from facekit.pipeline.resume_rehydrate import _resolve_anchor
+
+    class _FakeCheckpoint:
+        def get_embedding_safe_frames(self):
+            return [5, 12, 19, 40]
+
+        def get_resume_anchor(self):
+            # Existing frozen-anchor API. This should not be used when the
+            # richer historical safe-frame API is available and start is explicit.
+            return (40, 2, 103)
+
+    result = _resolve_anchor(
+        _FakeCheckpoint(),
+        resume_enabled=True,
+        requested_start_frame=25,
+    )
+
+    assert result == 19
+
+from pathlib import Path
+
+
+def test_resolve_anchor_uses_checkpoint_embedding_safe_frame_history(tmp_path: Path):
+    from facekit.pipeline.checkpoint import CheckpointManager
+    from facekit.pipeline.resume_rehydrate import _resolve_anchor
+
+    video_path = tmp_path / "video.mp4"
+    video_path.write_bytes(b"fake video")
+
+    ckpt = CheckpointManager(
+        tmp_path / "run",
+        video_path=str(video_path),
+    )
+
+    for frame_idx in [5, 12, 19, 40]:
+        ckpt.mark_embedding_safe(
+            frame_idx=frame_idx,
+            shot_number=1,
+            shot_first_frame=0,
+            open_tracks=[],
+            note="test",
+        )
+
+    assert _resolve_anchor(
+        ckpt,
+        resume_enabled=True,
+        requested_start_frame=25,
+    ) == 19

--- a/tests/test_resume_boundary_continuation.py
+++ b/tests/test_resume_boundary_continuation.py
@@ -62,8 +62,8 @@ def test_resume_first_resumed_frame_does_not_mint_fresh_tracks(monkeypatch):
     start_at, aggregator, seg_seed = _init_shot_aggregator(
         shot_idx=0,
         shot_number=2,
-        first=103,
-        last=299,
+        execution_start_frame=153,
+        execution_end_frame=299,
         detect_interval=8,
         resume_plan=plan,
         iou_thresh=0.3,

--- a/tests/test_resume_end_to_end_ckpt_v21.py
+++ b/tests/test_resume_end_to_end_ckpt_v21.py
@@ -291,7 +291,6 @@ def test_resume_safety_video_mismatch_raises(tmp_path: Path):
     vidA = tmp_path / "A.mp4"
     vidA.write_bytes(b"not a real video")
     run = CheckpointManager._create_new_run_dir(parent, {"video_path": str(vidA)})
-    Path(run, "ckpt").mkdir()
     obs_sidecar = Path(run, "ckpt", "obs_ckpt.npz")
     emb_sidecar = Path(run, "ckpt", "emb_ckpt.npz")
 
@@ -354,7 +353,6 @@ def test_resume_safety_schema_mismatch_raises(tmp_path: Path):
     vid = Path(tmp_path, "v.mp4")
     vid.write_bytes(b"v")
     run = CheckpointManager._create_new_run_dir(parent, {"video_path": str(vid)})
-    Path(run, "ckpt").mkdir()
 
     obs_sidecar = Path(run, "ckpt", "obs_ckpt.npz")
     emb_sidecar = Path(run, "ckpt", "emb_ckpt.npz")

--- a/tests/test_resume_rehydrate_anchor_boundary.py
+++ b/tests/test_resume_rehydrate_anchor_boundary.py
@@ -780,7 +780,11 @@ def test_build_resume_plan_midshot_keeps_live_anchor_tracks_unlabeled(monkeypatc
     checkpoint = _FakeCheckpoint()
     all_tracks = []
 
-    monkeypatch.setattr(rr, "_resolve_anchor", lambda checkpoint, resume_enabled: 152)
+    monkeypatch.setattr(
+        rr,
+        "_resolve_anchor",
+        lambda checkpoint, resume_enabled, requested_start_frame=None: 152,
+    )
     monkeypatch.setattr(rr, "_audit_preanchor_embedding_parity", lambda *a, **k: None)
     monkeypatch.setattr(rr, "_build_emb_lookups_for_checkpoint", lambda *a, **k: (None, None))
     monkeypatch.setattr(rr, "prepare_tracks_for_resume", lambda *a, **k: list(rehydrated))

--- a/tests/test_resume_starts_on_correct_frame.py
+++ b/tests/test_resume_starts_on_correct_frame.py
@@ -16,8 +16,8 @@ def test_resume_starts_after_embedding_safe_frame():
     start_at, _, _ = _init_shot_aggregator(
         shot_idx=0,
         shot_number=2,
-        first=103,
-        last=299,
+        execution_start_frame=153,
+        execution_end_frame=299,
         detect_interval=8,
         resume_plan=resume_plan,
         iou_thresh=0.2,
@@ -27,7 +27,7 @@ def test_resume_starts_after_embedding_safe_frame():
 
     assert start_at == 153
 
-def test_resume_skips_completed_shot_when_embedding_safe_frame_is_shot_last():
+def test_resume_rejects_empty_execution_range_when_anchor_consumes_shot():
     resume_plan = SimpleNamespace(
         anchor_frame=102,
         is_resume=True,
@@ -42,8 +42,8 @@ def test_resume_skips_completed_shot_when_embedding_safe_frame_is_shot_last():
         _init_shot_aggregator(
             shot_idx=0,
             shot_number=1,
-            first=0,
-            last=102,
+            execution_start_frame=103,
+            execution_end_frame=102,
             detect_interval=8,
             resume_plan=resume_plan,
             iou_thresh=0.2,
@@ -52,4 +52,4 @@ def test_resume_skips_completed_shot_when_embedding_safe_frame_is_shot_last():
         )
         assert False, "expected empty-work-range failure"
     except Exception as e:
-        assert "empty work-range" in str(e)
+        assert "empty execution range" in str(e)

--- a/tests/test_track_across_segments_frame_range.py
+++ b/tests/test_track_across_segments_frame_range.py
@@ -1,0 +1,600 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+import numpy as np
+import pytest
+
+from facekit.pipeline import track_across_segments as tas
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeFrameProvider:
+    def __init__(self, total_frames: int = 100):
+        self._total_frames = total_frames
+        self.reset_calls: list[int] = []
+        self.next_calls = 0
+        self.current_frame = 0
+        self.frames_returned: list[int] = []
+
+    def fps(self):
+        return 30.0
+
+    def size(self):
+        return (640, 360)
+
+    def total_frames(self):
+        return self._total_frames
+
+    def reset_to_frame(self, frame_idx: int):
+        self.reset_calls.append(int(frame_idx))
+        self.current_frame = int(frame_idx)
+
+    def next(self):
+        if self.current_frame >= self._total_frames:
+            return None
+        frame_idx = self.current_frame
+        self.current_frame += 1
+        self.next_calls += 1
+        self.frames_returned.append(frame_idx)
+        return np.zeros((32, 32, 3), dtype=np.uint8)
+
+class _FakeDetector:
+    def detect_faces_in_frame(self, frame):
+        return None
+
+class _FakeEmbedder:
+    def get_embedding_batch(self, aligned_faces):
+        n = len(aligned_faces)
+        return np.zeros((n, 512), dtype=np.float32)
+
+class _FakeTrack:
+    def __init__(self, shot_id=1, track_id=0, segment_id=None, observations=None):
+        self.shot_id = shot_id
+        self.track_id = track_id
+        self.segment_id = segment_id
+        self.observations = observations or []
+        self.embeddings = []
+
+    def is_closed(self):
+        return True
+
+    def first_frame(self):
+        return 0
+
+    def last_frame(self):
+        return -1
+
+    def get_last_bbox(self):
+        return None
+
+class _FakeAggregator:
+    def __init__(self, *args, **kwargs):
+        self.tracks = []
+        self.next_track_id = kwargs.get("next_tid_seed", 0)
+
+    def finalize_tracks(self):
+        return None
+
+    def update_tracks_with_frame(self, frame_idx, observations):
+        return None
+
+    def observations_at(self, frame_idx, source=None, require_track_id=False):
+        return []
+
+    def attach_embeddings(self, track_id, embs):
+        return None
+
+    def resolve_segment_ids(self, segment_id_counter=0, embedding_threshold=0.7):
+        return None
+
+class _FakeFaceTracker:
+    def __init__(self, tracker_type="CSRT"):
+        self.tracker_type = tracker_type
+
+    def update_trackers(self, frame):
+        return {}
+
+    def init_trackers(self, frame, boxes_xywh, track_ids):
+        return None
+
+class _FakeValidator:
+    def __init__(self, params=None):
+        self.params = params
+
+    def validate(self, tracked_boxes, frame, frame_idx):
+        return True
+
+    def seed_validator(self, boxes_map, frame_idx, frame):
+        return None
+
+class _FakeResumePlan:
+    def __init__(self, *, is_resume=False, anchor_frame=0, first_processed_shot_number=1):
+        self.is_resume = is_resume
+        self.anchor_frame = anchor_frame
+        self.first_processed_shot_number = first_processed_shot_number
+        self.prior_tracks_anchor = []
+        self.open_track_ids_anchor = frozenset()
+        self.trackid_seed_by_shot = {}
+        self.segment_id_seed_by_shot = {}
+        self.reuse_tid_for_first_shot = None
+
+def _write_shots_json(path: Path, *, first_frame: int = 0, last_frame: int = 99):
+    payload = {
+        "shots": [
+            {
+                "shot_number": 1,
+                "first_frame": first_frame,
+                "last_frame": last_frame,
+            }
+        ]
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+def _patch_minimal_tracking_stack(
+    monkeypatch,
+    *,
+    resume_plan: _FakeResumePlan | None = None,
+):
+    monkeypatch.setattr(tas, "ShotFaceTrackAggregator", _FakeAggregator)
+    monkeypatch.setattr(tas, "FaceTracker", _FakeFaceTracker)
+    monkeypatch.setattr(tas, "TrackerValidator", _FakeValidator)
+
+    monkeypatch.setattr(
+        tas,
+        "_build_resume_plan",
+        lambda shots, checkpoint, resume_enabled, all_tracks, requested_start_frame=None: (
+            resume_plan if resume_plan is not None else _FakeResumePlan(is_resume=False, anchor_frame=0),
+            shots,
+        )
+    )
+
+    monkeypatch.setattr(
+        tas,
+        "_checkpoint_root_dir",
+        lambda checkpoint: None,
+    )
+    monkeypatch.setattr(
+        tas,
+        "_checkpoint_observations_and_snapshot",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tas,
+        "_finalize_checkpoint_run",
+        lambda checkpoint: None,
+    )
+    monkeypatch.setattr(
+        tas,
+        "_persist_embeddings_for_track",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tas,
+        "_attach_and_persist_embedded_obs",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tas,
+        "_maybe_enqueue_track_embedding_observations_for_frame",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tas,
+        "bootstrap_runtime_trackers_for_resume_frame",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        tas,
+        "extend_prev_track_for_overlapping_detection",
+        lambda **kwargs: 0,
+    )
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_track_across_segments_local_range_uses_requested_start_frame(monkeypatch, tmp_path: Path):
+    """
+    Local range execution:
+    when resume is disabled and start_frame is specified, the frame provider
+    should begin exactly at requested start_frame.
+    """
+    _patch_minimal_tracking_stack(monkeypatch, resume_plan=_FakeResumePlan(is_resume=False, anchor_frame=0))
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+    detector = _FakeDetector()
+    embedder = _FakeEmbedder()
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=detector,
+        embedder=embedder,
+        start_frame=25,
+        end_frame=30,
+        resume_enabled=False,
+    )
+
+    assert fp.reset_calls == [25]
+    assert fp.frames_returned[0] == 25
+
+def test_track_across_segments_stops_at_end_frame(monkeypatch, tmp_path: Path):
+    """
+    Frame-range semantics:
+    when end_frame is specified, processing should stop at that inclusive frame.
+    """
+    _patch_minimal_tracking_stack(monkeypatch, resume_plan=_FakeResumePlan(is_resume=False, anchor_frame=0))
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+    detector = _FakeDetector()
+    embedder = _FakeEmbedder()
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=detector,
+        embedder=embedder,
+        start_frame=10,
+        end_frame=15,
+        resume_enabled=False,
+    )
+
+    assert fp.reset_calls == [10]
+    assert fp.frames_returned == [10, 11, 12, 13, 14, 15]
+    assert fp.next_calls == 6
+
+def test_track_across_segments_resume_explicit_start_uses_anchor_plus_one(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    History-preserving explicit-start semantics:
+    if resume is enabled and an embedding-safe anchor exists before the
+    requested start, execution should begin at anchor_frame + 1, not at the
+    requested start and not at the shot first frame.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=True,
+            anchor_frame=19,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+    detector = _FakeDetector()
+    embedder = _FakeEmbedder()
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=detector,
+        embedder=embedder,
+        start_frame=25,
+        end_frame=30,
+        resume_enabled=True,
+    )
+
+    assert fp.reset_calls == [20]
+    assert fp.frames_returned == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    assert fp.next_calls == 11
+
+def test_track_across_segments_resume_skips_completed_first_shot(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    If the embedding-safe anchor is the last frame of the first shot,
+    track_across_segments() should skip that completed shot and begin with the
+    next shot instead of handing an empty execution range to the helper.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=True,
+            anchor_frame=49,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    payload = {
+        "shots": [
+            {"shot_number": 1, "first_frame": 0, "last_frame": 49},
+            {"shot_number": 2, "first_frame": 50, "last_frame": 99},
+        ]
+    }
+    shot_json.write_text(json.dumps(payload), encoding="utf-8")
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=60,
+        end_frame=65,
+        resume_enabled=True,
+    )
+
+    assert fp.reset_calls == [50]
+    assert fp.frames_returned[:6] == [50, 51, 52, 53, 54, 55]
+
+def test_track_across_segments_no_resume_ignores_checkpoint_anchor(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    Non-history-preserving mode:
+    even if a checkpoint anchor exists, resume_enabled=False must use local range execution 
+    and begin exactly at requested start.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(is_resume=False, anchor_frame=80),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=25,
+        end_frame=30,
+        resume_enabled=False,
+    )
+
+    assert fp.reset_calls == [25]
+    assert fp.frames_returned == [25, 26, 27, 28, 29, 30]
+
+def test_track_across_segments_legacy_resume_no_requested_start_runs_from_anchor_plus_one(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    Legacy resume execution:
+    when start_frame is None and resume is enabled with a valid embedding-safe
+    anchor, execution should begin at anchor + 1.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=True,
+            anchor_frame=19,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=None,
+        end_frame=None,
+        resume_enabled=True,
+    )
+
+    assert fp.reset_calls == [20]
+    assert fp.frames_returned[:6] == [20, 21, 22, 23, 24, 25]
+
+def test_track_across_segments_legacy_resume_requested_end_after_anchor(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    Legacy resume execution:
+    when start_frame is None and end_frame is after the embedding-safe anchor,
+    execution should begin at anchor + 1 and stop at requested end.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=True,
+            anchor_frame=19,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=None,
+        end_frame=30,
+        resume_enabled=True,
+    )
+
+    assert fp.reset_calls == [20]
+    assert fp.frames_returned == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    assert fp.next_calls == 11
+
+def test_track_across_segments_legacy_resume_requested_end_within_safe_history_executes_nothing(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    History-covered output only:
+    when start_frame is None and requested end is already within persisted
+    embedding-safe history, no new frames should be executed.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=True,
+            anchor_frame=19,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=None,
+        end_frame=15,
+        resume_enabled=True,
+    )
+
+    # Final target behavior:
+    # no execution should occur because requested output is entirely inside
+    # already-safe history.
+    assert fp.reset_calls == []
+    assert fp.frames_returned == []
+    assert fp.next_calls == 0
+
+def test_track_across_segments_history_preserving_explicit_start_executes_from_prior_safe_boundary(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    History-preserving range execution:
+    when start_frame is explicit and a prior embedding-safe frame exists,
+    execution begins at anchor + 1 and proceeds only through the
+    requested execution range.
+    """
+
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=True,
+            anchor_frame=19,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=25,
+        end_frame=30,
+        resume_enabled=True,
+    )
+
+    assert fp.reset_calls == [20]
+    assert fp.frames_returned == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+
+    assert fp.next_calls == 11
+
+
+def test_track_across_segments_history_preserving_explicit_start_without_prior_safe_frame_starts_at_zero(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    History-preserving range execution fallback:
+    when start_frame is explicit but there is no embedding-safe frame prior to
+    the requested start, execution should start at frame 0.
+    """
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_FakeResumePlan(
+            is_resume=False,
+            anchor_frame=0,
+            first_processed_shot_number=1,
+        ),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=25,
+        end_frame=30,
+        resume_enabled=True,
+    )
+
+    assert fp.reset_calls == [0]
+    assert fp.frames_returned == list(range(0, 31))
+    assert fp.next_calls == 31
+
+def test_track_across_segments_history_preserving_explicit_start_uses_latest_prior_safe_frame(
+    monkeypatch,
+    tmp_path: Path,
+):
+    """
+    History-preserving range execution:
+    when multiple embedding-safe frames exist before requested start,
+    execution should begin immediately after the latest prior safe frame.
+    """
+
+    class _ResumePlanWithSafeFrames(_FakeResumePlan):
+        def __init__(self):
+            super().__init__(
+                is_resume=True,
+                anchor_frame=19,  # expected selected anchor
+                first_processed_shot_number=1,
+            )
+            self.embedding_safe_frames = [5, 12, 19, 40]
+
+    _patch_minimal_tracking_stack(
+        monkeypatch,
+        resume_plan=_ResumePlanWithSafeFrames(),
+    )
+
+    shot_json = tmp_path / "shots.json"
+    _write_shots_json(shot_json, first_frame=0, last_frame=99)
+
+    fp = _FakeFrameProvider(total_frames=100)
+
+    tas.track_across_segments(
+        frame_source=fp,
+        shot_json_path=str(shot_json),
+        detector=_FakeDetector(),
+        embedder=_FakeEmbedder(),
+        start_frame=25,
+        end_frame=30,
+        resume_enabled=True,
+    )
+
+    # latest safe frame strictly before 25 is 19
+    assert fp.reset_calls == [20]
+    assert fp.frames_returned == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]


### PR DESCRIPTION
* add explicit requested start/end frame semantics
  - start_frame=None => beginning-of-video
  - end_frame=None => end-of-video
* add history-preserving resume anchor selection
  - persist embedding_safe_frames history
  - select latest embedding-safe frame strictly before requested start
  - support legacy resume and explicit range replay modes
* refactor track_across_segments execution semantics
  - separate requested vs execution frame ranges
  - support local-range, legacy-resume, fallback-fresh, and history-preserving modes
  - skip fully covered shots cleanly
* add frame-range export filtering for observation sidecars
* publish checkpoint run directories atomically via .tmp-run-* staging directories
* ignore unpublished temp runs when selecting resume-latest
* fail fast on inconsistent published checkpoints